### PR TITLE
SUBMARINE-264. Delete unused libthrift dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,6 @@
     <zeppelin.version>0.9.0-SNAPSHOT</zeppelin.version>
     <jgit.version>5.5.1.201910021850-r</jgit.version>
     <atomix.version>3.0.0-rc4</atomix.version>
-    <libthrift.version>0.12.0</libthrift.version>
   </properties>
 
   <modules>

--- a/submarine-commons/commons-cluster/src/main/java/org/apache/submarine/commons/cluster/ClusterManager.java
+++ b/submarine-commons/commons-cluster/src/main/java/org/apache/submarine/commons/cluster/ClusterManager.java
@@ -85,7 +85,7 @@ import org.apache.submarine.commons.cluster.meta.ClusterMetaOperation;
 import org.apache.submarine.commons.cluster.meta.ClusterMetaType;
 import org.apache.submarine.commons.cluster.protocol.LocalRaftProtocolFactory;
 import org.apache.submarine.commons.cluster.protocol.RaftClientMessagingProtocol;
-import org.apache.submarine.commons.utils.NetUtils;
+import org.apache.submarine.commons.utils.NetworkUtils;
 import org.apache.submarine.commons.utils.SubmarineConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -153,7 +153,7 @@ public abstract class ClusterManager {
 
   protected ClusterManager() {
     try {
-      this.serverHost = NetUtils.findAvailableHostAddress();
+      this.serverHost = NetworkUtils.findAvailableHostAddress();
       String clusterAddr = sconf.getClusterAddress();
       LOG.info(this.getClass().toString() + "::clusterAddr = {}", clusterAddr);
       if (!StringUtils.isEmpty(clusterAddr)) {
@@ -214,7 +214,7 @@ public abstract class ClusterManager {
 
         int raftClientPort = 0;
         try {
-          raftClientPort = NetUtils.findRandomAvailablePortOnAllLocalInterfaces();
+          raftClientPort = NetworkUtils.findRandomAvailablePortOnAllLocalInterfaces();
         } catch (IOException e) {
           LOG.error(e.getMessage());
         }

--- a/submarine-commons/commons-cluster/src/test/java/org/apache/submarine/commons/cluster/ClusterMultiNodeTest.java
+++ b/submarine-commons/commons-cluster/src/test/java/org/apache/submarine/commons/cluster/ClusterMultiNodeTest.java
@@ -18,7 +18,7 @@ package org.apache.submarine.commons.cluster;
 
 import org.apache.submarine.commons.cluster.meta.ClusterMetaType;
 import org.apache.submarine.commons.utils.SubmarineConfiguration;
-import org.apache.submarine.commons.utils.NetUtils;
+import org.apache.submarine.commons.utils.NetworkUtils;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -48,10 +48,10 @@ public class ClusterMultiNodeTest {
     LOG.info("ClusterMultiNodeTest::startCluster >>>");
 
     String clusterAddrList = "";
-    String serverHost = NetUtils.findAvailableHostAddress();
+    String serverHost = NetworkUtils.findAvailableHostAddress();
     for (int i = 0; i < 3; i++) {
       // Set the cluster IP and port
-      int serverPort = NetUtils.findRandomAvailablePortOnAllLocalInterfaces();
+      int serverPort = NetworkUtils.findRandomAvailablePortOnAllLocalInterfaces();
       clusterAddrList += serverHost + ":" + serverPort;
       if (i != 2) {
         clusterAddrList += ",";

--- a/submarine-commons/commons-utils/pom.xml
+++ b/submarine-commons/commons-utils/pom.xml
@@ -60,26 +60,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.thrift</groupId>
-      <artifactId>libthrift</artifactId>
-      <version>${libthrift.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.slf4j</groupId>
-          <artifactId>slf4j-api</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.apache.httpcomponents</groupId>
-          <artifactId>httpcore</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>commons-logging</groupId>
-          <artifactId>commons-logging</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-
-    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
       <version>${slf4j.version}</version>

--- a/submarine-commons/commons-utils/src/main/java/org/apache/submarine/commons/utils/NetworkUtils.java
+++ b/submarine-commons/commons-utils/src/main/java/org/apache/submarine/commons/utils/NetworkUtils.java
@@ -17,9 +17,6 @@
 
 package org.apache.submarine.commons.utils;
 
-import org.apache.commons.lang.StringUtils;
-import org.apache.thrift.transport.TServerSocket;
-import org.apache.thrift.transport.TTransportException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,8 +33,8 @@ import java.net.SocketException;
 import java.net.UnknownHostException;
 import java.util.Collections;
 
-public class NetUtils {
-  static Logger LOG = LoggerFactory.getLogger(NetUtils.class);
+public class NetworkUtils {
+  static Logger LOG = LoggerFactory.getLogger(NetworkUtils.class);
 
   public static int findRandomAvailablePortOnAllLocalInterfaces() throws IOException {
     int port;
@@ -46,47 +43,6 @@ public class NetUtils {
       socket.close();
     }
     return port;
-  }
-
-  /**
-   * start:end
-   *
-   * @param portRange
-   * @return
-   * @throws IOException
-   */
-  public static TServerSocket createTServerSocket(String portRange)
-      throws IOException {
-
-    TServerSocket tSocket = null;
-    // ':' is the default value which means no constraints on the portRange
-    if (StringUtils.isBlank(portRange) || portRange.equals(":")) {
-      try {
-        tSocket = new TServerSocket(0);
-        return tSocket;
-      } catch (TTransportException e) {
-        throw new IOException("Fail to create TServerSocket", e);
-      }
-    }
-    // valid user registered port https://en.wikipedia.org/wiki/Registered_port
-    int start = 1024;
-    int end = 65535;
-    String[] ports = portRange.split(":", -1);
-    if (!ports[0].isEmpty()) {
-      start = Integer.parseInt(ports[0]);
-    }
-    if (!ports[1].isEmpty()) {
-      end = Integer.parseInt(ports[1]);
-    }
-    for (int i = start; i <= end; ++i) {
-      try {
-        tSocket = new TServerSocket(i);
-        return tSocket;
-      } catch (Exception e) {
-        // ignore this
-      }
-    }
-    throw new IOException("No available port in the portRange: " + portRange);
   }
 
   public static String findAvailableHostAddress() throws UnknownHostException, SocketException {

--- a/submarine-workbench/interpreter/python-interpreter/src/test/java/org/apache/submarine/interpreter/InterpreterClusterTest.java
+++ b/submarine-workbench/interpreter/python-interpreter/src/test/java/org/apache/submarine/interpreter/InterpreterClusterTest.java
@@ -20,7 +20,7 @@ package org.apache.submarine.interpreter;
 
 import org.apache.submarine.commons.cluster.ClusterClient;
 import org.apache.submarine.commons.cluster.ClusterServer;
-import org.apache.submarine.commons.utils.NetUtils;
+import org.apache.submarine.commons.utils.NetworkUtils;
 import org.apache.submarine.commons.utils.SubmarineConfiguration;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -55,8 +55,8 @@ public class InterpreterClusterTest {
     sconf = SubmarineConfiguration.create();
 
     // Set the cluster IP and port
-    serverHost = NetUtils.findAvailableHostAddress();
-    serverPort = NetUtils.findRandomAvailablePortOnAllLocalInterfaces();
+    serverHost = NetworkUtils.findAvailableHostAddress();
+    serverPort = NetworkUtils.findRandomAvailablePortOnAllLocalInterfaces();
     sconf.setClusterAddress(serverHost + ":" + serverPort);
 
     // mock cluster manager server

--- a/submarine-workbench/workbench-server/src/test/java/org/apache/submarine/server/WorkbenchClusterServerTest.java
+++ b/submarine-workbench/workbench-server/src/test/java/org/apache/submarine/server/WorkbenchClusterServerTest.java
@@ -20,7 +20,7 @@ package org.apache.submarine.server;
 
 import org.apache.submarine.commons.cluster.ClusterClient;
 import org.apache.submarine.commons.cluster.meta.ClusterMetaType;
-import org.apache.submarine.commons.utils.NetUtils;
+import org.apache.submarine.commons.utils.NetworkUtils;
 import org.apache.submarine.commons.utils.SubmarineConfiguration;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -46,8 +46,8 @@ public class WorkbenchClusterServerTest {
     LOG.info("WorkbenchClusterServerTest:start()");
 
     SubmarineConfiguration conf = SubmarineConfiguration.create();
-    String serverHost = NetUtils.findAvailableHostAddress();
-    int serverPort = NetUtils.findRandomAvailablePortOnAllLocalInterfaces();
+    String serverHost = NetworkUtils.findAvailableHostAddress();
+    int serverPort = NetworkUtils.findRandomAvailablePortOnAllLocalInterfaces();
     String clusterAdd = serverHost + ":" + serverPort;
     conf.setClusterAddress(clusterAdd);
 


### PR DESCRIPTION
### What is this PR for?
The libthrift library is now included in the project, but it is not used.
Submarine will use the gRPC framework to communicate later.
and delete unused libthrift dependency.


### What type of PR is it?
[Refactoring]

### What is the Jira issue?
* https://issues.apache.org/jira/browse/SUBMARINE-264

### How should this be tested?
* [CI pass](https://travis-ci.org/liuxunorg/hadoop-submarine/builds/603954727)

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions?  No
* Does this needs documentation? No
