### PR TITLE
SUBMARINE-266. Update CICD script as git repo location has changed.

### DIFF
--- a/dev-support/cicd/Dockerfile
+++ b/dev-support/cicd/Dockerfile
@@ -27,10 +27,10 @@ RUN \
   deactivate
 
 RUN \
-  git clone https://gitbox.apache.org/repos/asf/hadoop-submarine.git && \
+  git clone https://gitbox.apache.org/repos/asf/submarine.git && \
   cd hadoop-submarine && \
   git remote rename origin apache && \
-  git remote add apache-github https://github.com/apache/hadoop-submarine.git
+  git remote add apache-github https://github.com/apache/submarine.git
 ADD \
   entry.sh /entry.sh
 ENV \

--- a/dev-support/cicd/merge_submarine_pr.py
+++ b/dev-support/cicd/merge_submarine_pr.py
@@ -48,8 +48,8 @@ JIRA_USERNAME = os.environ.get("JIRA_USERNAME", "you-jira-user-name")
 # ASF JIRA password
 JIRA_PASSWORD = os.environ.get("JIRA_PASSWORD", "you-jira-password")
 
-GITHUB_BASE = "https://github.com/apache/hadoop-submarine/pull"
-GITHUB_API_BASE = "https://api.github.com/repos/apache/hadoop-submarine"
+GITHUB_BASE = "https://github.com/apache/submarine/pull"
+GITHUB_API_BASE = "https://api.github.com/repos/apache/submarine"
 JIRA_BASE = "https://issues.apache.org/jira/browse"
 JIRA_API_BASE = "https://issues.apache.org/jira"
 # Prefix added to temporary branches


### PR DESCRIPTION
### What is this PR for?
Because the name of the submarine project github repository changed, the CICD script  executed failed. So need to update.


### What type of PR is it?
Bug Fix

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-266

### How should this be tested?
https://travis-ci.org/yuanzac/hadoop-submarine/builds/604318379

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? Yes
* Does this needs documentation? No
