### PR TITLE
SUBMARINE-268. Unify all test class file name with "*Test" pattern

### DIFF
--- a/submarine-client/src/test/java/org/apache/submarine/client/cli/ShowJobCliParsingTest.java
+++ b/submarine-client/src/test/java/org/apache/submarine/client/cli/ShowJobCliParsingTest.java
@@ -41,7 +41,7 @@ import java.util.Map;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class TestShowJobCliParsing {
+public class ShowJobCliParsingTest {
   @Before
   public void before() {
     SubmarineLogs.verboseOff();

--- a/submarine-client/src/test/java/org/apache/submarine/client/cli/runjob/RunJobCliParsingCommonTest.java
+++ b/submarine-client/src/test/java/org/apache/submarine/client/cli/runjob/RunJobCliParsingCommonTest.java
@@ -47,7 +47,7 @@ import static org.mockito.Mockito.when;
  * This class contains some test methods to test common functionality
  * (including TF / PyTorch) of the run job Submarine command.
  */
-public class TestRunJobCliParsingCommon {
+public class RunJobCliParsingCommonTest {
 
   @Before
   public void before() {

--- a/submarine-client/src/test/java/org/apache/submarine/client/cli/runjob/RunJobCliParsingCommonYamlTest.java
+++ b/submarine-client/src/test/java/org/apache/submarine/client/cli/runjob/RunJobCliParsingCommonYamlTest.java
@@ -39,7 +39,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 
-import static org.apache.submarine.client.cli.runjob.TestRunJobCliParsingCommon.getMockClientContext;
+import static org.apache.submarine.client.cli.runjob.RunJobCliParsingCommonTest.getMockClientContext;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -47,12 +47,12 @@ import static org.junit.Assert.assertTrue;
  * This class contains some test methods to test common YAML parsing
  * functionality (including TF / PyTorch) of the run job Submarine command.
  */
-public class TestRunJobCliParsingCommonYaml {
+public class RunJobCliParsingCommonYamlTest {
   private static final String DIR_NAME = "runjob-common-yaml";
   private static final String TF_DIR = "runjob-pytorch-yaml";
   private File yamlConfig;
   private static Logger LOG = LoggerFactory.getLogger(
-      TestRunJobCliParsingCommonYaml.class);
+      RunJobCliParsingCommonYamlTest.class);
 
   @Before
   public void before() {

--- a/submarine-client/src/test/java/org/apache/submarine/client/cli/runjob/RunJobCliParsingParameterizedTest.java
+++ b/submarine-client/src/test/java/org/apache/submarine/client/cli/runjob/RunJobCliParsingParameterizedTest.java
@@ -40,7 +40,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
-import static org.apache.submarine.client.cli.runjob.TestRunJobCliParsingCommon.getMockClientContext;
+import static org.apache.submarine.client.cli.runjob.RunJobCliParsingCommonTest.getMockClientContext;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -51,7 +51,7 @@ import static org.mockito.Mockito.mock;
  * functionality (including TF / PyTorch) of the run job Submarine command.
  */
 @RunWith(Parameterized.class)
-public class TestRunJobCliParsingParameterized {
+public class RunJobCliParsingParameterizedTest {
 
   private final Framework framework;
 
@@ -71,7 +71,7 @@ public class TestRunJobCliParsingParameterized {
     return params;
   }
 
-  public TestRunJobCliParsingParameterized(Framework framework) {
+  public RunJobCliParsingParameterizedTest(Framework framework) {
     this.framework = framework;
   }
 

--- a/submarine-client/src/test/java/org/apache/submarine/client/cli/runjob/pytorch/RunJobCliParsingPyTorchTest.java
+++ b/submarine-client/src/test/java/org/apache/submarine/client/cli/runjob/pytorch/RunJobCliParsingPyTorchTest.java
@@ -25,7 +25,7 @@ import org.apache.submarine.client.cli.param.runjob.RunJobParameters;
 import org.apache.submarine.client.cli.runjob.RunJobCli;
 import org.apache.submarine.commons.runtime.conf.SubmarineLogs;
 import org.apache.hadoop.yarn.util.resource.Resources;
-import org.apache.submarine.client.cli.runjob.TestRunJobCliParsingCommon;
+import org.apache.submarine.client.cli.runjob.RunJobCliParsingCommonTest;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -39,7 +39,7 @@ import static org.junit.Assert.assertTrue;
  * Test class that verifies the correctness of PyTorch
  * CLI configuration parsing.
  */
-public class TestRunJobCliParsingPyTorch {
+public class RunJobCliParsingPyTorchTest {
 
   @Before
   public void before() {
@@ -51,7 +51,7 @@ public class TestRunJobCliParsingPyTorch {
 
   @Test
   public void testBasicRunJobForSingleNodeTraining() throws Exception {
-    RunJobCli runJobCli = new RunJobCli(TestRunJobCliParsingCommon.getMockClientContext());
+    RunJobCli runJobCli = new RunJobCli(RunJobCliParsingCommonTest.getMockClientContext());
     assertFalse(SubmarineLogs.isVerbose());
 
     runJobCli.run(
@@ -84,7 +84,7 @@ public class TestRunJobCliParsingPyTorch {
 
   @Test
   public void testNumPSCannotBeDefined() throws Exception {
-    RunJobCli runJobCli = new RunJobCli(TestRunJobCliParsingCommon.getMockClientContext());
+    RunJobCli runJobCli = new RunJobCli(RunJobCliParsingCommonTest.getMockClientContext());
     assertFalse(SubmarineLogs.isVerbose());
 
     expectedException.expect(ParseException.class);
@@ -102,7 +102,7 @@ public class TestRunJobCliParsingPyTorch {
 
   @Test
   public void testPSResourcesCannotBeDefined() throws Exception {
-    RunJobCli runJobCli = new RunJobCli(TestRunJobCliParsingCommon.getMockClientContext());
+    RunJobCli runJobCli = new RunJobCli(RunJobCliParsingCommonTest.getMockClientContext());
     assertFalse(SubmarineLogs.isVerbose());
 
     expectedException.expect(ParseException.class);
@@ -120,7 +120,7 @@ public class TestRunJobCliParsingPyTorch {
 
   @Test
   public void testPSDockerImageCannotBeDefined() throws Exception {
-    RunJobCli runJobCli = new RunJobCli(TestRunJobCliParsingCommon.getMockClientContext());
+    RunJobCli runJobCli = new RunJobCli(RunJobCliParsingCommonTest.getMockClientContext());
     assertFalse(SubmarineLogs.isVerbose());
 
     expectedException.expect(ParseException.class);
@@ -138,7 +138,7 @@ public class TestRunJobCliParsingPyTorch {
 
   @Test
   public void testPSLaunchCommandCannotBeDefined() throws Exception {
-    RunJobCli runJobCli = new RunJobCli(TestRunJobCliParsingCommon.getMockClientContext());
+    RunJobCli runJobCli = new RunJobCli(RunJobCliParsingCommonTest.getMockClientContext());
     assertFalse(SubmarineLogs.isVerbose());
 
     expectedException.expect(ParseException.class);
@@ -156,7 +156,7 @@ public class TestRunJobCliParsingPyTorch {
 
   @Test
   public void testTensorboardCannotBeDefined() throws Exception {
-    RunJobCli runJobCli = new RunJobCli(TestRunJobCliParsingCommon.getMockClientContext());
+    RunJobCli runJobCli = new RunJobCli(RunJobCliParsingCommonTest.getMockClientContext());
     assertFalse(SubmarineLogs.isVerbose());
 
     expectedException.expect(ParseException.class);
@@ -174,7 +174,7 @@ public class TestRunJobCliParsingPyTorch {
 
   @Test
   public void testTensorboardResourcesCannotBeDefined() throws Exception {
-    RunJobCli runJobCli = new RunJobCli(TestRunJobCliParsingCommon.getMockClientContext());
+    RunJobCli runJobCli = new RunJobCli(RunJobCliParsingCommonTest.getMockClientContext());
     assertFalse(SubmarineLogs.isVerbose());
 
     expectedException.expect(ParseException.class);
@@ -192,7 +192,7 @@ public class TestRunJobCliParsingPyTorch {
 
   @Test
   public void testTensorboardDockerImageCannotBeDefined() throws Exception {
-    RunJobCli runJobCli = new RunJobCli(TestRunJobCliParsingCommon.getMockClientContext());
+    RunJobCli runJobCli = new RunJobCli(RunJobCliParsingCommonTest.getMockClientContext());
     assertFalse(SubmarineLogs.isVerbose());
 
     expectedException.expect(ParseException.class);

--- a/submarine-client/src/test/java/org/apache/submarine/client/cli/runjob/pytorch/RunJobCliParsingPyTorchYamlTest.java
+++ b/submarine-client/src/test/java/org/apache/submarine/client/cli/runjob/pytorch/RunJobCliParsingPyTorchYamlTest.java
@@ -17,45 +17,48 @@
  * under the License.
  */
 
-package org.apache.submarine.client.cli.runjob.tensorflow;
-
-import com.google.common.collect.ImmutableList;
-import org.apache.hadoop.yarn.api.records.Resource;
-import org.apache.submarine.client.cli.YamlConfigTestUtils;
-import org.apache.submarine.client.cli.param.runjob.RunJobParameters;
-import org.apache.submarine.client.cli.param.runjob.TensorFlowRunJobParameters;
-import org.apache.submarine.client.cli.runjob.RunJobCli;
-import org.apache.submarine.commons.runtime.conf.SubmarineLogs;
-import org.apache.submarine.commons.runtime.exception.SubmarineRuntimeException;
-import org.apache.submarine.commons.runtime.resource.ResourceUtils;
-import org.apache.hadoop.yarn.util.resource.Resources;
-import org.apache.submarine.client.cli.runjob.TestRunJobCliParsingCommon;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.io.File;
-import java.util.List;
+package org.apache.submarine.client.cli.runjob.pytorch;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+import java.io.File;
+import java.util.List;
+
+import org.apache.hadoop.yarn.api.records.Resource;
+import org.apache.submarine.client.cli.YamlConfigTestUtils;
+import org.apache.submarine.client.cli.param.runjob.PyTorchRunJobParameters;
+import org.apache.submarine.client.cli.param.runjob.RunJobParameters;
+import org.apache.submarine.client.cli.param.yaml.YamlParseException;
+import org.apache.submarine.client.cli.runjob.RunJobCli;
+import org.apache.submarine.commons.runtime.conf.SubmarineLogs;
+import org.apache.submarine.commons.runtime.exception.SubmarineRuntimeException;
+import org.apache.submarine.commons.runtime.resource.ResourceUtils;
+import org.apache.hadoop.yarn.util.resource.Resources;
+import org.apache.submarine.client.cli.runjob.RunJobCliParsingCommonTest;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import com.google.common.collect.ImmutableList;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
- * Test class that verifies the correctness of TF YAML configuration parsing.
+ * Test class that verifies the correctness of PyTorch
+ * YAML configuration parsing.
  */
-public class TestRunJobCliParsingTensorFlowYaml {
+public class RunJobCliParsingPyTorchYamlTest {
   private static final String OVERRIDDEN_PREFIX = "overridden_";
-  private static final String DIR_NAME = "runjob-tensorflow-yaml";
+  private static final String DIR_NAME = "runjob-pytorch-yaml";
   private File yamlConfig;
   private static Logger LOG = LoggerFactory.getLogger(
-      TestRunJobCliParsingTensorFlowYaml.class);
+      RunJobCliParsingPyTorchYamlTest.class);
 
   @Before
   public void before() {
@@ -79,7 +82,7 @@ public class TestRunJobCliParsingTensorFlowYaml {
       List<String> expectedEnvs) {
     assertEquals("testInputPath", jobRunParameters.getInputPath());
     assertEquals("testCheckpointPath", jobRunParameters.getCheckpointPath());
-    assertEquals("testDockerImage", jobRunParameters.getDockerImageName());
+    Assert.assertEquals("testDockerImage", jobRunParameters.getDockerImageName());
 
     assertNotNull(jobRunParameters.getLocalizations());
     assertEquals(2, jobRunParameters.getLocalizations().size());
@@ -97,53 +100,38 @@ public class TestRunJobCliParsingTensorFlowYaml {
     }
   }
 
-  private void verifyPsValues(RunJobParameters jobRunParameters,
-      String prefix) {
+  private PyTorchRunJobParameters verifyWorkerCommonValues(RunJobParameters
+      jobRunParameters, String prefix) {
     assertTrue(RunJobParameters.class + " must be an instance of " +
-            TensorFlowRunJobParameters.class,
-        jobRunParameters instanceof TensorFlowRunJobParameters);
-    TensorFlowRunJobParameters tensorFlowParams =
-        (TensorFlowRunJobParameters) jobRunParameters;
+            PyTorchRunJobParameters.class,
+        jobRunParameters instanceof PyTorchRunJobParameters);
+    PyTorchRunJobParameters pyTorchParams =
+        (PyTorchRunJobParameters) jobRunParameters;
 
-    assertEquals(4, tensorFlowParams.getNumPS());
-    assertEquals(prefix + "testLaunchCmdPs", tensorFlowParams.getPSLaunchCmd());
-    assertEquals(prefix + "testDockerImagePs",
-        tensorFlowParams.getPsDockerImage());
-    assertEquals(Resources.createResource(20500, 34),
-        tensorFlowParams.getPsResource());
-  }
-
-  private TensorFlowRunJobParameters verifyWorkerCommonValues(
-      RunJobParameters jobRunParameters, String prefix) {
-    assertTrue(RunJobParameters.class + " must be an instance of " +
-            TensorFlowRunJobParameters.class,
-        jobRunParameters instanceof TensorFlowRunJobParameters);
-    TensorFlowRunJobParameters tensorFlowParams =
-        (TensorFlowRunJobParameters) jobRunParameters;
-
-    assertEquals(3, tensorFlowParams.getNumWorkers());
+    assertEquals(3, pyTorchParams.getNumWorkers());
     assertEquals(prefix + "testLaunchCmdWorker",
-        tensorFlowParams.getWorkerLaunchCmd());
+        pyTorchParams.getWorkerLaunchCmd());
     assertEquals(prefix + "testDockerImageWorker",
-        tensorFlowParams.getWorkerDockerImage());
-    return tensorFlowParams;
+        pyTorchParams.getWorkerDockerImage());
+    return pyTorchParams;
   }
 
   private void verifyWorkerValues(RunJobParameters jobRunParameters,
       String prefix) {
-    TensorFlowRunJobParameters tensorFlowParams = verifyWorkerCommonValues
+    PyTorchRunJobParameters pyTorchParams = verifyWorkerCommonValues
         (jobRunParameters, prefix);
     assertEquals(Resources.createResource(20480, 32),
-        tensorFlowParams.getWorkerResource());
+        pyTorchParams.getWorkerResource());
   }
 
   private void verifyWorkerValuesWithGpu(RunJobParameters jobRunParameters,
-                                  String prefix) {
-    TensorFlowRunJobParameters tensorFlowParams = verifyWorkerCommonValues
+      String prefix) {
+
+    PyTorchRunJobParameters pyTorchParams = verifyWorkerCommonValues
         (jobRunParameters, prefix);
     Resource workResource = Resources.createResource(20480, 32);
     ResourceUtils.setResource(workResource, ResourceUtils.GPU_URI, 2);
-    assertEquals(workResource, tensorFlowParams.getWorkerResource());
+    assertEquals(workResource, pyTorchParams.getWorkerResource());
   }
 
   private void verifySecurityValues(RunJobParameters jobRunParameters) {
@@ -152,23 +140,9 @@ public class TestRunJobCliParsingTensorFlowYaml {
     assertTrue(jobRunParameters.isDistributeKeytab());
   }
 
-  private void verifyTensorboardValues(RunJobParameters jobRunParameters) {
-    assertTrue(RunJobParameters.class + " must be an instance of " +
-            TensorFlowRunJobParameters.class,
-        jobRunParameters instanceof TensorFlowRunJobParameters);
-    TensorFlowRunJobParameters tensorFlowParams =
-        (TensorFlowRunJobParameters) jobRunParameters;
-
-    assertTrue(tensorFlowParams.isTensorboardEnabled());
-    assertEquals("tensorboardDockerImage",
-        tensorFlowParams.getTensorboardDockerImage());
-    assertEquals(Resources.createResource(21000, 37),
-        tensorFlowParams.getTensorboardResource());
-  }
-
   @Test
   public void testValidYamlParsing() throws Exception {
-    RunJobCli runJobCli = new RunJobCli(TestRunJobCliParsingCommon.getMockClientContext());
+    RunJobCli runJobCli = new RunJobCli(RunJobCliParsingCommonTest.getMockClientContext());
     Assert.assertFalse(SubmarineLogs.isVerbose());
 
     yamlConfig = YamlConfigTestUtils.createTempFileWithContents(
@@ -178,10 +152,8 @@ public class TestRunJobCliParsingTensorFlowYaml {
 
     RunJobParameters jobRunParameters = runJobCli.getRunJobParameters();
     verifyBasicConfigValues(jobRunParameters);
-    verifyPsValues(jobRunParameters, "");
     verifyWorkerValues(jobRunParameters, "");
     verifySecurityValues(jobRunParameters);
-    verifyTensorboardValues(jobRunParameters);
   }
 
   @Test
@@ -194,7 +166,7 @@ public class TestRunJobCliParsingTensorFlowYaml {
       return;
     }
 
-    RunJobCli runJobCli = new RunJobCli(TestRunJobCliParsingCommon.getMockClientContext());
+    RunJobCli runJobCli = new RunJobCli(RunJobCliParsingCommonTest.getMockClientContext());
     Assert.assertFalse(SubmarineLogs.isVerbose());
 
     yamlConfig = YamlConfigTestUtils.createTempFileWithContents(
@@ -204,15 +176,13 @@ public class TestRunJobCliParsingTensorFlowYaml {
 
     RunJobParameters jobRunParameters = runJobCli.getRunJobParameters();
     verifyBasicConfigValues(jobRunParameters);
-    verifyPsValues(jobRunParameters, "");
     verifyWorkerValuesWithGpu(jobRunParameters, "");
     verifySecurityValues(jobRunParameters);
-    verifyTensorboardValues(jobRunParameters);
   }
 
   @Test
   public void testRoleOverrides() throws Exception {
-    RunJobCli runJobCli = new RunJobCli(TestRunJobCliParsingCommon.getMockClientContext());
+    RunJobCli runJobCli = new RunJobCli(RunJobCliParsingCommonTest.getMockClientContext());
     Assert.assertFalse(SubmarineLogs.isVerbose());
 
     yamlConfig = YamlConfigTestUtils.createTempFileWithContents(
@@ -222,15 +192,13 @@ public class TestRunJobCliParsingTensorFlowYaml {
 
     RunJobParameters jobRunParameters = runJobCli.getRunJobParameters();
     verifyBasicConfigValues(jobRunParameters);
-    verifyPsValues(jobRunParameters, OVERRIDDEN_PREFIX);
     verifyWorkerValues(jobRunParameters, OVERRIDDEN_PREFIX);
     verifySecurityValues(jobRunParameters);
-    verifyTensorboardValues(jobRunParameters);
   }
 
   @Test
   public void testMissingPrincipalUnderSecuritySection() throws Exception {
-    RunJobCli runJobCli = new RunJobCli(TestRunJobCliParsingCommon.getMockClientContext());
+    RunJobCli runJobCli = new RunJobCli(RunJobCliParsingCommonTest.getMockClientContext());
 
     yamlConfig = YamlConfigTestUtils.createTempFileWithContents(
         DIR_NAME + "/security-principal-is-missing.yaml");
@@ -239,9 +207,7 @@ public class TestRunJobCliParsingTensorFlowYaml {
 
     RunJobParameters jobRunParameters = runJobCli.getRunJobParameters();
     verifyBasicConfigValues(jobRunParameters);
-    verifyPsValues(jobRunParameters, "");
     verifyWorkerValues(jobRunParameters, "");
-    verifyTensorboardValues(jobRunParameters);
 
     //Verify security values
     assertEquals("keytabPath", jobRunParameters.getKeytab());
@@ -250,34 +216,8 @@ public class TestRunJobCliParsingTensorFlowYaml {
   }
 
   @Test
-  public void testMissingTensorBoardDockerImage() throws Exception {
-    RunJobCli runJobCli = new RunJobCli(TestRunJobCliParsingCommon.getMockClientContext());
-
-    yamlConfig = YamlConfigTestUtils.createTempFileWithContents(
-        DIR_NAME + "/tensorboard-dockerimage-is-missing.yaml");
-    runJobCli.run(
-        new String[]{"-f", yamlConfig.getAbsolutePath(), "--verbose"});
-
-    RunJobParameters jobRunParameters = runJobCli.getRunJobParameters();
-
-    verifyBasicConfigValues(jobRunParameters);
-    verifyPsValues(jobRunParameters, "");
-    verifyWorkerValues(jobRunParameters, "");
-    verifySecurityValues(jobRunParameters);
-
-    TensorFlowRunJobParameters tensorFlowParams =
-        (TensorFlowRunJobParameters) jobRunParameters;
-
-    assertTrue(tensorFlowParams.isTensorboardEnabled());
-    assertNull("tensorboardDockerImage should be null!",
-        tensorFlowParams.getTensorboardDockerImage());
-    assertEquals(Resources.createResource(21000, 37),
-        tensorFlowParams.getTensorboardResource());
-  }
-
-  @Test
   public void testMissingEnvs() throws Exception {
-    RunJobCli runJobCli = new RunJobCli(TestRunJobCliParsingCommon.getMockClientContext());
+    RunJobCli runJobCli = new RunJobCli(RunJobCliParsingCommonTest.getMockClientContext());
 
     yamlConfig = YamlConfigTestUtils.createTempFileWithContents(
         DIR_NAME + "/envs-are-missing.yaml");
@@ -286,10 +226,34 @@ public class TestRunJobCliParsingTensorFlowYaml {
 
     RunJobParameters jobRunParameters = runJobCli.getRunJobParameters();
     verifyBasicConfigValues(jobRunParameters, ImmutableList.of());
-    verifyPsValues(jobRunParameters, "");
     verifyWorkerValues(jobRunParameters, "");
     verifySecurityValues(jobRunParameters);
-    verifyTensorboardValues(jobRunParameters);
+  }
+
+  @Test
+  public void testInvalidConfigPsSectionIsDefined() throws Exception {
+    RunJobCli runJobCli = new RunJobCli(RunJobCliParsingCommonTest.getMockClientContext());
+
+    exception.expect(YamlParseException.class);
+    exception.expectMessage("PS section should not be defined " +
+        "when PyTorch is the selected framework");
+    yamlConfig = YamlConfigTestUtils.createTempFileWithContents(
+        DIR_NAME + "/invalid-config-ps-section.yaml");
+    runJobCli.run(
+        new String[]{"-f", yamlConfig.getAbsolutePath(), "--verbose"});
+  }
+
+  @Test
+  public void testInvalidConfigTensorboardSectionIsDefined() throws Exception {
+    RunJobCli runJobCli = new RunJobCli(RunJobCliParsingCommonTest.getMockClientContext());
+
+    exception.expect(YamlParseException.class);
+    exception.expectMessage("TensorBoard section should not be defined " +
+        "when PyTorch is the selected framework");
+    yamlConfig = YamlConfigTestUtils.createTempFileWithContents(
+        DIR_NAME + "/invalid-config-tensorboard-section.yaml");
+    runJobCli.run(
+        new String[]{"-f", yamlConfig.getAbsolutePath(), "--verbose"});
   }
 
 }

--- a/submarine-client/src/test/java/org/apache/submarine/client/cli/runjob/tensorflow/RunJobCliParsingTensorFlowTest.java
+++ b/submarine-client/src/test/java/org/apache/submarine/client/cli/runjob/tensorflow/RunJobCliParsingTensorFlowTest.java
@@ -26,7 +26,7 @@ import org.apache.submarine.client.cli.param.runjob.TensorFlowRunJobParameters;
 import org.apache.submarine.client.cli.runjob.RunJobCli;
 import org.apache.submarine.commons.runtime.conf.SubmarineLogs;
 import org.apache.hadoop.yarn.util.resource.Resources;
-import org.apache.submarine.client.cli.runjob.TestRunJobCliParsingCommon;
+import org.apache.submarine.client.cli.runjob.RunJobCliParsingCommonTest;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -40,7 +40,7 @@ import static org.junit.Assert.assertTrue;
  * Test class that verifies the correctness of TensorFlow
  * CLI configuration parsing.
  */
-public class TestRunJobCliParsingTensorFlow {
+public class RunJobCliParsingTensorFlowTest {
 
   @Before
   public void before() {
@@ -52,7 +52,7 @@ public class TestRunJobCliParsingTensorFlow {
 
   @Test
   public void testNoInputPathOptionSpecified() throws Exception {
-    RunJobCli runJobCli = new RunJobCli(TestRunJobCliParsingCommon.getMockClientContext());
+    RunJobCli runJobCli = new RunJobCli(RunJobCliParsingCommonTest.getMockClientContext());
     String expectedErrorMessage = "\"--" + CliConstants.INPUT_PATH +
         "\" is absent";
     String actualMessage = "";
@@ -73,7 +73,7 @@ public class TestRunJobCliParsingTensorFlow {
 
   @Test
   public void testBasicRunJobForDistributedTraining() throws Exception {
-    RunJobCli runJobCli = new RunJobCli(TestRunJobCliParsingCommon.getMockClientContext());
+    RunJobCli runJobCli = new RunJobCli(RunJobCliParsingCommonTest.getMockClientContext());
 
     assertFalse(SubmarineLogs.isVerbose());
 
@@ -119,7 +119,7 @@ public class TestRunJobCliParsingTensorFlow {
 
   @Test
   public void testBasicRunJobForSingleNodeTraining() throws Exception {
-    RunJobCli runJobCli = new RunJobCli(TestRunJobCliParsingCommon.getMockClientContext());
+    RunJobCli runJobCli = new RunJobCli(RunJobCliParsingCommonTest.getMockClientContext());
     assertFalse(SubmarineLogs.isVerbose());
 
     runJobCli.run(
@@ -155,7 +155,7 @@ public class TestRunJobCliParsingTensorFlow {
    * */
   @Test
   public void testNoInputPathOptionButOnlyRunTensorboard() throws Exception {
-    RunJobCli runJobCli = new RunJobCli(TestRunJobCliParsingCommon.getMockClientContext());
+    RunJobCli runJobCli = new RunJobCli(RunJobCliParsingCommonTest.getMockClientContext());
     boolean success = true;
     try {
       runJobCli.run(

--- a/submarine-client/src/test/java/org/apache/submarine/client/cli/runjob/tensorflow/RunJobCliParsingTensorFlowYamlStandaloneTest.java
+++ b/submarine-client/src/test/java/org/apache/submarine/client/cli/runjob/tensorflow/RunJobCliParsingTensorFlowYamlStandaloneTest.java
@@ -44,7 +44,7 @@ import static org.junit.Assert.assertTrue;
  * Please note that this class just tests YAML parsing,
  * but only in an isolated fashion.
  */
-public class TestRunJobCliParsingTensorFlowYamlStandalone {
+public class RunJobCliParsingTensorFlowYamlStandaloneTest {
   private static final String OVERRIDDEN_PREFIX = "overridden_";
   private static final String DIR_NAME = "runjob-tensorflow-yaml";
 

--- a/submarine-server/server-submitter/submitter-yarn/src/test/java/YarnUtilsTest.java
+++ b/submarine-server/server-submitter/submitter-yarn/src/test/java/YarnUtilsTest.java
@@ -44,7 +44,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class TestYarnUtils {
+public class YarnUtilsTest {
 
   private MockClientContext getMockClientContext()
       throws IOException, YarnException {


### PR DESCRIPTION
### What is this PR for?
Due to history reasons, we have the test class file named with "Test*" mainly in submarine-client.
In order to unify this, I propose that we use "Test" as the suffix in the file name. Then we need to rename all needed test files.


### What type of PR is it?
Improvement

### What is the Jira issue?
https://issues.apache.org/jira/projects/SUBMARINE/issues/SUBMARINE-268?filter=allopenissues

### How should this be tested?
https://travis-ci.org/hhhizzz/hadoop-submarine/builds/604332888

### Questions:
* Does the licenses files need an update? No
* Are there breaking changes for older versions? Yes，The name of Tests has been changed
* Does this needs documentation? No
