### PR TITLE
SUBMARINE-272. Modules build order is incorrect.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,14 +117,14 @@
   </properties>
 
   <modules>
-    <module>submarine-all</module>
     <module>submarine-client</module>
     <module>submarine-commons</module>
-    <module>submarine-dist</module>
+    <module>submodules/tony</module>
     <module>submarine-server</module>
+    <module>submarine-all</module>
     <module>submarine-workbench</module>
     <module>submarine-test</module>
-    <module>submodules/tony</module>
+    <module>submarine-dist</module>
   </modules>
 
   <dependencyManagement>

--- a/submarine-dist/pom.xml
+++ b/submarine-dist/pom.xml
@@ -184,6 +184,21 @@
 
       <plugin>
         <artifactId>maven-enforcer-plugin</artifactId>
+        <version>${plugin.enforcer.version}</version>
+        <executions>
+          <execution>
+            <id>enforce</id>
+            <configuration>
+              <rules>
+                <DependencyConvergence/>
+              </rules>
+              <skip>true</skip>
+            </configuration>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/submarine-test/e2e/pom.xml
+++ b/submarine-test/e2e/pom.xml
@@ -10,7 +10,7 @@
     <version>0.3.0-SNAPSHOT</version>
   </parent>
 
-  <artifactId>e2e</artifactId>
+  <artifactId>submarine-e2e</artifactId>
   <version>0.3.0-SNAPSHOT</version>
   <name>Submarine: E2E Test</name>
 

--- a/submarine-workbench/workbench-server/pom.xml
+++ b/submarine-workbench/workbench-server/pom.xml
@@ -42,6 +42,12 @@
     </dependency>
 
     <dependency>
+      <groupId>commons-collections</groupId>
+      <artifactId>commons-collections</artifactId>
+      <version>${commons-collections.version}</version>
+    </dependency>
+
+    <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
       <version>${guava.version}</version>

--- a/submarine-workbench/workbench-web-ng/pom.xml
+++ b/submarine-workbench/workbench-web-ng/pom.xml
@@ -33,7 +33,7 @@
   <artifactId>workbench-web-ng</artifactId>
   <!--  <packaging>war</packaging>-->
   <!--  <version>0.3.0-SNAPSHOT</version>-->
-  <!--  <name>Submarine: Workbench Web Angular</name>-->
+  <name>Submarine: Workbench Web Angular</name>
 
   <!-- See https://github.com/eirslett/frontend-maven-plugin/issues/229 -->
   <prerequisites>


### PR DESCRIPTION
### What is this PR for?
Submarine dist module is used to build a submarine code package. It is supposed to contains all the submarine modules, including workbench and submarine server. 
But maven build order is incorrect, which would cause that workbench code is missing.


### What type of PR is it?
Improvement


### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-272

### How should this be tested?
https://travis-ci.org/yuanzac/hadoop-submarine/builds/605900900?utm_medium=notification&utm_source=github_status

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
