### PR TITLE
SUBMARINE-290. Update submainre DEFAULT_RUNTIME_CLASS

### DIFF
--- a/docs/helper/QuickStart.md
+++ b/docs/helper/QuickStart.md
@@ -51,7 +51,7 @@ Once the applicable runtime is chosen and environment is ready, a `submarine.xml
 
 |Configuration Name | Description |
 |:---- |:---- |
-| `submarine.runtime.class` | "org.apache.submarine.runtimes.tony.TonyRuntimeFactory" or "org.apache.submarine.runtimes.yarnservice.YarnServiceRuntimeFactory" |
+| `submarine.runtime.class` | "org.apache.submarine.server.submitter.yarn.YarnRuntimeFactory" or "org.apache.submarine.server.submitter.yarnservice.YarnServiceRuntimeFactory" |
 
 <br />
 
@@ -61,9 +61,9 @@ A sample `submarine.xml` is here:
 <configuration>
   <property>
     <name>submarine.runtime.class</name>
-    <value>org.apache.submarine.runtimes.tony.TonyRuntimeFactory</value>
+    <value>org.apache.submarine.server.submitter.yarn.YarnRuntimeFactory</value>
     <!-- Alternatively, you can use:
-    <value>org.apache.submarine.runtimes.yarnservice.YarnServiceRuntimeFactory</value>
+    <value>org.apache.submarine.server.submitter.yarnservice.YarnServiceRuntimeFactory</value>
     -->
   </property>
 </configuration>

--- a/submarine-commons/commons-runtime/src/main/java/org/apache/submarine/commons/runtime/conf/SubmarineConfiguration.java
+++ b/submarine-commons/commons-runtime/src/main/java/org/apache/submarine/commons/runtime/conf/SubmarineConfiguration.java
@@ -61,7 +61,7 @@ public class SubmarineConfiguration extends Configuration {
 
   public static final String RUNTIME_CLASS = PREFIX + "runtime.class";
   public static final String DEFAULT_RUNTIME_CLASS =
-      "org.apache.submarine.runtimes.tony.TonyRuntimeFactory";
+      "org.apache.submarine.server.submitter.yarn.YarnRuntimeFactory";
 
   public void setSubmarineRuntimeClass(String runtimeClass) {
     set(RUNTIME_CLASS, runtimeClass);


### PR DESCRIPTION
### What is this PR for?
After SUBMARINE-255 merged, we rename our runtimes to
```
 org.apache.submarine.server.submitter.yarn.YarnRuntimeFactory
 org.apache.submarine.server.submitter.yarnservice.YarnServiceRuntimeFactory
```
but default in SubmarineConfiguration still is
`org.apache.submarine.runtimes.tony.TonyRuntimeFactory`
we also need to update it.


### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-290

### How should this be tested?
https://travis-ci.org/pingsutw/hadoop-submarine/builds/610793459

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
