### PR TITLE
SUBMARINE-295. Modify mysql database submarineDB to submarine

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,10 +48,10 @@ env:
 
 before_install:
   - sudo service mysql restart
-  - mysql -e "create database submarineDB_test;"
+  - mysql -e "create database submarine_test;"
   - mysql -e "CREATE USER 'submarine_test'@'%' IDENTIFIED BY 'password_test';"
-  - mysql -e "GRANT ALL PRIVILEGES ON * . * TO 'submarine_test'@'%';"
-  - mysql -e "use submarineDB_test; source ./docs/database/submarine.sql; show tables;"
+  - mysql -e "GRANT ALL PRIVILEGES ON *.* TO 'submarine_test'@'%';"
+  - mysql -e "use submarine_test; source ./docs/database/submarine.sql; show tables;"
   - ./dev-support/travis/install_external_dependencies.sh
 
 matrix:

--- a/dev-support/mini-submarine/conf/setup-mysql.sh
+++ b/dev-support/mini-submarine/conf/setup-mysql.sh
@@ -17,12 +17,12 @@
 # Install mariadb
 apt-get -y install mariadb-server
 service mysql start
-mysql -e "CREATE DATABASE submarineDB_test;"
+mysql -e "CREATE DATABASE submarine_test;"
 mysql -e "CREATE USER 'submarine_test'@'%' IDENTIFIED BY 'password_test';"
-mysql -e "GRANT ALL PRIVILEGES ON * . * TO 'submarine_test'@'%';"
-mysql -e "use submarineDB_test; source /home/yarn/database/submarine.sql; source /home/yarn/database/submarine-data.sql;"
+mysql -e "GRANT ALL PRIVILEGES ON *.* TO 'submarine_test'@'%';"
+mysql -e "use submarine_test; source /home/yarn/database/submarine.sql; source /home/yarn/database/submarine-data.sql;"
 
-mysql -e "CREATE DATABASE submarineDB;"
+mysql -e "CREATE DATABASE submarine;"
 mysql -e "CREATE USER 'submarine'@'%' IDENTIFIED BY 'password';"
-mysql -e "GRANT ALL PRIVILEGES ON * . * TO 'submarine'@'%';"
-mysql -e "use submarineDB; source /home/yarn/database/submarine.sql; source /home/yarn/database/submarine-data.sql;"
+mysql -e "GRANT ALL PRIVILEGES ON *.* TO 'submarine'@'%';"
+mysql -e "use submarine; source /home/yarn/database/submarine.sql; source /home/yarn/database/submarine-data.sql;"

--- a/docs/database/README.md
+++ b/docs/database/README.md
@@ -93,14 +93,14 @@ Development database for development environment.
 bash > mysql -uroot -ppassword
 mysql> CREATE USER 'submarine'@'%' IDENTIFIED BY 'password';
 mysql> GRANT ALL PRIVILEGES ON * . * TO 'submarine'@'%';
-mysql> CREATE DATABASE submarineDB CHARACTER SET utf8 COLLATE utf8_general_ci;
-mysql> use submarineDB;
+mysql> CREATE DATABASE submarine CHARACTER SET utf8 COLLATE utf8_general_ci;
+mysql> use submarine;
 mysql> source /submarine.sql;
 mysql> source /submarine-data.sql;
 mysql> quit
 ```
 
->  NOTE: submarine development database name is  `submarineDB` and user name is `submarine`, password is `password`, This is the default value in the system's `submarine-site.xml` configuration file and is not recommended for modification.
+>  NOTE: submarine development database name is  `submarine` and user name is `submarine`, password is `password`, This is the default value in the system's `submarine-site.xml` configuration file and is not recommended for modification.
 
 
 ### Create test database
@@ -112,18 +112,18 @@ Test database for program unit testing and Travis test environment.
 bash > mysql -uroot -ppassword
 mysql> CREATE USER 'submarine_test'@'%' IDENTIFIED BY 'password_test';
 mysql> GRANT ALL PRIVILEGES ON * . * TO 'submarine_test'@'%';
-mysql> CREATE DATABASE `submarineDB_test` CHARACTER SET utf8 COLLATE utf8_general_ci;
-mysql> use `submarineDB_test`;
+mysql> CREATE DATABASE `submarine_test` CHARACTER SET utf8 COLLATE utf8_general_ci;
+mysql> use `submarine_test`;
 mysql> source /submarine.sql;
 mysql> quit
 ```
 
->  NOTE: submarine test database name is  `submarineDB_test` and user name is `submarine_test`, password is `password_test`, Cannot be configured, values that cannot be modified.
+>  NOTE: submarine test database name is  `submarine_test` and user name is `submarine_test`, password is `password_test`, Cannot be configured, values that cannot be modified.
 
 ### mysqldump
 
 ```$xslt
-mysqldump -uroot -ppassword --databases submarineDB > submarineDB.sql;
+mysqldump -uroot -ppassword --databases submarine > submarine.sql;
 ```
 
 

--- a/docs/submarine-sdk/pysubmarine/tracking.md
+++ b/docs/submarine-sdk/pysubmarine/tracking.md
@@ -45,7 +45,7 @@ there. The URI should be database connection string.
 
 - URI - Submarine record data to Mysql server. The database URL
 is expected in the format ``<dialect>+<driver>://<username>:<password>@<host>:<port>/<database>``.
-By default it's `mysql+pymysql://submarine:password@localhost:3306/submarineDB`.
+By default it's `mysql+pymysql://submarine:password@localhost:3306/submarine`.
 More detail : [SQLAlchemy docs](https://docs.sqlalchemy.org/en/latest/core/engines.html#database-urls)
 
 <!--

--- a/submarine-commons/commons-utils/src/main/java/org/apache/submarine/commons/utils/SubmarineConfiguration.java
+++ b/submarine-commons/commons-utils/src/main/java/org/apache/submarine/commons/utils/SubmarineConfiguration.java
@@ -433,7 +433,7 @@ public class SubmarineConfiguration extends XMLConfiguration {
     CLUSTER_HEARTBEAT_INTERVAL("cluster.heartbeat.interval", 3000),
     CLUSTER_HEARTBEAT_TIMEOUT("cluster.heartbeat.timeout", 9000),
     JDBC_DRIVERCLASSNAME("jdbc.driverClassName", "com.mysql.jdbc.Driver"),
-    JDBC_URL("jdbc.url", "jdbc:mysql://127.0.0.1:3306/submarineDB" +
+    JDBC_URL("jdbc.url", "jdbc:mysql://127.0.0.1:3306/submarine" +
         "?useUnicode=true&amp;characterEncoding=UTF-8&amp;autoReconnect=true&amp;" +
         "failOverReadOnly=false&amp;zeroDateTimeBehavior=convertToNull&amp;useSSL=false"),
     JDBC_USERNAME("jdbc.username", "submarine"),

--- a/submarine-sdk/pysubmarine/submarine/store/__init__.py
+++ b/submarine-sdk/pysubmarine/submarine/store/__init__.py
@@ -13,6 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-DEFAULT_SUBMARINE_JDBC_URL = "mysql+pymysql://submarine:password@localhost:3306/submarineDB"
+DEFAULT_SUBMARINE_JDBC_URL = "mysql+pymysql://submarine:password@localhost:3306/submarine"
 
 __all__ = ["DEFAULT_SUBMARINE_JDBC_URL"]

--- a/submarine-sdk/pysubmarine/tests/store/test_sqlalchemy_store.py
+++ b/submarine-sdk/pysubmarine/tests/store/test_sqlalchemy_store.py
@@ -29,7 +29,7 @@ JOB_NAME = "application_123456789"
 class TestSqlAlchemyStore(unittest.TestCase):
     def setUp(self):
         submarine.set_tracking_uri(
-            "mysql+pymysql://submarine_test:password_test@localhost:3306/submarineDB_test")
+            "mysql+pymysql://submarine_test:password_test@localhost:3306/submarine_test")
         self.tracking_uri = utils.get_tracking_uri()
         self.store = utils.get_sqlalchemy_store(self.tracking_uri)
 

--- a/submarine-sdk/pysubmarine/tests/tracking/test_tracking.py
+++ b/submarine-sdk/pysubmarine/tests/tracking/test_tracking.py
@@ -28,7 +28,7 @@ class TestTracking(unittest.TestCase):
     def setUp(self):
         environ["SUBMARINE_JOB_NAME"] = JOB_NAME
         submarine.set_tracking_uri(
-            "mysql+pymysql://submarine_test:password_test@localhost:3306/submarineDB_test")
+            "mysql+pymysql://submarine_test:password_test@localhost:3306/submarine_test")
         self.tracking_uri = utils.get_tracking_uri()
         self.store = utils.get_sqlalchemy_store(self.tracking_uri)
 

--- a/submarine-server/server-core/src/main/java/org/apache/submarine/server/workbench/database/MyBatisUtil.java
+++ b/submarine-server/server-core/src/main/java/org/apache/submarine/server/workbench/database/MyBatisUtil.java
@@ -96,7 +96,7 @@ public class MyBatisUtil {
     LOG.info("Run the test unit using the test database");
     // Run the test unit using the test database
     SubmarineConfiguration conf = SubmarineConfiguration.getInstance();
-    conf.setJdbcUrl("jdbc:mysql://127.0.0.1:3306/submarineDB_test?" +
+    conf.setJdbcUrl("jdbc:mysql://127.0.0.1:3306/submarine_test?" +
         "useUnicode=true&amp;characterEncoding=UTF-8&amp;autoReconnect=true&amp;" +
         "failOverReadOnly=false&amp;zeroDateTimeBehavior=convertToNull&amp;useSSL=false");
     conf.setJdbcUserName("submarine_test");

--- a/submarine-server/server-core/src/main/resources/mbgConfiguration.xml
+++ b/submarine-server/server-core/src/main/resources/mbgConfiguration.xml
@@ -28,7 +28,7 @@
     </commentGenerator>
 
     <jdbcConnection driverClass="com.mysql.jdbc.Driver"
-                    connectionURL="jdbc:mysql://127.0.0.1:3306/submarineDB"
+                    connectionURL="jdbc:mysql://127.0.0.1:3306/submarine"
                     userId="submarine"
                     password="password">
     </jdbcConnection>


### PR DESCRIPTION
### What is this PR for?
Because the mysql database name is case sensitive,
Now submarine has 2 mysql databases. They are `submarineDB` and `submarineDB_test`.
It is easy to write `DB` as `db` in program development, Causes a program error and is difficult to troubleshoot.
So modify the `submarineDB` and `submarineDB_test` database to `submarine` and `submarine_test`.

### What type of PR is it?
Improvement

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/SUBMARINE-295

### How should this be tested?
* [CI Pass](https://travis-ci.org/liuxunorg/submarine/builds/614558566)

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
