### PR TITLE
SUBMARINE-302. Split the submitter-yarnservice from travis into job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@
 # limitations under the License.
 
 sudo: required
+dist: xenial
+language: java
 
 before_cache:
   - sudo chown -R travis:travis $HOME/.m2
@@ -43,7 +45,7 @@ env:
     # If you need to compile Phadoop-3.1 or Phadoop-3.2, you need to add `!submarine-server/server-submitter/submitter-yarnservice` in EXCLUDE_SUBMARINE
     - EXCLUDE_SUBMARINE="!submarine-all,!submarine-client,!submarine-commons,!submarine-commons/commons-runtime,!submarine-dist,!submarine-server/server-submitter/submitter-yarn,!submarine-server/server-core,!submarine-server/server-rpc"
     - EXCLUDE_WORKBENCH="!submarine-workbench,!submarine-workbench/workbench-web"
-    - EXCLUDE_INTERPRETER="!submarine-workbench/interpreter,!submarine-workbench/interpreter/interpreter-engine,!submarine-workbench/interpreter/python-interpreter,!submarine-workbench/interpreter/spark-interpreter""
+    - EXCLUDE_INTERPRETER="!submarine-workbench/interpreter,!submarine-workbench/interpreter/interpreter-engine,!submarine-workbench/interpreter/python-interpreter,!submarine-workbench/interpreter/spark-interpreter"
     - EXCLUDE_SUBMODULE_TONY="!submodules/tony,!submodules/tony/tony-mini,!submodules/tony/tony-core,!submodules/tony/tony-proxy,!submodules/tony/tony-portal,!submodules/tony/tony-azkaban,!submodules/tony/tony-cli"
     - EXCLUDE_K8S="!submarine-server/server-submitter/submitter-k8s"
     - EXCLUDE_COMMON_RPC="!submarine-commons/commons-rpc"
@@ -78,33 +80,23 @@ before_install:
 matrix:
   include:
     # Test License compliance using RAT tool
-    - language: java
-      jdk: "openjdk8"
-      dist: xenial
+    - jdk: "openjdk8"
       env: NAME="Check RAT" PROFILE="" BUILD_FLAG="clean" TEST_FLAG="org.apache.rat:apache-rat-plugin:check" TEST_PROJECTS=""
 
     # Build hadoop-2.7
-    - language: java
-      jdk: "openjdk8"
-      dist: xenial
+    - jdk: "openjdk8"
       env: NAME="Build hadoop-2.7" PROFILE="-Phadoop-2.7" BUILD_FLAG="clean package install -DskipTests -DskipRat" TEST_FLAG="test -DskipRat" MODULES="-pl \"${EXCLUDE_K8S},${EXCLUDE_WORKBENCH},${EXCLUDE_INTERPRETER},!submarine-dist\"" TEST_MODULES="-pl \"${EXCLUDE_K8S},${EXCLUDE_WORKBENCH},${EXCLUDE_INTERPRETER},${EXCLUDE_COMMON_RPC},!submarine-dist\"" TEST_PROJECTS=""
 
     # Build hadoop-2.9(default)
-    - language: java
-      jdk: "openjdk8"
-      dist: xenial
+    - jdk: "openjdk8"
       env: NAME="Build hadoop-2.9" PROFILE="-Phadoop-2.9" BUILD_FLAG="clean package install -DskipTests -DskipRat" TEST_FLAG="test -DskipRat" MODULES="-pl \"${EXCLUDE_K8S},${EXCLUDE_WORKBENCH},${EXCLUDE_INTERPRETER},!submarine-dist\"" TEST_MODULES="-pl \"${EXCLUDE_K8S},${EXCLUDE_WORKBENCH},${EXCLUDE_INTERPRETER},${EXCLUDE_COMMON_RPC},!submarine-dist\"" TEST_PROJECTS=""
 
     # Build hadoop-3.1
-    - language: java
-      jdk: "openjdk8"
-      dist: xenial
+    - jdk: "openjdk8"
       env: NAME="Build hadoop-3.1" PROFILE="-Phadoop-3.1" BUILD_FLAG="clean package install -DskipTests -DskipRat" TEST_FLAG="test -DskipRat" MODULES="-pl \"${EXCLUDE_K8S},${EXCLUDE_WORKBENCH},${EXCLUDE_INTERPRETER},!submarine-dist\"" TEST_MODULES="-pl \"${EXCLUDE_K8S},${EXCLUDE_WORKBENCH},${EXCLUDE_INTERPRETER},${EXCLUDE_COMMON_RPC},!submarine-dist\"" TEST_PROJECTS=""
 
     # Build hadoop-3.2
-    - language: java
-      jdk: "openjdk8"
-      dist: xenial
+    - jdk: "openjdk8"
       env: NAME="Build hadoop-3.2" PROFILE="-Phadoop-3.2" BUILD_FLAG="clean package install -DskipTests -DskipRat" TEST_FLAG="test -DskipRat" MODULES="-pl \"${EXCLUDE_K8S},${EXCLUDE_WORKBENCH},${EXCLUDE_INTERPRETER},!submarine-dist\"" TEST_MODULES="-pl \"${EXCLUDE_K8S},${EXCLUDE_WORKBENCH},${EXCLUDE_INTERPRETER},${EXCLUDE_COMMON_RPC},!submarine-dist\"" TEST_PROJECTS=""
 
     # Build workbench-web
@@ -121,21 +113,15 @@ matrix:
       env: NAME="Build workbench-web"
 
     # Test workbench-web
-    - language: java
-      jdk: "openjdk8"
-      dist: xenial
+    - jdk: "openjdk8"
       env: NAME="Test workbench-web" PROFILE="-Phadoop-2.9" BUILD_FLAG="clean package install -DskipTests" TEST_FLAG="test -DskipRat -am" MODULES="-pl ${EXCLUDE_K8S},${EXCLUDE_SUBMARINE},${EXCLUDE_INTERPRETER}" TEST_MODULES="-pl submarine-workbench/workbench-web" TEST_PROJECTS=""
 
     # Test test-e2e
-    - language: java
-      jdk: "openjdk8"
-      dist: xenial
+    - jdk: "openjdk8"
       env: NAME="Test test-e2e" PROFILE="-Phadoop-2.9" BUILD_FLAG="clean test" TEST_FLAG="test -DskipRat -am" MODULES="-pl submarine-test/e2e" TEST_MODULES="-pl submarine-test/e2e" TEST_PROJECTS=""
 
     # Test interpreter
-    - language: java
-      jdk: "openjdk8"
-      dist: xenial
+    - jdk: "openjdk8"
       env: NAME="Test interpreter" PYTHON="3" PROFILE="-Phadoop-2.9" BUILD_FLAG="clean package install -DskipTests" TEST_FLAG="test -DskipRat -am" MODULES="-pl ${EXCLUDE_K8S},${EXCLUDE_SUBMARINE},${EXCLUDE_WORKBENCH},${EXCLUDE_SUBMODULE_TONY}" TEST_MODULES="-pl $(echo ${EXCLUDE_INTERPRETER} | sed 's/!//g')" TEST_PROJECTS=""
 
     # Test submarine-sdk
@@ -150,9 +136,7 @@ matrix:
         - pytest --cov=submarine -vs
 
     # Test submarine distribution
-    - language: java
-      jdk: "openjdk8"
-      dist: xenial
+    - jdk: "openjdk8"
       env: NAME="Test submarine distribution" PROFILE="-Phadoop-2.9" BUILD_FLAG="clean package install -DskipTests" TEST_FLAG="test -DskipRat" MODULES="-pl ${EXCLUDE_K8S}" TEST_MODULES="-pl ${EXCLUDE_K8S},${EXCLUDE_COMMON_RPC}" TEST_PROJECTS=""
 
     # Test submarine web-ng
@@ -175,16 +159,20 @@ matrix:
       env: NAME="Build workbench-web-ng"
 
     # Test submarine-server
-    - language: java
-      jdk: "openjdk8"
-      dist: xenial
+    - jdk: "openjdk8"
       env: NAME="Test submarine-server" PROFILE="-Phadoop-2.9" BUILD_FLAG="clean package install -DskipTests" TEST_FLAG="test -DskipRat" MODULES="-pl ${EXCLUDE_K8S},${EXCLUDE_WORKBENCH},${EXCLUDE_INTERPRETER}" TEST_MODULES="-pl submarine-server/server-core" TEST_PROJECTS=""
+
+    - name: Submarine on Hadoop YARN 3.1
+      jdk: openjdk8
+      env: PROFILE="-Phadoop-3.1" BUILD_FLAG="clean package install -DskipTests -am" TEST_FLAG="test -am" MODULES="-pl org.apache.submarine:submitter-yarnservice" TEST_MODULES="-pl org.apache.submarine:submitter-yarnservice" TEST_PROJECTS=""
+
+    - name: Submarine on Hadoop YARN 3.2
+      jdk: openjdk8
+      env: PROFILE="-Phadoop-3.2" BUILD_FLAG="clean package install -DskipTests -am" TEST_FLAG="test -am" MODULES="-pl org.apache.submarine:submitter-yarnservice" TEST_MODULES="-pl org.apache.submarine:submitter-yarnservice" TEST_PROJECTS=""
 
     - name: Submarine on Kubernetes
       dist: xenial
       services: docker
-      language: java
-      jdk: openjdk8
       env: BUILD_FLAG="clean package install -DskipTests -am" TEST_FLAG="test -am" MODULES="-pl org.apache.submarine:submitter-k8s" TEST_MODULES="-pl org.apache.submarine:submitter-k8s" TEST_PROJECTS=""
       before_install:
         # deploy Kubernetes cluster


### PR DESCRIPTION
### What is this PR for?
The submitter-yarnservice depend on hadoop (3.1+), but it always break other modules. So we'd better split it into job from travis at first.

### What type of PR is it?
[Improvement]

### Todos

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-302

### How should this be tested?
https://travis-ci.org/jiwq/submarine/builds/617271191

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
