### PR TITLE
SUBMARINE-305. Rename test classes in submitter-yarnservice to conform Code style

### DIFF
--- a/submarine-server/server-submitter/submitter-yarnservice/src/test/java/org/apache/submarine/client/cli/yarnservice/YarnServiceRunJobCliCommonsTest.java
+++ b/submarine-server/server-submitter/submitter-yarnservice/src/test/java/org/apache/submarine/client/cli/yarnservice/YarnServiceRunJobCliCommonsTest.java
@@ -39,7 +39,7 @@ import static org.mockito.Mockito.when;
 /**
  * Common operations shared with test classes using Run job-related actions.
  */
-public class TestYarnServiceRunJobCliCommons {
+public class YarnServiceRunJobCliCommonsTest {
   static final String DEFAULT_JOB_NAME = "my-job";
   static final String DEFAULT_DOCKER_IMAGE = "tf-docker:1.1.0";
   static final String DEFAULT_INPUT_PATH = "s3://input";

--- a/submarine-server/server-submitter/submitter-yarnservice/src/test/java/org/apache/submarine/client/cli/yarnservice/YarnServiceRunJobCliLocalizationTest.java
+++ b/submarine-server/server-submitter/submitter-yarnservice/src/test/java/org/apache/submarine/client/cli/yarnservice/YarnServiceRunJobCliLocalizationTest.java
@@ -52,13 +52,13 @@ import static org.mockito.Mockito.verify;
 /**
  * Class to test YarnService localization feature with the Run job CLI action.
  */
-public class TestYarnServiceRunJobCliLocalization {
+public class YarnServiceRunJobCliLocalizationTest {
   private static final Logger LOG =
-      LoggerFactory.getLogger(TestYarnServiceRunJobCliLocalization.class);
+      LoggerFactory.getLogger(YarnServiceRunJobCliLocalizationTest.class);
 
   private static final String ZIP_EXTENSION = ".zip";
-  private TestYarnServiceRunJobCliCommons testCommons =
-      new TestYarnServiceRunJobCliCommons();
+  private YarnServiceRunJobCliCommonsTest testCommons =
+      new YarnServiceRunJobCliCommonsTest();
   private MockClientContext mockClientContext;
   private RemoteDirectoryManager spyRdm;
 
@@ -77,18 +77,18 @@ public class TestYarnServiceRunJobCliLocalization {
   private ParamBuilderForTest createCommonParamsBuilder() {
     return ParamBuilderForTest.create()
         .withFramework("tensorflow")
-        .withJobName(TestYarnServiceRunJobCliCommons.DEFAULT_JOB_NAME)
-        .withDockerImage(TestYarnServiceRunJobCliCommons.DEFAULT_DOCKER_IMAGE)
-        .withInputPath(TestYarnServiceRunJobCliCommons.DEFAULT_INPUT_PATH)
-        .withCheckpointPath(TestYarnServiceRunJobCliCommons.DEFAULT_CHECKPOINT_PATH)
+        .withJobName(YarnServiceRunJobCliCommonsTest.DEFAULT_JOB_NAME)
+        .withDockerImage(YarnServiceRunJobCliCommonsTest.DEFAULT_DOCKER_IMAGE)
+        .withInputPath(YarnServiceRunJobCliCommonsTest.DEFAULT_INPUT_PATH)
+        .withCheckpointPath(YarnServiceRunJobCliCommonsTest.DEFAULT_CHECKPOINT_PATH)
         .withNumberOfWorkers(3)
-        .withWorkerDockerImage(TestYarnServiceRunJobCliCommons.DEFAULT_WORKER_DOCKER_IMAGE)
-        .withWorkerLaunchCommand(TestYarnServiceRunJobCliCommons.DEFAULT_WORKER_LAUNCH_CMD)
-        .withWorkerResources(TestYarnServiceRunJobCliCommons.DEFAULT_WORKER_RESOURCES)
+        .withWorkerDockerImage(YarnServiceRunJobCliCommonsTest.DEFAULT_WORKER_DOCKER_IMAGE)
+        .withWorkerLaunchCommand(YarnServiceRunJobCliCommonsTest.DEFAULT_WORKER_LAUNCH_CMD)
+        .withWorkerResources(YarnServiceRunJobCliCommonsTest.DEFAULT_WORKER_RESOURCES)
         .withNumberOfPs(2)
-        .withPsDockerImage(TestYarnServiceRunJobCliCommons.DEFAULT_PS_DOCKER_IMAGE)
-        .withPsLaunchCommand(TestYarnServiceRunJobCliCommons.DEFAULT_PS_LAUNCH_CMD)
-        .withPsResources(TestYarnServiceRunJobCliCommons.DEFAULT_PS_RESOURCES)
+        .withPsDockerImage(YarnServiceRunJobCliCommonsTest.DEFAULT_PS_DOCKER_IMAGE)
+        .withPsLaunchCommand(YarnServiceRunJobCliCommonsTest.DEFAULT_PS_LAUNCH_CMD)
+        .withPsResources(YarnServiceRunJobCliCommonsTest.DEFAULT_PS_RESOURCES)
         .withVerbose();
   }
 
@@ -108,7 +108,7 @@ public class TestYarnServiceRunJobCliLocalization {
 
   private Path getStagingDir() throws IOException {
     return mockClientContext.getRemoteDirectoryManager()
-        .getJobStagingArea(TestYarnServiceRunJobCliCommons.DEFAULT_JOB_NAME, true);
+        .getJobStagingArea(YarnServiceRunJobCliCommonsTest.DEFAULT_JOB_NAME, true);
   }
 
   private RunJobCli createRunJobCliWithoutVerboseAssertion() {

--- a/submarine-server/server-submitter/submitter-yarnservice/src/test/java/org/apache/submarine/client/cli/yarnservice/YarnServiceRunJobCliTest.java
+++ b/submarine-server/server-submitter/submitter-yarnservice/src/test/java/org/apache/submarine/client/cli/yarnservice/YarnServiceRunJobCliTest.java
@@ -65,12 +65,12 @@ import static org.junit.Assert.assertTrue;
 /**
  * Class to test YarnService with the Run job CLI action.
  */
-public class TestYarnServiceRunJobCli {
+public class YarnServiceRunJobCliTest {
   private static final Logger LOG =
-      LoggerFactory.getLogger(TestYarnServiceRunJobCli.class);
+      LoggerFactory.getLogger(YarnServiceRunJobCliTest.class);
 
-  private TestYarnServiceRunJobCliCommons testCommons =
-      new TestYarnServiceRunJobCliCommons();
+  private YarnServiceRunJobCliCommonsTest testCommons =
+      new YarnServiceRunJobCliCommonsTest();
 
   @Rule
   public TestName testName = new TestName();
@@ -123,10 +123,10 @@ public class TestYarnServiceRunJobCli {
     assertEquals(4, psComp.getResource().getCpus().intValue());
 
     Assert.assertEquals(
-        TestYarnServiceRunJobCliCommons.DEFAULT_WORKER_DOCKER_IMAGE,
+        YarnServiceRunJobCliCommonsTest.DEFAULT_WORKER_DOCKER_IMAGE,
         workerComp.getArtifact().getId());
     Assert.assertEquals(
-        TestYarnServiceRunJobCliCommons.DEFAULT_PS_DOCKER_IMAGE,
+        YarnServiceRunJobCliCommonsTest.DEFAULT_PS_DOCKER_IMAGE,
         psComp.getArtifact().getId());
 
     assertTrue(SubmarineLogs.isVerbose());
@@ -175,17 +175,17 @@ public class TestYarnServiceRunJobCli {
     String[] params = ParamBuilderForTest.create()
         .withFramework("tensorflow")
         .withJobName(testName.getMethodName())
-        .withDockerImage(TestYarnServiceRunJobCliCommons.DEFAULT_DOCKER_IMAGE)
-        .withInputPath(TestYarnServiceRunJobCliCommons.DEFAULT_INPUT_PATH)
-        .withCheckpointPath(TestYarnServiceRunJobCliCommons.DEFAULT_CHECKPOINT_PATH)
+        .withDockerImage(YarnServiceRunJobCliCommonsTest.DEFAULT_DOCKER_IMAGE)
+        .withInputPath(YarnServiceRunJobCliCommonsTest.DEFAULT_INPUT_PATH)
+        .withCheckpointPath(YarnServiceRunJobCliCommonsTest.DEFAULT_CHECKPOINT_PATH)
         .withNumberOfWorkers(3)
-        .withWorkerDockerImage(TestYarnServiceRunJobCliCommons.DEFAULT_WORKER_DOCKER_IMAGE)
-        .withWorkerLaunchCommand(TestYarnServiceRunJobCliCommons.DEFAULT_WORKER_LAUNCH_CMD)
-        .withWorkerResources(TestYarnServiceRunJobCliCommons.DEFAULT_WORKER_RESOURCES)
+        .withWorkerDockerImage(YarnServiceRunJobCliCommonsTest.DEFAULT_WORKER_DOCKER_IMAGE)
+        .withWorkerLaunchCommand(YarnServiceRunJobCliCommonsTest.DEFAULT_WORKER_LAUNCH_CMD)
+        .withWorkerResources(YarnServiceRunJobCliCommonsTest.DEFAULT_WORKER_RESOURCES)
         .withNumberOfPs(2)
-        .withPsDockerImage(TestYarnServiceRunJobCliCommons.DEFAULT_PS_DOCKER_IMAGE)
-        .withPsLaunchCommand(TestYarnServiceRunJobCliCommons.DEFAULT_PS_LAUNCH_CMD)
-        .withPsResources(TestYarnServiceRunJobCliCommons.DEFAULT_PS_RESOURCES)
+        .withPsDockerImage(YarnServiceRunJobCliCommonsTest.DEFAULT_PS_DOCKER_IMAGE)
+        .withPsLaunchCommand(YarnServiceRunJobCliCommonsTest.DEFAULT_PS_LAUNCH_CMD)
+        .withPsResources(YarnServiceRunJobCliCommonsTest.DEFAULT_PS_RESOURCES)
         .withVerbose()
         .build();
     runJobCli.run(params);
@@ -211,17 +211,17 @@ public class TestYarnServiceRunJobCli {
     String[] params = ParamBuilderForTest.create()
         .withFramework("tensorflow")
         .withJobName(jobName)
-        .withDockerImage(TestYarnServiceRunJobCliCommons.DEFAULT_DOCKER_IMAGE)
-        .withInputPath(TestYarnServiceRunJobCliCommons.DEFAULT_INPUT_PATH)
-        .withCheckpointPath(TestYarnServiceRunJobCliCommons.DEFAULT_CHECKPOINT_PATH)
+        .withDockerImage(YarnServiceRunJobCliCommonsTest.DEFAULT_DOCKER_IMAGE)
+        .withInputPath(YarnServiceRunJobCliCommonsTest.DEFAULT_INPUT_PATH)
+        .withCheckpointPath(YarnServiceRunJobCliCommonsTest.DEFAULT_CHECKPOINT_PATH)
         .withNumberOfWorkers(3)
-        .withWorkerDockerImage(TestYarnServiceRunJobCliCommons.DEFAULT_WORKER_DOCKER_IMAGE)
-        .withWorkerLaunchCommand(TestYarnServiceRunJobCliCommons.DEFAULT_WORKER_LAUNCH_CMD)
-        .withWorkerResources(TestYarnServiceRunJobCliCommons.DEFAULT_WORKER_RESOURCES)
+        .withWorkerDockerImage(YarnServiceRunJobCliCommonsTest.DEFAULT_WORKER_DOCKER_IMAGE)
+        .withWorkerLaunchCommand(YarnServiceRunJobCliCommonsTest.DEFAULT_WORKER_LAUNCH_CMD)
+        .withWorkerResources(YarnServiceRunJobCliCommonsTest.DEFAULT_WORKER_RESOURCES)
         .withNumberOfPs(2)
-        .withPsDockerImage(TestYarnServiceRunJobCliCommons.DEFAULT_PS_DOCKER_IMAGE)
-        .withPsLaunchCommand(TestYarnServiceRunJobCliCommons.DEFAULT_PS_LAUNCH_CMD)
-        .withPsResources(TestYarnServiceRunJobCliCommons.DEFAULT_PS_RESOURCES)
+        .withPsDockerImage(YarnServiceRunJobCliCommonsTest.DEFAULT_PS_DOCKER_IMAGE)
+        .withPsLaunchCommand(YarnServiceRunJobCliCommonsTest.DEFAULT_PS_LAUNCH_CMD)
+        .withPsResources(YarnServiceRunJobCliCommonsTest.DEFAULT_PS_RESOURCES)
         .withVerbose()
         .withTensorboard()
         .build();
@@ -253,12 +253,12 @@ public class TestYarnServiceRunJobCli {
     String[] params = ParamBuilderForTest.create()
         .withFramework("tensorflow")
         .withJobName(testName.getMethodName())
-        .withDockerImage(TestYarnServiceRunJobCliCommons.DEFAULT_DOCKER_IMAGE)
-        .withInputPath(TestYarnServiceRunJobCliCommons.DEFAULT_INPUT_PATH)
-        .withCheckpointPath(TestYarnServiceRunJobCliCommons.DEFAULT_CHECKPOINT_PATH)
+        .withDockerImage(YarnServiceRunJobCliCommonsTest.DEFAULT_DOCKER_IMAGE)
+        .withInputPath(YarnServiceRunJobCliCommonsTest.DEFAULT_INPUT_PATH)
+        .withCheckpointPath(YarnServiceRunJobCliCommonsTest.DEFAULT_CHECKPOINT_PATH)
         .withNumberOfWorkers(1)
-        .withWorkerLaunchCommand(TestYarnServiceRunJobCliCommons.DEFAULT_WORKER_LAUNCH_CMD)
-        .withWorkerResources(TestYarnServiceRunJobCliCommons.DEFAULT_WORKER_RESOURCES)
+        .withWorkerLaunchCommand(YarnServiceRunJobCliCommonsTest.DEFAULT_WORKER_LAUNCH_CMD)
+        .withWorkerResources(YarnServiceRunJobCliCommonsTest.DEFAULT_WORKER_RESOURCES)
         .withVerbose()
         .build();
     runJobCli.run(params);
@@ -281,9 +281,9 @@ public class TestYarnServiceRunJobCli {
     String[] params = ParamBuilderForTest.create()
         .withFramework("tensorflow")
         .withJobName(testName.getMethodName())
-        .withDockerImage(TestYarnServiceRunJobCliCommons.DEFAULT_DOCKER_IMAGE)
-        .withInputPath(TestYarnServiceRunJobCliCommons.DEFAULT_INPUT_PATH)
-        .withCheckpointPath(TestYarnServiceRunJobCliCommons.DEFAULT_CHECKPOINT_PATH)
+        .withDockerImage(YarnServiceRunJobCliCommonsTest.DEFAULT_DOCKER_IMAGE)
+        .withInputPath(YarnServiceRunJobCliCommonsTest.DEFAULT_INPUT_PATH)
+        .withCheckpointPath(YarnServiceRunJobCliCommonsTest.DEFAULT_CHECKPOINT_PATH)
         .withNumberOfWorkers(0)
         .withTensorboard()
         .withVerbose()
@@ -313,13 +313,13 @@ public class TestYarnServiceRunJobCli {
     String[] params = ParamBuilderForTest.create()
         .withFramework("tensorflow")
         .withJobName(testName.getMethodName())
-        .withDockerImage(TestYarnServiceRunJobCliCommons.DEFAULT_DOCKER_IMAGE)
-        .withInputPath(TestYarnServiceRunJobCliCommons.DEFAULT_INPUT_PATH)
-        .withCheckpointPath(TestYarnServiceRunJobCliCommons.DEFAULT_CHECKPOINT_PATH)
+        .withDockerImage(YarnServiceRunJobCliCommonsTest.DEFAULT_DOCKER_IMAGE)
+        .withInputPath(YarnServiceRunJobCliCommonsTest.DEFAULT_INPUT_PATH)
+        .withCheckpointPath(YarnServiceRunJobCliCommonsTest.DEFAULT_CHECKPOINT_PATH)
         .withNumberOfWorkers(0)
         .withTensorboard()
-        .withTensorboardResources(TestYarnServiceRunJobCliCommons.DEFAULT_TENSORBOARD_RESOURCES)
-        .withTensorboardDockerImage(TestYarnServiceRunJobCliCommons.DEFAULT_TENSORBOARD_DOCKER_IMAGE)
+        .withTensorboardResources(YarnServiceRunJobCliCommonsTest.DEFAULT_TENSORBOARD_RESOURCES)
+        .withTensorboardDockerImage(YarnServiceRunJobCliCommonsTest.DEFAULT_TENSORBOARD_DOCKER_IMAGE)
         .withVerbose()
         .build();
     runJobCli.run(params);
@@ -347,11 +347,11 @@ public class TestYarnServiceRunJobCli {
     String[] params = ParamBuilderForTest.create()
         .withFramework("tensorflow")
         .withJobName(jobName)
-        .withDockerImage(TestYarnServiceRunJobCliCommons.DEFAULT_DOCKER_IMAGE)
+        .withDockerImage(YarnServiceRunJobCliCommonsTest.DEFAULT_DOCKER_IMAGE)
         .withNumberOfWorkers(0)
         .withTensorboard()
-        .withTensorboardResources(TestYarnServiceRunJobCliCommons.DEFAULT_TENSORBOARD_RESOURCES)
-        .withTensorboardDockerImage(TestYarnServiceRunJobCliCommons.DEFAULT_TENSORBOARD_DOCKER_IMAGE)
+        .withTensorboardResources(YarnServiceRunJobCliCommonsTest.DEFAULT_TENSORBOARD_RESOURCES)
+        .withTensorboardDockerImage(YarnServiceRunJobCliCommonsTest.DEFAULT_TENSORBOARD_DOCKER_IMAGE)
         .withVerbose()
         .build();
     runJobCli.run(params);
@@ -456,12 +456,12 @@ public class TestYarnServiceRunJobCli {
     String[] params = ParamBuilderForTest.create()
         .withFramework("tensorflow")
         .withJobName(testName.getMethodName())
-        .withDockerImage(TestYarnServiceRunJobCliCommons.DEFAULT_DOCKER_IMAGE)
-        .withInputPath(TestYarnServiceRunJobCliCommons.DEFAULT_INPUT_PATH)
-        .withCheckpointPath(TestYarnServiceRunJobCliCommons.DEFAULT_CHECKPOINT_PATH)
+        .withDockerImage(YarnServiceRunJobCliCommonsTest.DEFAULT_DOCKER_IMAGE)
+        .withInputPath(YarnServiceRunJobCliCommonsTest.DEFAULT_INPUT_PATH)
+        .withCheckpointPath(YarnServiceRunJobCliCommonsTest.DEFAULT_CHECKPOINT_PATH)
         .withNumberOfWorkers(1)
-        .withWorkerLaunchCommand(TestYarnServiceRunJobCliCommons.DEFAULT_WORKER_LAUNCH_CMD)
-        .withWorkerResources(TestYarnServiceRunJobCliCommons.DEFAULT_WORKER_RESOURCES)
+        .withWorkerLaunchCommand(YarnServiceRunJobCliCommonsTest.DEFAULT_WORKER_LAUNCH_CMD)
+        .withWorkerResources(YarnServiceRunJobCliCommonsTest.DEFAULT_WORKER_RESOURCES)
         .withTensorboard()
         .withVerbose()
         .build();
@@ -489,11 +489,11 @@ public class TestYarnServiceRunJobCli {
     String[] params = ParamBuilderForTest.create()
         .withFramework("tensorflow")
         .withJobName(testName.getMethodName())
-        .withDockerImage(TestYarnServiceRunJobCliCommons.DEFAULT_DOCKER_IMAGE)
-        .withInputPath(TestYarnServiceRunJobCliCommons.DEFAULT_INPUT_PATH)
+        .withDockerImage(YarnServiceRunJobCliCommonsTest.DEFAULT_DOCKER_IMAGE)
+        .withInputPath(YarnServiceRunJobCliCommonsTest.DEFAULT_INPUT_PATH)
         .withNumberOfWorkers(1)
-        .withWorkerLaunchCommand(TestYarnServiceRunJobCliCommons.DEFAULT_WORKER_LAUNCH_CMD)
-        .withWorkerResources(TestYarnServiceRunJobCliCommons.DEFAULT_WORKER_RESOURCES)
+        .withWorkerLaunchCommand(YarnServiceRunJobCliCommonsTest.DEFAULT_WORKER_LAUNCH_CMD)
+        .withWorkerResources(YarnServiceRunJobCliCommonsTest.DEFAULT_WORKER_RESOURCES)
         .withTensorboard()
         .withVerbose()
         .build();
@@ -521,12 +521,12 @@ public class TestYarnServiceRunJobCli {
     String[] params = ParamBuilderForTest.create()
         .withFramework("tensorflow")
         .withJobName(jobName)
-        .withDockerImage(TestYarnServiceRunJobCliCommons.DEFAULT_DOCKER_IMAGE)
-        .withInputPath(TestYarnServiceRunJobCliCommons.DEFAULT_INPUT_PATH)
-        .withCheckpointPath(TestYarnServiceRunJobCliCommons.DEFAULT_CHECKPOINT_PATH)
+        .withDockerImage(YarnServiceRunJobCliCommonsTest.DEFAULT_DOCKER_IMAGE)
+        .withInputPath(YarnServiceRunJobCliCommonsTest.DEFAULT_INPUT_PATH)
+        .withCheckpointPath(YarnServiceRunJobCliCommonsTest.DEFAULT_CHECKPOINT_PATH)
         .withNumberOfWorkers(1)
-        .withWorkerLaunchCommand(TestYarnServiceRunJobCliCommons.DEFAULT_WORKER_LAUNCH_CMD)
-        .withWorkerResources(TestYarnServiceRunJobCliCommons.DEFAULT_WORKER_RESOURCES)
+        .withWorkerLaunchCommand(YarnServiceRunJobCliCommonsTest.DEFAULT_WORKER_LAUNCH_CMD)
+        .withWorkerResources(YarnServiceRunJobCliCommonsTest.DEFAULT_WORKER_RESOURCES)
         .withTensorboard()
         .withVerbose()
         .build();
@@ -540,7 +540,7 @@ public class TestYarnServiceRunJobCli {
     Map<String, String> jobInfo = storage.getJobInfoByName(jobName);
     assertTrue(jobInfo.size() > 0);
     Assert.assertEquals(jobInfo.get(StorageKeyConstants.INPUT_PATH),
-        TestYarnServiceRunJobCliCommons.DEFAULT_INPUT_PATH);
+        YarnServiceRunJobCliCommonsTest.DEFAULT_INPUT_PATH);
   }
 
   @Test
@@ -554,17 +554,17 @@ public class TestYarnServiceRunJobCli {
     String[] params = ParamBuilderForTest.create()
         .withFramework("tensorflow")
         .withJobName(jobName)
-        .withDockerImage(TestYarnServiceRunJobCliCommons.DEFAULT_DOCKER_IMAGE)
-        .withInputPath(TestYarnServiceRunJobCliCommons.DEFAULT_INPUT_PATH)
-        .withCheckpointPath(TestYarnServiceRunJobCliCommons.DEFAULT_CHECKPOINT_PATH)
+        .withDockerImage(YarnServiceRunJobCliCommonsTest.DEFAULT_DOCKER_IMAGE)
+        .withInputPath(YarnServiceRunJobCliCommonsTest.DEFAULT_INPUT_PATH)
+        .withCheckpointPath(YarnServiceRunJobCliCommonsTest.DEFAULT_CHECKPOINT_PATH)
         .withNumberOfWorkers(3)
-        .withWorkerDockerImage(TestYarnServiceRunJobCliCommons.DEFAULT_WORKER_DOCKER_IMAGE)
-        .withWorkerLaunchCommand(TestYarnServiceRunJobCliCommons.DEFAULT_WORKER_LAUNCH_CMD)
-        .withWorkerResources(TestYarnServiceRunJobCliCommons.DEFAULT_WORKER_RESOURCES)
+        .withWorkerDockerImage(YarnServiceRunJobCliCommonsTest.DEFAULT_WORKER_DOCKER_IMAGE)
+        .withWorkerLaunchCommand(YarnServiceRunJobCliCommonsTest.DEFAULT_WORKER_LAUNCH_CMD)
+        .withWorkerResources(YarnServiceRunJobCliCommonsTest.DEFAULT_WORKER_RESOURCES)
         .withNumberOfPs(2)
-        .withPsDockerImage(TestYarnServiceRunJobCliCommons.DEFAULT_PS_DOCKER_IMAGE)
-        .withPsLaunchCommand(TestYarnServiceRunJobCliCommons.DEFAULT_PS_LAUNCH_CMD)
-        .withPsResources(TestYarnServiceRunJobCliCommons.DEFAULT_PS_RESOURCES)
+        .withPsDockerImage(YarnServiceRunJobCliCommonsTest.DEFAULT_PS_DOCKER_IMAGE)
+        .withPsLaunchCommand(YarnServiceRunJobCliCommonsTest.DEFAULT_PS_LAUNCH_CMD)
+        .withPsResources(YarnServiceRunJobCliCommonsTest.DEFAULT_PS_RESOURCES)
         .withQuickLink("AAA=http://master-0:8321")
         .withQuickLink("BBB=http://worker-0:1234")
         .withVerbose()
@@ -594,17 +594,17 @@ public class TestYarnServiceRunJobCli {
     String[] params = ParamBuilderForTest.create()
         .withFramework("tensorflow")
         .withJobName(jobName)
-        .withDockerImage(TestYarnServiceRunJobCliCommons.DEFAULT_DOCKER_IMAGE)
-        .withInputPath(TestYarnServiceRunJobCliCommons.DEFAULT_INPUT_PATH)
-        .withCheckpointPath(TestYarnServiceRunJobCliCommons.DEFAULT_CHECKPOINT_PATH)
+        .withDockerImage(YarnServiceRunJobCliCommonsTest.DEFAULT_DOCKER_IMAGE)
+        .withInputPath(YarnServiceRunJobCliCommonsTest.DEFAULT_INPUT_PATH)
+        .withCheckpointPath(YarnServiceRunJobCliCommonsTest.DEFAULT_CHECKPOINT_PATH)
         .withNumberOfWorkers(3)
-        .withWorkerDockerImage(TestYarnServiceRunJobCliCommons.DEFAULT_WORKER_DOCKER_IMAGE)
-        .withWorkerLaunchCommand(TestYarnServiceRunJobCliCommons.DEFAULT_WORKER_LAUNCH_CMD)
-        .withWorkerResources(TestYarnServiceRunJobCliCommons.DEFAULT_WORKER_RESOURCES)
+        .withWorkerDockerImage(YarnServiceRunJobCliCommonsTest.DEFAULT_WORKER_DOCKER_IMAGE)
+        .withWorkerLaunchCommand(YarnServiceRunJobCliCommonsTest.DEFAULT_WORKER_LAUNCH_CMD)
+        .withWorkerResources(YarnServiceRunJobCliCommonsTest.DEFAULT_WORKER_RESOURCES)
         .withNumberOfPs(2)
-        .withPsDockerImage(TestYarnServiceRunJobCliCommons.DEFAULT_PS_DOCKER_IMAGE)
-        .withPsLaunchCommand(TestYarnServiceRunJobCliCommons.DEFAULT_PS_LAUNCH_CMD)
-        .withPsResources(TestYarnServiceRunJobCliCommons.DEFAULT_PS_RESOURCES)
+        .withPsDockerImage(YarnServiceRunJobCliCommonsTest.DEFAULT_PS_DOCKER_IMAGE)
+        .withPsLaunchCommand(YarnServiceRunJobCliCommonsTest.DEFAULT_PS_LAUNCH_CMD)
+        .withPsResources(YarnServiceRunJobCliCommonsTest.DEFAULT_PS_RESOURCES)
         .withQuickLink("AAA=http://master-0:8321")
         .withQuickLink("BBB=http://worker-0:1234")
         .withTensorboard()

--- a/submarine-server/server-submitter/submitter-yarnservice/src/test/java/org/apache/submarine/server/submitter/yarnservice/ServiceWrapperTest.java
+++ b/submarine-server/server-submitter/submitter-yarnservice/src/test/java/org/apache/submarine/server/submitter/yarnservice/ServiceWrapperTest.java
@@ -34,7 +34,7 @@ import static org.mockito.Mockito.when;
 /**
  * Class to test the {@link ServiceWrapper}.
  */
-public class TestServiceWrapper {
+public class ServiceWrapperTest {
   private AbstractComponent createMockAbstractComponent(Component mockComponent,
       String componentName, String localScriptFile) throws IOException {
     when(mockComponent.getName()).thenReturn(componentName);

--- a/submarine-server/server-submitter/submitter-yarnservice/src/test/java/org/apache/submarine/server/submitter/yarnservice/command/LaunchCommandFactoryTest.java
+++ b/submarine-server/server-submitter/submitter-yarnservice/src/test/java/org/apache/submarine/server/submitter/yarnservice/command/LaunchCommandFactoryTest.java
@@ -37,7 +37,7 @@ import static org.mockito.Mockito.mock;
 /**
  * This class is to test the {@link TensorFlowLaunchCommandFactory}.
  */
-public class TestLaunchCommandFactory {
+public class LaunchCommandFactoryTest {
 
   private TensorFlowLaunchCommandFactory createLaunchCommandFactory(
       TensorFlowRunJobParameters parameters) {

--- a/submarine-server/server-submitter/submitter-yarnservice/src/test/java/org/apache/submarine/server/submitter/yarnservice/pytorch/PyTorchServiceSpecTest.java
+++ b/submarine-server/server-submitter/submitter-yarnservice/src/test/java/org/apache/submarine/server/submitter/yarnservice/pytorch/PyTorchServiceSpecTest.java
@@ -41,7 +41,7 @@ import java.util.List;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
-public class TestPyTorchServiceSpec {
+public class PyTorchServiceSpecTest {
 
   private ComponentTestCommons testCommons =
       new ComponentTestCommons(PyTorchRole.PRIMARY_WORKER);

--- a/submarine-server/server-submitter/submitter-yarnservice/src/test/java/org/apache/submarine/server/submitter/yarnservice/tensorflow/command/TensorBoardLaunchCommandTest.java
+++ b/submarine-server/server-submitter/submitter-yarnservice/src/test/java/org/apache/submarine/server/submitter/yarnservice/tensorflow/command/TensorBoardLaunchCommandTest.java
@@ -35,7 +35,7 @@ import java.util.List;
 /**
  * This class is to test the {@link TensorBoardLaunchCommand}.
  */
-public class TestTensorBoardLaunchCommand extends
+public class TensorBoardLaunchCommandTest extends
     AbstractTFLaunchCommandTestHelper {
 
   @Test

--- a/submarine-server/server-submitter/submitter-yarnservice/src/test/java/org/apache/submarine/server/submitter/yarnservice/tensorflow/command/TensorFlowLaunchCommandTest.java
+++ b/submarine-server/server-submitter/submitter-yarnservice/src/test/java/org/apache/submarine/server/submitter/yarnservice/tensorflow/command/TensorFlowLaunchCommandTest.java
@@ -41,7 +41,7 @@ import java.util.List;
  * This class is to test the implementors of {@link TensorFlowLaunchCommand}.
  */
 @RunWith(Parameterized.class)
-public class TestTensorFlowLaunchCommand
+public class TensorFlowLaunchCommandTest
     extends AbstractTFLaunchCommandTestHelper {
   private TensorFlowRole taskType;
 
@@ -53,7 +53,7 @@ public class TestTensorFlowLaunchCommand
     return params;
   }
 
-  public TestTensorFlowLaunchCommand(TensorFlowRole taskType) {
+  public TensorFlowLaunchCommandTest(TensorFlowRole taskType) {
     this.taskType = taskType;
   }
 

--- a/submarine-server/server-submitter/submitter-yarnservice/src/test/java/org/apache/submarine/server/submitter/yarnservice/tensorflow/component/TensorBoardComponentTest.java
+++ b/submarine-server/server-submitter/submitter-yarnservice/src/test/java/org/apache/submarine/server/submitter/yarnservice/tensorflow/component/TensorBoardComponentTest.java
@@ -42,7 +42,7 @@ import static org.mockito.Mockito.verify;
 /**
  * This class is to test {@link TensorBoardComponent}.
  */
-public class TestTensorBoardComponent {
+public class TensorBoardComponentTest {
 
   @Rule
   public ExpectedException expectedException = ExpectedException.none();

--- a/submarine-server/server-submitter/submitter-yarnservice/src/test/java/org/apache/submarine/server/submitter/yarnservice/tensorflow/component/TensorFlowPsComponentTest.java
+++ b/submarine-server/server-submitter/submitter-yarnservice/src/test/java/org/apache/submarine/server/submitter/yarnservice/tensorflow/component/TensorFlowPsComponentTest.java
@@ -42,7 +42,7 @@ import org.junit.rules.ExpectedException;
 /**
  * This class is to test {@link TensorFlowPsComponent}.
  */
-public class TestTensorFlowPsComponent {
+public class TensorFlowPsComponentTest {
 
   @Rule
   public ExpectedException expectedException = ExpectedException.none();

--- a/submarine-server/server-submitter/submitter-yarnservice/src/test/java/org/apache/submarine/server/submitter/yarnservice/tensorflow/component/TensorFlowWorkerComponentTest.java
+++ b/submarine-server/server-submitter/submitter-yarnservice/src/test/java/org/apache/submarine/server/submitter/yarnservice/tensorflow/component/TensorFlowWorkerComponentTest.java
@@ -45,7 +45,7 @@ import static org.mockito.Mockito.verify;
 /**
  * This class is to test {@link TensorFlowWorkerComponent}.
  */
-public class TestTensorFlowWorkerComponent {
+public class TensorFlowWorkerComponentTest {
 
   @Rule
   public ExpectedException expectedException = ExpectedException.none();

--- a/submarine-server/server-submitter/submitter-yarnservice/src/test/java/org/apache/submarine/server/submitter/yarnservice/utils/ClassPathUtilitiesTest.java
+++ b/submarine-server/server-submitter/submitter-yarnservice/src/test/java/org/apache/submarine/server/submitter/yarnservice/utils/ClassPathUtilitiesTest.java
@@ -35,7 +35,7 @@ import static org.junit.Assert.assertNull;
 /**
  * This class is to test {@link ClassPathUtilities}.
  */
-public class TestClassPathUtilities {
+public class ClassPathUtilitiesTest {
 
   private static final String CLASSPATH_KEY = "java.class.path";
   private FileUtilitiesForTests fileUtils = new FileUtilitiesForTests();

--- a/submarine-server/server-submitter/submitter-yarnservice/src/test/java/org/apache/submarine/server/submitter/yarnservice/utils/EnvironmentUtilitiesTest.java
+++ b/submarine-server/server-submitter/submitter-yarnservice/src/test/java/org/apache/submarine/server/submitter/yarnservice/utils/EnvironmentUtilitiesTest.java
@@ -36,7 +36,7 @@ import static org.mockito.Mockito.when;
 /**
  * This class is to test {@link EnvironmentUtilities}.
  */
-public class TestEnvironmentUtilities {
+public class EnvironmentUtilitiesTest {
   private Service createServiceWithEmptyEnvVars() {
     return createServiceWithEnvVars(Maps.newHashMap());
   }

--- a/submarine-server/server-submitter/submitter-yarnservice/src/test/java/org/apache/submarine/server/submitter/yarnservice/utils/KerberosPrincipalFactoryTest.java
+++ b/submarine-server/server-submitter/submitter-yarnservice/src/test/java/org/apache/submarine/server/submitter/yarnservice/utils/KerberosPrincipalFactoryTest.java
@@ -41,7 +41,7 @@ import static org.mockito.Mockito.when;
 /**
  * This class is to test {@link KerberosPrincipalFactory}.
  */
-public class TestKerberosPrincipalFactory {
+public class KerberosPrincipalFactoryTest {
   private FileUtilitiesForTests fileUtils = new FileUtilitiesForTests();
 
   @Before

--- a/submarine-server/server-submitter/submitter-yarnservice/src/test/java/org/apache/submarine/server/submitter/yarnservice/utils/SubmarineResourceUtilsTest.java
+++ b/submarine-server/server-submitter/submitter-yarnservice/src/test/java/org/apache/submarine/server/submitter/yarnservice/utils/SubmarineResourceUtilsTest.java
@@ -40,7 +40,7 @@ import static org.junit.Assert.assertEquals;
 /**
  * This class is to test {@link SubmarineResourceUtils}.
  */
-public class TestSubmarineResourceUtils {
+public class SubmarineResourceUtilsTest {
   /**
    * With the dependencies of hadoop 3.2.0, Need to create a
    * CustomResourceTypesConfigurationProvider implementations. If the


### PR DESCRIPTION
### What is this PR for?
Renaming test classes in submitter-yarnservice submodule to conform code style.

### What type of PR is it?
Refactoring

### Todos
* [ ] - The unit tests should pass as before the patch.

### What is the Jira issue?
* [SUBMARINE-305](SUBMARINE-305)

### How should this be tested?
* No further testing is needed besides Travis.

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
