### PR TITLE
SUBMARINE-324. Submarine cluster status RESTful

### DIFF
--- a/submarine-commons/commons-cluster/src/main/java/org/apache/submarine/commons/cluster/ClusterManager.java
+++ b/submarine-commons/commons-cluster/src/main/java/org/apache/submarine/commons/cluster/ClusterManager.java
@@ -216,7 +216,7 @@ public abstract class ClusterManager {
         try {
           raftClientPort = NetworkUtils.findRandomAvailablePortOnAllLocalInterfaces();
         } catch (IOException e) {
-          LOG.error(e.getMessage());
+          LOG.error(e.getMessage(), e);
         }
 
         MemberId memberId = MemberId.from(serverHost + ":" + raftClientPort);
@@ -283,7 +283,7 @@ public abstract class ClusterManager {
             }
           }
         } catch (InterruptedException e) {
-          LOG.error(e.getMessage());
+          LOG.error(e.getMessage(), e);
         }
       }
     }).start();
@@ -416,7 +416,7 @@ public abstract class ClusterManager {
       mateData = raftSessionClient.execute(operation(ClusterStateMachine.GET,
           clientSerializer.encode(entity))).get(3, TimeUnit.SECONDS);
     } catch (InterruptedException | ExecutionException | TimeoutException e) {
-      LOG.error(e.getMessage());
+      LOG.error(e.getMessage(), e);
     }
 
     if (null != mateData) {

--- a/submarine-commons/commons-cluster/src/main/java/org/apache/submarine/commons/cluster/ClusterMonitor.java
+++ b/submarine-commons/commons-cluster/src/main/java/org/apache/submarine/commons/cluster/ClusterMonitor.java
@@ -184,6 +184,8 @@ public class ClusterMonitor {
   // indicating that the process is still active.
   private void sendHeartbeat() {
     HashMap<String, Object> mapMonitorUtil = new HashMap<>();
+    mapMonitorUtil.put(ClusterMeta.NODE_NAME, clusterManager.getClusterNodeName());
+    mapMonitorUtil.put(ClusterMeta.INTP_PROCESS_NAME, metaKey);
     mapMonitorUtil.put(ClusterMeta.LATEST_HEARTBEAT, LocalDateTime.now());
     mapMonitorUtil.put(ClusterMeta.STATUS, ClusterMeta.ONLINE_STATUS);
 

--- a/submarine-commons/commons-cluster/src/main/java/org/apache/submarine/commons/cluster/meta/ClusterMeta.java
+++ b/submarine-commons/commons-cluster/src/main/java/org/apache/submarine/commons/cluster/meta/ClusterMeta.java
@@ -57,6 +57,9 @@ public class ClusterMeta implements Serializable {
   public static String ONLINE_STATUS        = "ONLINE";
   public static String OFFLINE_STATUS       = "OFFLINE";
 
+  public static String INTP_PROCESS_COUNT   = "INTP_PROCESS_COUNT";
+  public static String INTP_PROCESS_LIST    = "INTP_PROCESS_LIST";
+
   // cluster_name = host:port
   // Map:cluster_name -> {server_tserver_host,server_tserver_port,cpu_capacity,...}
   private Map<String, Map<String, Object>> mapServerMeta = new HashMap<>();

--- a/submarine-commons/commons-cluster/src/main/java/org/apache/submarine/commons/cluster/meta/ClusterMeta.java
+++ b/submarine-commons/commons-cluster/src/main/java/org/apache/submarine/commons/cluster/meta/ClusterMeta.java
@@ -60,6 +60,8 @@ public class ClusterMeta implements Serializable {
   public static String INTP_PROCESS_COUNT   = "INTP_PROCESS_COUNT";
   public static String INTP_PROCESS_LIST    = "INTP_PROCESS_LIST";
 
+  public static String PROPERTIES = "properties";
+
   // cluster_name = host:port
   // Map:cluster_name -> {server_tserver_host,server_tserver_port,cpu_capacity,...}
   private Map<String, Map<String, Object>> mapServerMeta = new HashMap<>();

--- a/submarine-server/server-core/src/main/java/org/apache/submarine/server/SubmarineServer.java
+++ b/submarine-server/server-core/src/main/java/org/apache/submarine/server/SubmarineServer.java
@@ -113,8 +113,8 @@ public class SubmarineServer extends ResourceConfig {
   @Inject
   public SubmarineServer() {
     packages("org.apache.submarine.server.workbench.rest",
-             "org.apache.submarine.server.jobserver.rest.api",
-             "org.apache.submarine.server.metastore.rest"
+             "org.apache.submarine.server.jobserver.rest",
+             "org.apache.submarine.server.rest"
     );
   }
 

--- a/submarine-server/server-core/src/main/java/org/apache/submarine/server/jobserver/dao/Component.java
+++ b/submarine-server/server-core/src/main/java/org/apache/submarine/server/jobserver/dao/Component.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.apache.submarine.server.jobserver.rest.dao;
+package org.apache.submarine.server.jobserver.dao;
 
 
 /**

--- a/submarine-server/server-core/src/main/java/org/apache/submarine/server/jobserver/dao/EnvVaraible.java
+++ b/submarine-server/server-core/src/main/java/org/apache/submarine/server/jobserver/dao/EnvVaraible.java
@@ -17,13 +17,37 @@
  * under the License.
  */
 
-package org.apache.submarine.server.jobserver.rest.dao;
+package org.apache.submarine.server.jobserver.dao;
 
-public class RestConstants {
-  public static final String V1 = "v1";
-  public static final String JOBS = "jobs";
-  public static final String JOB_ID = "id";
-  public static final String PING = "ping";
-  public static final String MEDIA_TYPE_YAML = "application/yaml";
-  public static final String CHARSET_UTF8 = "charset=utf-8";
+// A process level environment variable.
+public class EnvVaraible {
+
+  public String getKey() {
+    return key;
+  }
+
+  public void setKey(String key) {
+    this.key = key;
+  }
+
+  public String getValue() {
+    return value;
+  }
+
+  public void setValue(String value) {
+    this.value = value;
+  }
+
+  String key;
+  String value;
+
+  public EnvVaraible() {}
+
+  public EnvVaraible(String k, String v) {
+    this.key = k;
+    this.value = v;
+  }
+
+
+
 }

--- a/submarine-server/server-core/src/main/java/org/apache/submarine/server/jobserver/dao/MLJobSpec.java
+++ b/submarine-server/server-core/src/main/java/org/apache/submarine/server/jobserver/dao/MLJobSpec.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.apache.submarine.server.jobserver.rest.dao;
+package org.apache.submarine.server.jobserver.dao;
 
 /**
  * The machine learning job spec the submarine job server can accept.

--- a/submarine-server/server-core/src/main/java/org/apache/submarine/server/jobserver/provider/YamlEntityProvider.java
+++ b/submarine-server/server-core/src/main/java/org/apache/submarine/server/jobserver/provider/YamlEntityProvider.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.apache.submarine.server.jobserver.rest.provider;
+package org.apache.submarine.server.jobserver.provider;
 
 import org.yaml.snakeyaml.Yaml;
 

--- a/submarine-server/server-core/src/main/java/org/apache/submarine/server/jobserver/rest/JobServerRestApi.java
+++ b/submarine-server/server-core/src/main/java/org/apache/submarine/server/jobserver/rest/JobServerRestApi.java
@@ -16,10 +16,10 @@
  * limitations under the License.
  */
 
-package org.apache.submarine.server.jobserver.rest.api;
+package org.apache.submarine.server.jobserver.rest;
 
-import org.apache.submarine.server.jobserver.rest.dao.MLJobSpec;
-import org.apache.submarine.server.jobserver.rest.dao.RestConstants;
+import org.apache.submarine.server.rest.RestConstants;
+import org.apache.submarine.server.jobserver.dao.MLJobSpec;
 import org.apache.submarine.server.response.JsonResponse;
 
 import javax.ws.rs.Consumes;
@@ -48,7 +48,7 @@ import javax.ws.rs.core.Response;
  * */
 @Path(RestConstants.V1 + "/" + RestConstants.JOBS)
 @Produces({MediaType.APPLICATION_JSON + "; " + RestConstants.CHARSET_UTF8})
-public class JobApi {
+public class JobServerRestApi {
 
   // A ping test to verify the job server is up.
   @Path(RestConstants.PING)

--- a/submarine-server/server-core/src/main/java/org/apache/submarine/server/rest/ClusterRestApi.java
+++ b/submarine-server/server-core/src/main/java/org/apache/submarine/server/rest/ClusterRestApi.java
@@ -1,0 +1,236 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.submarine.server.rest;
+
+import com.google.gson.Gson;
+import org.apache.submarine.commons.cluster.ClusterServer;
+import org.apache.submarine.commons.cluster.meta.ClusterMeta;
+import org.apache.submarine.commons.cluster.meta.ClusterMetaType;
+import org.apache.submarine.commons.utils.SubmarineConfiguration;
+import org.apache.submarine.server.response.JsonResponse;
+import org.apache.submarine.server.workbench.annotation.SubmarineApi;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Response;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * clusters Rest api.
+ */
+@Path(RestConstants.V1 + "/" + RestConstants.CLUSTER)
+@Produces("application/json")
+public class ClusterRestApi {
+  private static final Logger LOG = LoggerFactory.getLogger(ClusterRestApi.class);
+  Gson gson = new Gson();
+
+  private ClusterServer clusterServer = ClusterServer.getInstance();
+
+  // Do not modify, Use by `zeppelin-web/src/app/cluster/cluster.html`
+  public static String PROPERTIES = "properties";
+
+  @GET
+  @Path("/" + RestConstants.ADDRESS)
+  @SubmarineApi
+  public Response getClusterAddress() {
+    SubmarineConfiguration sConf = SubmarineConfiguration.getInstance();
+    String clusterAddr = sConf.getClusterAddress();
+    String[] arrAddr = clusterAddr.split(",");
+    List<String> listAddr = Arrays.asList(arrAddr);
+
+    return new JsonResponse.Builder<List<String>>(Response.Status.OK)
+        .success(true).result(listAddr).build();
+  }
+
+  /**
+   * get all nodes of clusters
+   */
+  @GET
+  @Path("/" + RestConstants.NODES)
+  @SubmarineApi
+  public Response getClusterNodes(){
+    ArrayList<HashMap<String, Object>> nodes = new ArrayList<>();
+
+    Map<String, HashMap<String, Object>> clusterMeta = null;
+    Map<String, HashMap<String, Object>> intpMeta = null;
+    clusterMeta = clusterServer.getClusterMeta(ClusterMetaType.SERVER_META, "");
+    intpMeta = clusterServer.getClusterMeta(ClusterMetaType.INTP_PROCESS_META, "");
+
+    // Number of calculation processes
+    for (Map.Entry<String, HashMap<String, Object>> serverMetaEntity : clusterMeta.entrySet()) {
+      if (!serverMetaEntity.getValue().containsKey(ClusterMeta.NODE_NAME)) {
+        continue;
+      }
+      String serverNodeName = (String) serverMetaEntity.getValue().get(ClusterMeta.NODE_NAME);
+
+      ArrayList<String> arrIntpProcess = new ArrayList<>();
+      int intpProcCount = 0;
+      for (Map.Entry<String, HashMap<String, Object>> intpMetaEntity : intpMeta.entrySet()) {
+        if (!intpMetaEntity.getValue().containsKey(ClusterMeta.NODE_NAME)
+            && !intpMetaEntity.getValue().containsKey(ClusterMeta.INTP_PROCESS_NAME)) {
+          continue;
+        }
+        String intpNodeName = (String) intpMetaEntity.getValue().get(ClusterMeta.NODE_NAME);
+
+        if (serverNodeName.equals(intpNodeName)) {
+          intpProcCount++;
+          String intpName = (String) intpMetaEntity.getValue().get(ClusterMeta.INTP_PROCESS_NAME);
+          arrIntpProcess.add(intpName);
+        }
+      }
+      serverMetaEntity.getValue().put(ClusterMeta.INTP_PROCESS_COUNT, intpProcCount);
+      serverMetaEntity.getValue().put(ClusterMeta.INTP_PROCESS_LIST, arrIntpProcess);
+    }
+
+    for (Map.Entry<String, HashMap<String, Object>> entry : clusterMeta.entrySet()) {
+      String nodeName = entry.getKey();
+      Map<String, Object> properties = entry.getValue();
+
+      Map<String, Object> sortProperties = new HashMap<>();
+
+      if (properties.containsKey(ClusterMeta.CPU_USED)
+          && properties.containsKey(ClusterMeta.CPU_CAPACITY)) {
+        float cpuUsed = (long) properties.get(ClusterMeta.CPU_USED) / (float) 100.0;
+        float cpuCapacity = (long) properties.get(ClusterMeta.CPU_CAPACITY) / (float) 100.0;
+        float cpuRate = cpuUsed / cpuCapacity * 100;
+
+        String cpuInfo = String.format("%.2f / %.2f = %.2f", cpuUsed, cpuCapacity, cpuRate);
+        sortProperties.put(ClusterMeta.CPU_USED + " / " + ClusterMeta.CPU_CAPACITY, cpuInfo + "%");
+      }
+
+      if (properties.containsKey(ClusterMeta.MEMORY_USED)
+          && properties.containsKey(ClusterMeta.MEMORY_CAPACITY)) {
+        float memoryUsed = (long) properties.get(ClusterMeta.MEMORY_USED) / (float) (1024 * 1024 * 1024);
+        float memoryCapacity
+            = (long) properties.get(ClusterMeta.MEMORY_CAPACITY) / (float) (1024 * 1024 * 1024);
+        float memoryRate = memoryUsed / memoryCapacity * 100;
+
+        String memoryInfo = String.format("%.2fGB / %.2fGB = %.2f",
+            memoryUsed, memoryCapacity, memoryRate);
+        sortProperties.put(ClusterMeta.MEMORY_USED + " / " + ClusterMeta.MEMORY_CAPACITY, memoryInfo + "%");
+      }
+
+      if (properties.containsKey(ClusterMeta.SERVER_START_TIME)) {
+        // format LocalDateTime
+        Object serverStartTime = properties.get(ClusterMeta.SERVER_START_TIME);
+        if (serverStartTime instanceof LocalDateTime) {
+          LocalDateTime localDateTime = (LocalDateTime) serverStartTime;
+          String dateTime = formatLocalDateTime(localDateTime);
+          sortProperties.put(ClusterMeta.SERVER_START_TIME, dateTime);
+        } else {
+          sortProperties.put(ClusterMeta.SERVER_START_TIME, "Wrong time type!");
+        }
+      }
+      if (properties.containsKey(ClusterMeta.STATUS)) {
+        sortProperties.put(ClusterMeta.STATUS, properties.get(ClusterMeta.STATUS));
+      }
+      if (properties.containsKey(ClusterMeta.LATEST_HEARTBEAT)) {
+        // format LocalDateTime
+        Object latestHeartbeat = properties.get(ClusterMeta.LATEST_HEARTBEAT);
+        if (latestHeartbeat instanceof LocalDateTime) {
+          LocalDateTime localDateTime = (LocalDateTime) latestHeartbeat;
+          String dateTime = formatLocalDateTime(localDateTime);
+          sortProperties.put(ClusterMeta.LATEST_HEARTBEAT, dateTime);
+        } else {
+          sortProperties.put(ClusterMeta.LATEST_HEARTBEAT, "Wrong time type!");
+        }
+      }
+      if (properties.containsKey(ClusterMeta.INTP_PROCESS_LIST)) {
+        sortProperties.put(ClusterMeta.INTP_PROCESS_LIST, properties.get(ClusterMeta.INTP_PROCESS_LIST));
+      }
+
+      HashMap<String, Object> node = new HashMap<>();
+      node.put(ClusterMeta.NODE_NAME, nodeName);
+      node.put(PROPERTIES, sortProperties);
+
+      nodes.add(node);
+    }
+
+    return new JsonResponse.Builder<ArrayList<HashMap<String, Object>>>(Response.Status.OK)
+        .success(true).result(nodes).build();
+  }
+
+  /**
+   * get node info by id
+   */
+  @GET
+  @Path("/" + RestConstants.NODE + "/{nodeName}/{intpName}")
+  @SubmarineApi
+  public Response getClusterNode(@PathParam("nodeName") String nodeName,
+                                 @PathParam("intpName") String intpName){
+    ArrayList<HashMap<String, Object>> intpProcesses = new ArrayList<>();
+
+    Map<String, HashMap<String, Object>> intpMeta = null;
+    intpMeta = clusterServer.getClusterMeta(ClusterMetaType.INTP_PROCESS_META, "");
+
+    // Number of calculation processes
+    for (Map.Entry<String, HashMap<String, Object>> intpMetaEntity : intpMeta.entrySet()) {
+      String intpNodeName = (String) intpMetaEntity.getValue().get(ClusterMeta.NODE_NAME);
+
+      if (null != intpNodeName && intpNodeName.equals(nodeName)) {
+        HashMap<String, Object> node = new HashMap<String, Object>();
+        node.put(ClusterMeta.NODE_NAME, intpNodeName);
+        node.put(PROPERTIES, intpMetaEntity.getValue());
+
+        // format LocalDateTime
+        HashMap<String, Object> properties = intpMetaEntity.getValue();
+        if (properties.containsKey(ClusterMeta.INTP_START_TIME)) {
+          Object intpStartTime = properties.get(ClusterMeta.INTP_START_TIME);
+          if (intpStartTime instanceof LocalDateTime) {
+            LocalDateTime localDateTime = (LocalDateTime) intpStartTime;
+            String dateTime = formatLocalDateTime(localDateTime);
+            properties.put(ClusterMeta.INTP_START_TIME, dateTime);
+          } else {
+            properties.put(ClusterMeta.INTP_START_TIME, "Wrong time type!");
+          }
+        }
+        if (properties.containsKey(ClusterMeta.LATEST_HEARTBEAT)) {
+          Object latestHeartbeat = properties.get(ClusterMeta.LATEST_HEARTBEAT);
+          if (latestHeartbeat instanceof LocalDateTime) {
+            LocalDateTime localDateTime = (LocalDateTime) latestHeartbeat;
+            String dateTime = formatLocalDateTime(localDateTime);
+            properties.put(ClusterMeta.LATEST_HEARTBEAT, dateTime);
+          } else {
+            properties.put(ClusterMeta.LATEST_HEARTBEAT, "Wrong time type!");
+          }
+        }
+
+        intpProcesses.add(node);
+      }
+    }
+
+    return new JsonResponse.Builder<ArrayList<HashMap<String, Object>>>(Response.Status.OK)
+        .success(true).result(intpProcesses).build();
+  }
+
+  private String formatLocalDateTime(LocalDateTime localDateTime) {
+    DateTimeFormatter dtf = DateTimeFormatter.ISO_DATE_TIME;
+    String strDate = localDateTime.format(dtf);
+    return strDate;
+  }
+}

--- a/submarine-server/server-core/src/main/java/org/apache/submarine/server/rest/ClusterRestApi.java
+++ b/submarine-server/server-core/src/main/java/org/apache/submarine/server/rest/ClusterRestApi.java
@@ -51,9 +51,6 @@ public class ClusterRestApi {
 
   private ClusterServer clusterServer = ClusterServer.getInstance();
 
-  // Do not modify, Use by `zeppelin-web/src/app/cluster/cluster.html`
-  public static String PROPERTIES = "properties";
-
   @GET
   @Path("/" + RestConstants.ADDRESS)
   @SubmarineApi
@@ -81,7 +78,7 @@ public class ClusterRestApi {
     clusterMeta = clusterServer.getClusterMeta(ClusterMetaType.SERVER_META, "");
     intpMeta = clusterServer.getClusterMeta(ClusterMetaType.INTP_PROCESS_META, "");
 
-    // Number of calculation processes
+    // Number of interpreter processes
     for (Map.Entry<String, HashMap<String, Object>> serverMetaEntity : clusterMeta.entrySet()) {
       if (!serverMetaEntity.getValue().containsKey(ClusterMeta.NODE_NAME)) {
         continue;
@@ -166,7 +163,7 @@ public class ClusterRestApi {
 
       HashMap<String, Object> node = new HashMap<>();
       node.put(ClusterMeta.NODE_NAME, nodeName);
-      node.put(PROPERTIES, sortProperties);
+      node.put(ClusterMeta.PROPERTIES, sortProperties);
 
       nodes.add(node);
     }
@@ -195,7 +192,7 @@ public class ClusterRestApi {
       if (null != intpNodeName && intpNodeName.equals(nodeName)) {
         HashMap<String, Object> node = new HashMap<String, Object>();
         node.put(ClusterMeta.NODE_NAME, intpNodeName);
-        node.put(PROPERTIES, intpMetaEntity.getValue());
+        node.put(ClusterMeta.PROPERTIES, intpMetaEntity.getValue());
 
         // format LocalDateTime
         HashMap<String, Object> properties = intpMetaEntity.getValue();

--- a/submarine-server/server-core/src/main/java/org/apache/submarine/server/rest/MetaStoreRestApi.java
+++ b/submarine-server/server-core/src/main/java/org/apache/submarine/server/rest/MetaStoreRestApi.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.submarine.server.metastore.rest;
+package org.apache.submarine.server.rest;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonSyntaxException;
@@ -44,17 +44,17 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Response;
 import java.util.List;
 
-@Path("/metaStore")
+@Path(RestConstants.V1 + "/" + RestConstants.METASTORE)
 @Produces("application/json")
 @Singleton
-public class MetaStoreApi {
-  private static final Logger LOG = LoggerFactory.getLogger(MetaStoreApi.class);
+public class MetaStoreRestApi {
+  private static final Logger LOG = LoggerFactory.getLogger(MetaStoreRestApi.class);
   private static final Gson gson = new Gson();
   private static final SubmarineConfiguration submarineConf = SubmarineConfiguration.getInstance();
   private SubmarineMetaStore submarineMetaStore = new SubmarineMetaStore(submarineConf);
 
   @Inject
-  public MetaStoreApi() {
+  public MetaStoreRestApi() {
   }
 
   @POST

--- a/submarine-server/server-core/src/main/java/org/apache/submarine/server/rest/RestConstants.java
+++ b/submarine-server/server-core/src/main/java/org/apache/submarine/server/rest/RestConstants.java
@@ -17,37 +17,21 @@
  * under the License.
  */
 
-package org.apache.submarine.server.jobserver.rest.dao;
+package org.apache.submarine.server.rest;
 
-// A process level environment variable.
-public class EnvVaraible {
+public class RestConstants {
+  public static final String V1 = "v1";
+  public static final String JOBS = "jobs";
+  public static final String JOB_ID = "id";
+  public static final String PING = "ping";
+  public static final String MEDIA_TYPE_YAML = "application/yaml";
+  public static final String CHARSET_UTF8 = "charset=utf-8";
 
-  public String getKey() {
-    return key;
-  }
+  public static final String METASTORE = "metastore";
 
-  public void setKey(String key) {
-    this.key = key;
-  }
+  public static final String CLUSTER = "cluster";
+  public static final String ADDRESS = "address";
 
-  public String getValue() {
-    return value;
-  }
-
-  public void setValue(String value) {
-    this.value = value;
-  }
-
-  String key;
-  String value;
-
-  public EnvVaraible() {}
-
-  public EnvVaraible(String k, String v) {
-    this.key = k;
-    this.value = v;
-  }
-
-
-
+  public static final String NODES = "nodes";
+  public static final String NODE = "node";
 }

--- a/submarine-server/server-core/src/test/java/org/apache/submarine/server/SubmarineServerClusterTest.java
+++ b/submarine-server/server-core/src/test/java/org/apache/submarine/server/SubmarineServerClusterTest.java
@@ -28,7 +28,6 @@ import org.apache.submarine.commons.cluster.meta.ClusterMetaType;
 import org.apache.submarine.commons.utils.NetworkUtils;
 import org.apache.submarine.commons.utils.SubmarineConfiguration;
 import org.apache.submarine.server.response.JsonResponse;
-import org.apache.submarine.server.rest.ClusterRestApi;
 import org.apache.submarine.server.rest.RestConstants;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -170,7 +169,7 @@ public class SubmarineServerClusterTest extends AbstractSubmarineServerTest {
     ArrayList<HashMap<String, Object>> listNodes = getClusterNodes();
 
     Map<String, Object> properties
-        = (LinkedTreeMap<String, Object>) listNodes.get(0).get(ClusterRestApi.PROPERTIES);
+        = (LinkedTreeMap<String, Object>) listNodes.get(0).get(ClusterMeta.PROPERTIES);
     ArrayList<String> intpList = (ArrayList<String>) properties.get(ClusterMeta.INTP_PROCESS_LIST);
     String nodeName = listNodes.get(0).get(ClusterMeta.NODE_NAME).toString();
     String intpName = intpList.get(0);

--- a/submarine-server/server-core/src/test/java/org/apache/submarine/server/SubmarineServerClusterTest.java
+++ b/submarine-server/server-core/src/test/java/org/apache/submarine/server/SubmarineServerClusterTest.java
@@ -18,18 +18,32 @@
  */
 package org.apache.submarine.server;
 
+import com.google.common.reflect.TypeToken;
+import com.google.gson.Gson;
+import com.google.gson.internal.LinkedTreeMap;
+import org.apache.commons.httpclient.methods.GetMethod;
 import org.apache.submarine.commons.cluster.ClusterClient;
+import org.apache.submarine.commons.cluster.meta.ClusterMeta;
 import org.apache.submarine.commons.cluster.meta.ClusterMetaType;
 import org.apache.submarine.commons.utils.NetworkUtils;
 import org.apache.submarine.commons.utils.SubmarineConfiguration;
+import org.apache.submarine.server.response.JsonResponse;
+import org.apache.submarine.server.rest.ClusterRestApi;
+import org.apache.submarine.server.rest.RestConstants;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.ws.rs.core.Response;
+import java.io.IOException;
 import java.lang.reflect.Constructor;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import static java.lang.Thread.sleep;
 import static org.junit.Assert.assertEquals;
@@ -60,7 +74,7 @@ public class SubmarineServerClusterTest extends AbstractSubmarineServerTest {
     constructor = clazz.getDeclaredConstructor();
     constructor.setAccessible(true);
     clusterClient = (ClusterClient) constructor.newInstance();
-    clusterClient.start("SubmarineServerClusterTest");
+    clusterClient.start(SubmarineServerClusterTest.class.getSimpleName());
 
     // Waiting for cluster startup
     int wait = 0;
@@ -75,8 +89,8 @@ public class SubmarineServerClusterTest extends AbstractSubmarineServerTest {
 
     assertTrue("Can not start Submarine server!", clusterClient.raftInitialized());
 
-    // Waiting for the workbench server to register in the cluster
-    sleep(5000);
+    // Waiting for the submarine server to register in the cluster and client send heartbeat to cluster
+    sleep(10000);
   }
 
   @AfterClass
@@ -103,5 +117,83 @@ public class SubmarineServerClusterTest extends AbstractSubmarineServerTest {
 
     assertEquals(hashMap.size(), 1);
     LOG.info("SubmarineServerClusterTest::testGetServerClusterMeta <<<");
+  }
+
+  @Test
+  public void testGetClusterAddress() throws IOException {
+    GetMethod response = httpGet("/api/" + RestConstants.V1 + "/"
+        + RestConstants.CLUSTER + "/" + RestConstants.ADDRESS);
+    LOG.info(response.toString());
+
+    String requestBody = response.getResponseBodyAsString();
+    LOG.info(requestBody);
+
+    Type type = new TypeToken<JsonResponse<List<String>>>() {}.getType();
+    Gson gson = new Gson();
+    JsonResponse<List<String>> jsonResponse = gson.fromJson(requestBody, type);
+    LOG.info(jsonResponse.getResult().toString());
+    assertEquals(jsonResponse.getCode(), Response.Status.OK.getStatusCode());
+
+    List<String> listAddr = jsonResponse.getResult();
+    LOG.info("listAddr.size = {}", listAddr.size());
+    assertEquals(listAddr.size(), 1);
+  }
+
+  private ArrayList<HashMap<String, Object>> getClusterNodes() throws IOException {
+    GetMethod response = httpGet("/api/" + RestConstants.V1 + "/"
+        + RestConstants.CLUSTER + "/" + RestConstants.NODES);
+    LOG.info(response.toString());
+
+    String requestBody = response.getResponseBodyAsString();
+    LOG.info(requestBody);
+
+    Type type = new TypeToken<JsonResponse<ArrayList<HashMap<String, Object>>>>() {}.getType();
+    Gson gson = new Gson();
+    JsonResponse<ArrayList<HashMap<String, Object>>> jsonResponse = gson.fromJson(requestBody, type);
+    LOG.info(jsonResponse.getResult().toString());
+    assertEquals(jsonResponse.getCode(), Response.Status.OK.getStatusCode());
+
+    ArrayList<HashMap<String, Object>> listNodes = jsonResponse.getResult();
+    LOG.info("listNodes.size = {}", listNodes.size());
+    assertEquals(listNodes.size(), 1);
+
+    return listNodes;
+  }
+
+  @Test
+  public void testGetClusterNodes() throws IOException {
+    getClusterNodes();
+  }
+
+  @Test
+  public void testGetClusterNode() throws IOException {
+    ArrayList<HashMap<String, Object>> listNodes = getClusterNodes();
+
+    Map<String, Object> properties
+        = (LinkedTreeMap<String, Object>) listNodes.get(0).get(ClusterRestApi.PROPERTIES);
+    ArrayList<String> intpList = (ArrayList<String>) properties.get(ClusterMeta.INTP_PROCESS_LIST);
+    String nodeName = listNodes.get(0).get(ClusterMeta.NODE_NAME).toString();
+    String intpName = intpList.get(0);
+    LOG.info("properties = {}", properties);
+    LOG.info("intpList = {}", intpList);
+    LOG.info("nodeName = {}", nodeName);
+    LOG.info("intpName = {}", intpName);
+
+    GetMethod response = httpGet("/api/" + RestConstants.V1 + "/"
+        + RestConstants.CLUSTER + "/" + RestConstants.NODE + "/" + nodeName + "/" + intpName);
+    LOG.info(response.toString());
+
+    String requestBody = response.getResponseBodyAsString();
+    LOG.info(requestBody);
+
+    Type type = new TypeToken<JsonResponse<ArrayList<HashMap<String, Object>>>>() {}.getType();
+    Gson gson = new Gson();
+    JsonResponse<ArrayList<HashMap<String, Object>>> jsonResponse = gson.fromJson(requestBody, type);
+    LOG.info(jsonResponse.getResult().toString());
+    assertEquals(jsonResponse.getCode(), Response.Status.OK.getStatusCode());
+
+    ArrayList<HashMap<String, Object>> intpProcesses = jsonResponse.getResult();
+    LOG.info("intpProcesses = {}", intpProcesses);
+    assertEquals(intpProcesses.size(), 1);
   }
 }

--- a/submarine-server/server-core/src/test/java/org/apache/submarine/server/jobserver/JobServerRestApiTest.java
+++ b/submarine-server/server-core/src/test/java/org/apache/submarine/server/jobserver/JobServerRestApiTest.java
@@ -17,14 +17,14 @@
  * under the License.
  */
 
-package org.apache.submarine.server.jobserver.rest.api;
+package org.apache.submarine.server.jobserver;
 
 import com.google.gson.Gson;
 import org.apache.commons.httpclient.methods.DeleteMethod;
 import org.apache.commons.httpclient.methods.GetMethod;
 import org.apache.commons.httpclient.methods.PostMethod;
 import org.apache.submarine.server.AbstractSubmarineServerTest;
-import org.apache.submarine.server.jobserver.rest.dao.RestConstants;
+import org.apache.submarine.server.rest.RestConstants;
 import org.apache.submarine.server.response.JsonResponse;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -37,12 +37,12 @@ import java.io.IOException;
 
 import static org.junit.Assert.assertEquals;
 
-public class JobApiTest extends AbstractSubmarineServerTest {
-  private static final Logger LOG = LoggerFactory.getLogger(JobApiTest.class);
+public class JobServerRestApiTest extends AbstractSubmarineServerTest {
+  private static final Logger LOG = LoggerFactory.getLogger(JobServerRestApiTest.class);
 
   @BeforeClass
   public static void init() throws Exception {
-    AbstractSubmarineServerTest.startUp(JobApiTest.class.getSimpleName());
+    AbstractSubmarineServerTest.startUp(JobServerRestApiTest.class.getSimpleName());
   }
 
   @AfterClass

--- a/submarine-server/server-core/src/test/java/org/apache/submarine/server/rest/MetaStoreApiTest.java
+++ b/submarine-server/server-core/src/test/java/org/apache/submarine/server/rest/MetaStoreApiTest.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.submarine.server.metastore.rest;
+package org.apache.submarine.server.rest;
 
 import com.google.gson.Gson;
 import org.apache.hadoop.hive.metastore.api.Database;
@@ -42,7 +42,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 public class MetaStoreApiTest {
-  private static MetaStoreApi metaStoreApi;
+  private static MetaStoreRestApi metaStoreApi;
 
   @BeforeClass
   public static void init() {
@@ -56,7 +56,7 @@ public class MetaStoreApiTest {
                                               "useSSL=false");
     submarineConf.setMetastoreJdbcUserName("metastore_test");
     submarineConf.setMetastoreJdbcPassword("password_test");
-    metaStoreApi = new MetaStoreApi();
+    metaStoreApi = new MetaStoreRestApi();
   }
 
   @Before

--- a/submarine-server/server-core/src/test/java/org/apache/submarine/server/rest/MetaStoreRestApiTest.java
+++ b/submarine-server/server-core/src/test/java/org/apache/submarine/server/rest/MetaStoreRestApiTest.java
@@ -41,7 +41,7 @@ import java.util.ArrayList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-public class MetaStoreApiTest {
+public class MetaStoreRestApiTest {
   private static MetaStoreRestApi metaStoreApi;
 
   @BeforeClass


### PR DESCRIPTION
### What is this PR for?
Now, the submarine server supports cluster function,
You can get the status of multiple submarine servers and interpreter processes.
Now provides a REST interface that provides external access to cluster status information.
Provides diagnostics of cluster status for submarine k8s operator.


### What type of PR is it?
Feature

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/SUBMARINE-324


### How should this be tested?
* [CI Pass](https://travis-ci.org/liuxunorg/submarine/builds/629923676)

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
