### PR TITLE
SUBMARINE-327. Fix unchecked call 'result<T>' when used JsonResponse.Builder build response

### DIFF
--- a/submarine-server/server-core/src/main/java/org/apache/submarine/server/jobserver/rest/JobServerRestApi.java
+++ b/submarine-server/server-core/src/main/java/org/apache/submarine/server/jobserver/rest/JobServerRestApi.java
@@ -71,7 +71,7 @@ public class JobServerRestApi {
   @Path("{" + RestConstants.JOB_ID + "}")
   public Response listJob(@PathParam(RestConstants.JOB_ID) String id) {
     // Query the job status though submitter
-    return new JsonResponse.Builder<JobSpec>(Response.Status.OK)
+    return new JsonResponse.Builder<String>(Response.Status.OK)
         .success(true).result(id).build();
   }
 
@@ -86,7 +86,7 @@ public class JobServerRestApi {
   @Path("{" + RestConstants.JOB_ID + "}")
   public Response deleteJob(@PathParam(RestConstants.JOB_ID) String id) {
     // Delete the job though submitter
-    return new JsonResponse.Builder<JobSpec>(Response.Status.OK)
+    return new JsonResponse.Builder<String>(Response.Status.OK)
         .success(true).result(id).build();
   }
 

--- a/submarine-server/server-core/src/main/java/org/apache/submarine/server/response/JsonResponse.java
+++ b/submarine-server/server-core/src/main/java/org/apache/submarine/server/response/JsonResponse.java
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 package org.apache.submarine.server.response;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -54,7 +55,7 @@ public class JsonResponse<T> {
 
   private static final String CGLIB_PROPERTY_PREFIX = "\\$cglib_prop_";
 
-  private JsonResponse(Builder builder) {
+  private JsonResponse(Builder<T> builder) {
     this.status = builder.status;
     this.code = builder.code;
     this.success = builder.success;
@@ -100,32 +101,32 @@ public class JsonResponse<T> {
       this.code = code;
     }
 
-    public Builder attribute(String key, Object value) {
+    public Builder<T> attribute(String key, Object value) {
       this.attributes.put(key, value);
       return this;
     }
 
-    public Builder success(Boolean success) {
+    public Builder<T> success(Boolean success) {
       this.success = success;
       return this;
     }
 
-    public Builder message(String message) {
+    public Builder<T> message(String message) {
       this.message = message;
       return this;
     }
 
-    public Builder result(T result) {
+    public Builder<T> result(T result) {
       this.result = result;
       return this;
     }
 
-    public Builder code(int code) {
+    public Builder<T> code(int code) {
       this.code = code;
       return this;
     }
 
-    public Builder cookies(ArrayList<NewCookie> newCookies) {
+    public Builder<T> cookies(ArrayList<NewCookie> newCookies) {
       if (cookies == null) {
         cookies = new ArrayList<>();
       }
@@ -134,7 +135,7 @@ public class JsonResponse<T> {
     }
 
     public javax.ws.rs.core.Response build() {
-      JsonResponse jsonResponse = new JsonResponse(this);
+      JsonResponse<T> jsonResponse = new JsonResponse<>(this);
       return jsonResponse.build();
     }
   }

--- a/submarine-server/server-core/src/main/java/org/apache/submarine/server/rest/MetaStoreRestApi.java
+++ b/submarine-server/server-core/src/main/java/org/apache/submarine/server/rest/MetaStoreRestApi.java
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 package org.apache.submarine.server.rest;
 
 import com.google.gson.Gson;
@@ -106,11 +107,11 @@ public class MetaStoreRestApi {
       databaseCount = submarineMetaStore.getDatabaseCount();
     } catch (MetaException e) {
       LOG.error(e.getMessage(), e);
-      return new JsonResponse.Builder<String>(
+      return new JsonResponse.Builder<Integer>(
               Response.Status.INTERNAL_SERVER_ERROR).success(false)
               .result(databaseCount).build();
     }
-    return new JsonResponse.Builder<String>(Response.Status.OK)
+    return new JsonResponse.Builder<Integer>(Response.Status.OK)
             .success(true).result(databaseCount).build();
   }
 
@@ -126,7 +127,7 @@ public class MetaStoreRestApi {
       return new JsonResponse.Builder<String>(Response.Status.INTERNAL_SERVER_ERROR)
               .success(false).build();
     }
-    return new JsonResponse.Builder<String>(Response.Status.OK)
+    return new JsonResponse.Builder<List<String>>(Response.Status.OK)
             .success(true).result(allDatabases).build();
   }
 
@@ -142,7 +143,7 @@ public class MetaStoreRestApi {
       return new JsonResponse.Builder<String>(Response.Status.NOT_FOUND)
               .success(false).build();
     }
-    return new JsonResponse.Builder<String>(Response.Status.OK)
+    return new JsonResponse.Builder<Database>(Response.Status.OK)
             .success(true).result(database).build();
   }
 
@@ -177,7 +178,7 @@ public class MetaStoreRestApi {
       return new JsonResponse.Builder<String>(Response.Status.INTERNAL_SERVER_ERROR)
               .success(false).build();
     }
-    return new JsonResponse.Builder<String>(Response.Status.OK)
+    return new JsonResponse.Builder<List<String>>(Response.Status.OK)
             .success(true).result(tables).build();
   }
 
@@ -193,7 +194,7 @@ public class MetaStoreRestApi {
       return new JsonResponse.Builder<String>(Response.Status.INTERNAL_SERVER_ERROR)
               .success(false).build();
     }
-    return new JsonResponse.Builder<String>(Response.Status.OK)
+    return new JsonResponse.Builder<Integer>(Response.Status.OK)
             .success(true).result(tableCount).build();
   }
 
@@ -210,7 +211,7 @@ public class MetaStoreRestApi {
       return new JsonResponse.Builder<String>(Response.Status.INTERNAL_SERVER_ERROR)
               .success(false).build();
     }
-    return new JsonResponse.Builder<String>(Response.Status.OK)
+    return new JsonResponse.Builder<Table>(Response.Status.OK)
             .success(true).result(table).build();
   }
 

--- a/submarine-server/server-core/src/main/java/org/apache/submarine/server/workbench/rest/SysDeptRestApi.java
+++ b/submarine-server/server-core/src/main/java/org/apache/submarine/server/workbench/rest/SysDeptRestApi.java
@@ -126,7 +126,7 @@ public class SysDeptRestApi {
       return new JsonResponse.Builder<>(Response.Status.OK).success(false).build();
     }
 
-    return new JsonResponse.Builder<ListResult<List<SysDeptSelect>>>(Response.Status.OK)
+    return new JsonResponse.Builder<List<SysDeptSelect>>(Response.Status.OK)
         .success(true).result(sysDeptSelects).build();
   }
 

--- a/submarine-server/server-core/src/main/java/org/apache/submarine/server/workbench/rest/SysUserRestApi.java
+++ b/submarine-server/server-core/src/main/java/org/apache/submarine/server/workbench/rest/SysUserRestApi.java
@@ -21,7 +21,6 @@ package org.apache.submarine.server.workbench.rest;
 import com.github.pagehelper.PageInfo;
 import com.google.gson.Gson;
 import org.apache.submarine.server.workbench.annotation.SubmarineApi;
-import org.apache.submarine.server.workbench.database.entity.SysDept;
 import org.apache.submarine.server.workbench.database.entity.SysUser;
 import org.apache.submarine.server.workbench.database.service.SysUserService;
 import org.apache.submarine.server.workbench.entity.Action;
@@ -118,7 +117,7 @@ public class SysUserRestApi {
           .message("Save user failed!").build();
     }
 
-    return new JsonResponse.Builder<SysDept>(Response.Status.OK)
+    return new JsonResponse.Builder<SysUser>(Response.Status.OK)
         .success(true).message("Save user successfully!").result(sysUser).build();
   }
 


### PR DESCRIPTION
### What is this PR for?
Fix the check warning for JsonResponse, the two warning problems list as below: 
* Unchecked call to 'result(T)' as a member of raw type
* Raw use of parameterized class

### What type of PR is it?
Bug Fix

### Todos

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-327

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
