### PR TITLE
SUBMARINE-329. Workbench-web-ng support mvn compile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ env:
   global:
     # If you need to compile Phadoop-3.1 or Phadoop-3.2, you need to add `!submarine-server/server-submitter/submitter-yarnservice` in EXCLUDE_SUBMARINE
     - EXCLUDE_SUBMARINE="!submarine-all,!submarine-client,!submarine-commons,!submarine-commons/commons-runtime,!submarine-dist,!submarine-server/server-submitter/submitter-yarn,!submarine-server/server-core,!submarine-server/server-rpc"
-    - EXCLUDE_WORKBENCH="!submarine-workbench,!submarine-workbench/workbench-web"
+    - EXCLUDE_WORKBENCH="!submarine-workbench,!submarine-workbench/workbench-web,!submarine-workbench/workbench-web-ng"
     - EXCLUDE_INTERPRETER="!submarine-workbench/interpreter,!submarine-workbench/interpreter/interpreter-engine,!submarine-workbench/interpreter/python-interpreter,!submarine-workbench/interpreter/spark-interpreter""
     - EXCLUDE_SUBMODULE_TONY="!submodules/tony,!submodules/tony/tony-mini,!submodules/tony/tony-core,!submodules/tony/tony-proxy,!submodules/tony/tony-portal,!submodules/tony/tony-azkaban,!submodules/tony/tony-cli"
     - EXCLUDE_K8S="!submarine-server/server-submitter/submitter-k8s"
@@ -77,38 +77,64 @@ before_install:
 
 matrix:
   include:
-    # Test License compliance using RAT tool
-    - language: java
+    - name: Test License compliance using RAT tool
+      language: java
       jdk: "openjdk8"
       dist: xenial
-      env: NAME="Check RAT" PROFILE="" BUILD_FLAG="clean" TEST_FLAG="org.apache.rat:apache-rat-plugin:check" TEST_PROJECTS=""
+      env: PROFILE="" BUILD_FLAG="clean" TEST_FLAG="org.apache.rat:apache-rat-plugin:check" TEST_PROJECTS=""
 
-    # Build hadoop-2.7
-    - language: java
+    - name: Build submarine submitter on hadoop-2.7
+      language: java
       jdk: "openjdk8"
       dist: xenial
-      env: NAME="Build hadoop-2.7" PROFILE="-Phadoop-2.7" BUILD_FLAG="clean package install -DskipTests -DskipRat" TEST_FLAG="test -DskipRat" MODULES="-pl \"${EXCLUDE_K8S},${EXCLUDE_WORKBENCH},${EXCLUDE_INTERPRETER},!submarine-dist\"" TEST_MODULES="-pl \"${EXCLUDE_K8S},${EXCLUDE_WORKBENCH},${EXCLUDE_INTERPRETER},${EXCLUDE_COMMON_RPC},!submarine-dist\"" TEST_PROJECTS=""
+      env: PROFILE="-Phadoop-2.7" BUILD_FLAG="clean package install -DskipTests -DskipRat" TEST_FLAG="test -DskipRat" MODULES="-pl ${EXCLUDE_K8S},${EXCLUDE_WORKBENCH},${EXCLUDE_INTERPRETER},!submarine-dist" TEST_MODULES="-pl ${EXCLUDE_K8S},${EXCLUDE_WORKBENCH},${EXCLUDE_INTERPRETER},${EXCLUDE_COMMON_RPC},!submarine-dist" TEST_PROJECTS=""
 
-    # Build hadoop-2.9(default)
-    - language: java
+    - name: Build submarine submitter on hadoop-2.9 (default)
+      language: java
       jdk: "openjdk8"
       dist: xenial
-      env: NAME="Build hadoop-2.9" PROFILE="-Phadoop-2.9" BUILD_FLAG="clean package install -DskipTests -DskipRat" TEST_FLAG="test -DskipRat" MODULES="-pl \"${EXCLUDE_K8S},${EXCLUDE_WORKBENCH},${EXCLUDE_INTERPRETER},!submarine-dist\"" TEST_MODULES="-pl \"${EXCLUDE_K8S},${EXCLUDE_WORKBENCH},${EXCLUDE_INTERPRETER},${EXCLUDE_COMMON_RPC},!submarine-dist\"" TEST_PROJECTS=""
+      env: PROFILE="-Phadoop-2.9" BUILD_FLAG="clean package install -DskipTests -DskipRat" TEST_FLAG="test -DskipRat" MODULES="-pl ${EXCLUDE_K8S},${EXCLUDE_WORKBENCH},${EXCLUDE_INTERPRETER},!submarine-dist" TEST_MODULES="-pl ${EXCLUDE_K8S},${EXCLUDE_WORKBENCH},${EXCLUDE_INTERPRETER},${EXCLUDE_COMMON_RPC},!submarine-dist" TEST_PROJECTS=""
 
-    # Build hadoop-3.1
-    - language: java
+    - name: Build submarine submitter on hadoop-3.1
+      language: java
       jdk: "openjdk8"
       dist: xenial
-      env: NAME="Build hadoop-3.1" PROFILE="-Phadoop-3.1" BUILD_FLAG="clean package install -DskipTests -DskipRat" TEST_FLAG="test -DskipRat" MODULES="-pl \"${EXCLUDE_K8S},${EXCLUDE_WORKBENCH},${EXCLUDE_INTERPRETER},!submarine-dist\"" TEST_MODULES="-pl \"${EXCLUDE_K8S},${EXCLUDE_WORKBENCH},${EXCLUDE_INTERPRETER},${EXCLUDE_COMMON_RPC},!submarine-dist\"" TEST_PROJECTS=""
+      env: PROFILE="-Phadoop-3.1" BUILD_FLAG="clean package install -DskipTests -DskipRat" TEST_FLAG="test -DskipRat" MODULES="-pl ${EXCLUDE_K8S},${EXCLUDE_WORKBENCH},${EXCLUDE_INTERPRETER},!submarine-dist" TEST_MODULES="-pl ${EXCLUDE_K8S},${EXCLUDE_WORKBENCH},${EXCLUDE_INTERPRETER},${EXCLUDE_COMMON_RPC},!submarine-dist" TEST_PROJECTS=""
 
-    # Build hadoop-3.2
-    - language: java
+    - name: Build submarine submitter on hadoop-3.2
+      language: java
       jdk: "openjdk8"
       dist: xenial
-      env: NAME="Build hadoop-3.2" PROFILE="-Phadoop-3.2" BUILD_FLAG="clean package install -DskipTests -DskipRat" TEST_FLAG="test -DskipRat" MODULES="-pl \"${EXCLUDE_K8S},${EXCLUDE_WORKBENCH},${EXCLUDE_INTERPRETER},!submarine-dist\"" TEST_MODULES="-pl \"${EXCLUDE_K8S},${EXCLUDE_WORKBENCH},${EXCLUDE_INTERPRETER},${EXCLUDE_COMMON_RPC},!submarine-dist\"" TEST_PROJECTS=""
+      env: PROFILE="-Phadoop-3.2" BUILD_FLAG="clean package install -DskipTests -DskipRat" TEST_FLAG="test -DskipRat" MODULES="-pl ${EXCLUDE_K8S},${EXCLUDE_WORKBENCH},${EXCLUDE_INTERPRETER},!submarine-dist" TEST_MODULES="-pl ${EXCLUDE_K8S},${EXCLUDE_WORKBENCH},${EXCLUDE_INTERPRETER},${EXCLUDE_COMMON_RPC},!submarine-dist" TEST_PROJECTS=""
 
-    # Build workbench-web
-    - language: node_js
+    - name: Build submarine submitter on Kubernetes
+      dist: xenial
+      services: docker
+      language: java
+      jdk: openjdk8
+      env: BUILD_FLAG="clean package install -DskipTests -am" TEST_FLAG="test -am" MODULES="-pl org.apache.submarine:submitter-k8s" TEST_MODULES="-pl org.apache.submarine:submitter-k8s" TEST_PROJECTS=""
+      before_install:
+        # deploy Kubernetes cluster
+        - curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl
+        - chmod +x kubectl
+        - sudo mv kubectl /usr/bin
+        - docker run -d --name kube --privileged -p 8443:8443 -p 10080:10080 bsycorp/kind:latest-1.15
+        - until curl -s --fail http://127.0.0.1:10080/kubernetes-ready; do
+          sleep 1;
+          done
+        - echo "Kubernetes ready - run tests!"
+        - mkdir $HOME/.kube
+        - curl http://127.0.0.1:10080/config > $HOME/.kube/config
+        - export KUBECONFIG=$HOME/.kube/config
+        - echo $KUBECONFIG
+        - kubectl config set clusters.kubernetes.server https://127.0.0.1:8443
+        - kubectl get nodes
+        - kubectl create namespace kubeflow
+        - kubectl apply -f ./dev-support/travis/tf-operator/crd_v1.yaml
+        - kubectl apply -f ./dev-support/travis/tf-operator/tfevent-volume/.
+
+    - name: Build submarine workbench-web VUE
+      language: node_js
       node_js:
         - 10.15.0
       before_install:
@@ -120,26 +146,26 @@ matrix:
         - yarn run lint --no-fix && yarn run build
       env: NAME="Build workbench-web"
 
-    # Test workbench-web
-    - language: java
+    - name: Test submarine workbench-web VUE
+      language: java
       jdk: "openjdk8"
       dist: xenial
-      env: NAME="Test workbench-web" PROFILE="-Phadoop-2.9" BUILD_FLAG="clean package install -DskipTests" TEST_FLAG="test -DskipRat -am" MODULES="-pl ${EXCLUDE_K8S},${EXCLUDE_SUBMARINE},${EXCLUDE_INTERPRETER}" TEST_MODULES="-pl submarine-workbench/workbench-web" TEST_PROJECTS=""
+      env: PROFILE="-Phadoop-2.9" BUILD_FLAG="clean package install -DskipTests" TEST_FLAG="test -DskipRat -am" MODULES="-pl org.apache.submarine:workbench-web" TEST_MODULES="-pl org.apache.submarine:workbench-web" TEST_PROJECTS=""
 
-    # Test test-e2e
-    - language: java
+    - name: Test submarine test-e2e
+      language: java
       jdk: "openjdk8"
       dist: xenial
-      env: NAME="Test test-e2e" PROFILE="-Phadoop-2.9" BUILD_FLAG="clean test" TEST_FLAG="test -DskipRat -am" MODULES="-pl submarine-test/e2e" TEST_MODULES="-pl submarine-test/e2e" TEST_PROJECTS=""
+      env: PROFILE="-Phadoop-2.9" BUILD_FLAG="clean test" TEST_FLAG="test -DskipRat -am" MODULES="-pl submarine-test/e2e" TEST_MODULES="-pl submarine-test/e2e" TEST_PROJECTS=""
 
-    # Test interpreter
-    - language: java
+    - name: Test submarine interpreter
+      language: java
       jdk: "openjdk8"
       dist: xenial
-      env: NAME="Test interpreter" PYTHON="3" PROFILE="-Phadoop-2.9" BUILD_FLAG="clean package install -DskipTests" TEST_FLAG="test -DskipRat -am" MODULES="-pl ${EXCLUDE_K8S},${EXCLUDE_SUBMARINE},${EXCLUDE_WORKBENCH},${EXCLUDE_SUBMODULE_TONY}" TEST_MODULES="-pl $(echo ${EXCLUDE_INTERPRETER} | sed 's/!//g')" TEST_PROJECTS=""
+      env: PYTHON="3" PROFILE="-Phadoop-2.9" BUILD_FLAG="clean package install -DskipTests" TEST_FLAG="test -DskipRat -am" MODULES="-pl ${EXCLUDE_K8S},${EXCLUDE_SUBMARINE},${EXCLUDE_WORKBENCH},${EXCLUDE_SUBMODULE_TONY}" TEST_MODULES="-pl $(echo ${EXCLUDE_INTERPRETER} | sed 's/!//g')" TEST_PROJECTS=""
 
-    # Test submarine-sdk
-    - language: python
+    - name: Test submarine-sdk
+      language: python
       python: 3.6
       dist: xenial
       install:
@@ -149,14 +175,14 @@ matrix:
         - ./submarine-sdk/pysubmarine/travis/lint.sh
         - pytest --cov=submarine -vs
 
-    # Test submarine distribution
-    - language: java
+    - name: Test submarine distribution
+      language: java
       jdk: "openjdk8"
       dist: xenial
-      env: NAME="Test submarine distribution" PROFILE="-Phadoop-2.9" BUILD_FLAG="clean package install -DskipTests" TEST_FLAG="test -DskipRat" MODULES="-pl ${EXCLUDE_K8S}" TEST_MODULES="-pl ${EXCLUDE_K8S},${EXCLUDE_COMMON_RPC}" TEST_PROJECTS=""
+      env: PROFILE="-Phadoop-2.9" BUILD_FLAG="clean package install -DskipTests" TEST_FLAG="test -DskipRat" MODULES="-pl ${EXCLUDE_K8S}" TEST_MODULES="-pl ${EXCLUDE_K8S},${EXCLUDE_COMMON_RPC}" TEST_PROJECTS=""
 
-    # Test submarine web-ng
-    - language: node_js
+    - name: Test submarine workbench-web Angular
+      language: node_js
       node_js:
         - "10"
       before_install:
@@ -172,43 +198,17 @@ matrix:
       script:
         - npm run test -- --no-watch --no-progress --browsers=ChromeHeadlessCI
         - npm run e2e -- --protractor-config=e2e/protractor-ci.conf.js
-      env: NAME="Build workbench-web-ng"
+      env: BUILD_FLAG="clean package -DskipTests" TEST_FLAG="test -DskipRat -am" MODULES="-pl org.apache.submarine:workbench-web-ng" TEST_MODULES="-pl org.apache.submarine:workbench-web-ng" TEST_PROJECTS=""
 
-    # Test submarine-server
-    - language: java
+    - name: Test submarine-server
+      language: java
       jdk: "openjdk8"
       dist: xenial
-      env: NAME="Test submarine-server" PROFILE="-Phadoop-2.9" BUILD_FLAG="clean package install -DskipTests" TEST_FLAG="test -DskipRat" MODULES="-pl ${EXCLUDE_K8S},${EXCLUDE_WORKBENCH},${EXCLUDE_INTERPRETER}" TEST_MODULES="-pl submarine-server/server-core" TEST_PROJECTS=""
-
-    - name: Submarine on Kubernetes
-      dist: xenial
-      services: docker
-      language: java
-      jdk: openjdk8
-      env: BUILD_FLAG="clean package install -DskipTests -am" TEST_FLAG="test -am" MODULES="-pl org.apache.submarine:submitter-k8s" TEST_MODULES="-pl org.apache.submarine:submitter-k8s" TEST_PROJECTS=""
-      before_install:
-        # deploy Kubernetes cluster
-        - curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl
-        - chmod +x kubectl
-        - sudo mv kubectl /usr/bin
-        - docker run -d --name kube --privileged -p 8443:8443 -p 10080:10080 bsycorp/kind:latest-1.15
-        - until curl -s --fail http://127.0.0.1:10080/kubernetes-ready; do
-            sleep 1;
-          done
-        - echo "Kubernetes ready - run tests!"
-        - mkdir $HOME/.kube
-        - curl http://127.0.0.1:10080/config > $HOME/.kube/config
-        - export KUBECONFIG=$HOME/.kube/config
-        - echo $KUBECONFIG
-        - kubectl config set clusters.kubernetes.server https://127.0.0.1:8443
-        - kubectl get nodes
-        - kubectl create namespace kubeflow
-        - kubectl apply -f ./dev-support/travis/tf-operator/crd_v1.yaml
-        - kubectl apply -f ./dev-support/travis/tf-operator/tfevent-volume/.
+      env: PROFILE="-Phadoop-2.9" BUILD_FLAG="clean package install -DskipTests" TEST_FLAG="test -DskipRat" MODULES="-pl ${EXCLUDE_K8S},${EXCLUDE_WORKBENCH},${EXCLUDE_INTERPRETER}" TEST_MODULES="-pl org.apache.submarine:server-core" TEST_PROJECTS=""
 
 install:
   - mvn --version
-  - echo "[$NAME] > mvn $BUILD_FLAG $MODULES $PROFILE -B"
+  - echo "mvn $BUILD_FLAG $MODULES $PROFILE -B"
   - mvn $BUILD_FLAG $MODULES $PROFILE -B
 
 before_script:

--- a/conf/submarine-site.xml
+++ b/conf/submarine-site.xml
@@ -103,7 +103,7 @@
 
   <property>
     <name>workbench.web.war</name>
-    <value>../workbench-web.war</value>
+    <value>../workbench-web-ng.war</value>
     <description>Submarine workbench web war file path.</description>
   </property>
 

--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,7 @@
     <plugin.frontend.version>1.6</plugin.frontend.version>
     <node.version>v10.12.0</node.version>
     <yarn.version>v1.10.1</yarn.version>
+    <npm.version>6.4.1</npm.version>
 
     <hadoop.common.build.dir>${basedir}/../hadoop-common-project/hadoop-common/target</hadoop.common.build.dir>
     <slf4j.version>1.7.25</slf4j.version>

--- a/submarine-dist/src/assembly/distribution.xml
+++ b/submarine-dist/src/assembly/distribution.xml
@@ -67,10 +67,10 @@
       </includes>
     </fileSet>
     <fileSet>
-      <directory>../submarine-workbench/workbench-web/target</directory>
+      <directory>../submarine-workbench/workbench-web-ng/target</directory>
       <outputDirectory>/</outputDirectory>
       <includes>
-        <include>workbench-web.war</include>
+        <include>workbench-web-ng.war</include>
       </includes>
     </fileSet>
     <fileSet>

--- a/submarine-workbench/workbench-web-ng/README.md
+++ b/submarine-workbench/workbench-web-ng/README.md
@@ -16,6 +16,10 @@ Run `ng generate component component-name` to generate a new component. You can 
 
 Run `ng build` to build the project. The build artifacts will be stored in the `dist/` directory. Use the `--prod` flag for a production build.
 
+## Package
+
+Run `mvn clean package` to package the project. The build `workbech-web-ng.war` will be stored in the `target` directory.
+
 ## Running unit tests
 
 Run `ng test` to execute the unit tests via [Karma](https://karma-runner.github.io).

--- a/submarine-workbench/workbench-web-ng/pom.xml
+++ b/submarine-workbench/workbench-web-ng/pom.xml
@@ -31,8 +31,8 @@
 
   <groupId>org.apache.submarine</groupId>
   <artifactId>workbench-web-ng</artifactId>
-  <!--  <packaging>war</packaging>-->
-  <!--  <version>0.3.0-SNAPSHOT</version>-->
+  <packaging>war</packaging>
+  <version>0.3.0-SNAPSHOT</version>
   <name>Submarine: Workbench Web Angular</name>
 
   <!-- See https://github.com/eirslett/frontend-maven-plugin/issues/229 -->
@@ -42,14 +42,92 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-
     <!--plugin versions-->
     <plugin.frontend.nodeDownloadRoot>https://nodejs.org/dist/</plugin.frontend.nodeDownloadRoot>
   </properties>
 
   <build>
-    <defaultGoal>compile</defaultGoal>
     <plugins>
+      <!-- Gulp Frontend -->
+      <plugin>
+        <groupId>com.github.eirslett</groupId>
+        <artifactId>frontend-maven-plugin</artifactId>
+        <version>${plugin.frontend.version}</version>
+
+        <configuration>
+          <installDirectory>target</installDirectory>
+          <environmentVariables>
+            <!-- Avoid certificates issues, needed behind a corporate proxy -->
+            <NODE_TLS_REJECT_UNAUTHORIZED>0</NODE_TLS_REJECT_UNAUTHORIZED>
+          </environmentVariables>
+        </configuration>
+
+        <executions>
+          <execution>
+            <id>install node and npm</id>
+            <goals>
+              <goal>install-node-and-npm</goal>
+            </goals>
+            <configuration>
+              <nodeVersion>${node.version}</nodeVersion>
+              <npmVersion>${npm.version}</npmVersion>
+            </configuration>
+          </execution>
+          <execution>
+            <id>npm install</id>
+            <goals>
+              <goal>npm</goal>
+            </goals>
+            <configuration>
+              <arguments>install</arguments>
+            </configuration>
+          </execution>
+          <execution>
+            <id>npm build</id>
+            <goals>
+              <goal>npm</goal>
+            </goals>
+            <configuration>
+              <arguments>run build --prod</arguments>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <!-- End Gulp Frontend -->
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-war-plugin</artifactId>
+        <version>${plugin.war.version}</version>
+        <configuration>
+          <warName>${project.artifactId}</warName>
+          <failOnMissingWebXml>true</failOnMissingWebXml>
+          <warSourceDirectory>dist/workbench-web-ng</warSourceDirectory>
+          <webXml>src/WEB-INF/web.xml</webXml>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <!-- clean task will be executed by front-end-maven plugin -->
+        <artifactId>maven-clean-plugin</artifactId>
+        <configuration>
+          <filesets>
+            <fileset>
+              <directory>dist</directory>
+            </fileset>
+            <fileset>
+              <directory>node_modules</directory>
+            </fileset>
+            <fileset>
+              <directory>target</directory>
+            </fileset>
+            <fileset>
+              <directory>node</directory>
+            </fileset>
+          </filesets>
+        </configuration>
+      </plugin>
+
       <plugin>
         <groupId>org.apache.rat</groupId>
         <artifactId>apache-rat-plugin</artifactId>

--- a/submarine-workbench/workbench-web-ng/tsconfig.json
+++ b/submarine-workbench/workbench-web-ng/tsconfig.json
@@ -16,7 +16,7 @@
     "module": "esnext",
     "moduleResolution": "node",
     "importHelpers": true,
-    "target": "es2015",
+    "target": "es5",
     "typeRoots": [
       "node_modules/@types"
     ],


### PR DESCRIPTION
### What is this PR for?
workbench-web-ng now requires developers to manually download nodejs and npm tools to compile.
The mvn plugin now supports the `mvn clean package` command to compile the `workbench-web-ng.war` package.

Run `mvn clean package` to package the project. The build `workbech-web-ng.war` will be stored in the `target` directory.

### What type of PR is it?
Improvement


### What is the Jira issue?
* https://issues.apache.org/jira/browse/SUBMARINE-329

### How should this be tested?
* [CI Pass](https://travis-ci.org/liuxunorg/submarine/builds/631589571)

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? Yes
