### PR TITLE
SUBMARINE-340. Add submarine database dockerfile

### DIFF
--- a/dev-support/docker-images/database/Dockerfile
+++ b/dev-support/docker-images/database/Dockerfile
@@ -1,0 +1,26 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM submarinehub/mysql:5.7.27
+MAINTAINER Apache Software Foundation <dev@submarine.apache.org>
+
+ENV AUTO_RUN_DIR /docker-entrypoint-initdb.d
+
+ADD database/* /tmp/database/
+ADD startup.sh ${AUTO_RUN_DIR}/
+RUN chmod +x ${AUTO_RUN_DIR}/startup.sh
+
+# mysql port
+EXPOSE 3306

--- a/dev-support/docker-images/database/build.sh
+++ b/dev-support/docker-images/database/build.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eo pipefail
+
+if [ -L ${BASH_SOURCE-$0} ]; then
+  PWD=$(dirname $(readlink "${BASH_SOURCE-$0}"))
+else
+  PWD=$(dirname ${BASH_SOURCE-$0})
+fi
+export BUILD_PATH=$(cd "${PWD}">/dev/null; pwd)
+SUBMARINE_HOME=${BUILD_PATH}/../../..
+
+SUBMARINE_VERSION="0.3.0"
+SUBMARINE_IMAGE_NAME="apache/submarine:database-${SUBMARINE_VERSION}"
+
+cp -rf "${SUBMARINE_HOME}/docs/database" "${BUILD_PATH}"
+
+# build image
+echo "Start building the submarine docker image ..."
+
+docker build -t ${SUBMARINE_IMAGE_NAME} .
+
+# clean template file
+rm -rf ${BUILD_PATH}/database

--- a/dev-support/docker-images/database/build.sh
+++ b/dev-support/docker-images/database/build.sh
@@ -24,7 +24,7 @@ fi
 export BUILD_PATH=$(cd "${PWD}">/dev/null; pwd)
 SUBMARINE_HOME=${BUILD_PATH}/../../..
 
-SUBMARINE_VERSION="0.3.0"
+SUBMARINE_VERSION="0.3.0-SNAPSHOT"
 SUBMARINE_IMAGE_NAME="apache/submarine:database-${SUBMARINE_VERSION}"
 
 cp -rf "${SUBMARINE_HOME}/docs/database" "${BUILD_PATH}"

--- a/dev-support/docker-images/database/startup.sh
+++ b/dev-support/docker-images/database/startup.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+mysql -uroot -p$MYSQL_ROOT_PASSWORD <<EOF
+CREATE DATABASE submarine_test;
+CREATE USER 'submarine_test'@'%' IDENTIFIED BY 'password_test';
+GRANT ALL PRIVILEGES ON *.* TO 'submarine_test'@'%';
+use submarine_test; source /tmp/database/submarine.sql; source /tmp/database/submarine-data.sql;
+CREATE DATABASE submarine;
+CREATE USER 'submarine'@'%' IDENTIFIED BY 'password';
+GRANT ALL PRIVILEGES ON *.* TO 'submarine'@'%';
+use submarine; source /tmp/database/submarine.sql; source /tmp/database/submarine-data.sql;
+CREATE DATABASE metastore_test;
+CREATE USER 'metastore_test'@'%' IDENTIFIED BY 'password_test';
+GRANT ALL PRIVILEGES ON * . * TO 'metastore_test'@'%';
+use metastore_test; source /tmp/database/metastore.sql;
+CREATE DATABASE metastore;
+CREATE USER 'metastore'@'%' IDENTIFIED BY 'password';
+GRANT ALL PRIVILEGES ON * . * TO 'metastore'@'%';
+use metastore; source /tmp/database/metastore.sql;
+EOF

--- a/docs/database/README.md
+++ b/docs/database/README.md
@@ -29,14 +29,15 @@ Must:
 
 ## Run mysql on docker
 
-Run the mysql container, modify the character set (if you need to support Chinese), Create a submarine database.
+By using the official docker image of submarine databsase, only one docker command is required to run submarine databsase
 
 ```bash
-~bash> docker run -p 3306:3306 -d --name mysql -e MYSQL_ROOT_PASSWORD=password mysql:5.7.27
-~bash> docker exec -it mysql bash
+docker run -it -p 3306:3306 -d --name submarine-database -e MYSQL_ROOT_PASSWORD=password apache/submarine:database-0.3.0
 ```
 
-## Modify character set (Optional)
+## Manual operation of the submarine database
+
+### Modify character set (Optional)
 
 If you need to store Chinese character data in mysql, you need to execute the following command to modify the mysql character set.
 
@@ -76,9 +77,9 @@ If you need to store Chinese character data in mysql, you need to execute the fo
   default-character-set = utf8
   ```
 
-## Create Submarine Database
+### Create Submarine Database
 
-### Create development database
+#### Create development database
 Copy the files, submarine.sql, submarine-data.sql and metastore.sql to the mysql docker.
 
 ```
@@ -109,7 +110,7 @@ mysql> quit
 >  NOTE: submarine development database name is  `submarine` and user name is `submarine`, password is `password`, metastore development database name is  `metastore` and user name is `metastore`, password is `password`, This is the default value in the system's `submarine-site.xml` configuration file and is not recommended for modification.
 
 
-### Create test database
+#### Create test database
 
 Test database for program unit testing and Travis test environment.
 
@@ -131,7 +132,7 @@ mysql> quit
 
 >  NOTE: submarine test database name is  `submarine_test` and user name is `submarine_test`, password is `password_test`, metastore test database name is  `metastore_test` and user name is `metastore_test`, password is `password_test`, Cannot be configured, values that cannot be modified.
 
-### mysqldump
+#### mysqldump
 
 ```$xslt
 mysqldump -uroot -ppassword --databases submarine > submarine.sql;


### PR DESCRIPTION
### What is this PR for?
In order to enable submarine to support deployment in k8s,
We need to enable each service of submarine to be deployed independently.
The problem that jira solves is the ability to install the submarine table structure and initialization data into mysql.
Allows users to run submarine's database service with only one command.
like., 
```
docker run -it -p 3306:3306 -d --name s1 -e MYSQL_ROOT_PASSWORD=password apache/submarine:database-0.3.0-SNAPSHOT
```

### What type of PR is it?
[Refactoring]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/SUBMARINE-340

### How should this be tested?
* https://travis-ci.org/liuxunorg/submarine/builds/635299028

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? Yes
