### PR TITLE
SUBMARINE-341. Add submarine server dockerfile

### DIFF
--- a/bin/submarine.sh
+++ b/bin/submarine.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+USAGE="Usage: bin/submarine.sh [--config <conf-dir>]"
+
+if [[ "$1" == "--config" ]]; then
+  shift
+  conf_dir="$1"
+  if [[ ! -d "${conf_dir}" ]]; then
+    echo "ERROR : ${conf_dir} is not a directory"
+    echo ${USAGE}
+    exit 1
+  else
+    export SUBMARINE_CONF_DIR="${conf_dir}"
+  fi
+  shift
+fi
+
+if [ -L ${BASH_SOURCE-$0} ]; then
+  BIN=$(dirname $(readlink "${BASH_SOURCE-$0}"))
+else
+  BIN=$(dirname ${BASH_SOURCE-$0})
+fi
+export BIN=$(cd "${BIN}">/dev/null; pwd)
+GET_MYSQL_JAR=false
+
+. "${BIN}/common.sh"
+
+cd ${BIN}/>/dev/null
+
+SUBMARINE_SERVER_NAME="Submarine Server"
+SUBMARINE_SERVER_LOGFILE="${SUBMARINE_LOG_DIR}/submarine.log"
+SUBMARINE_SERVER_MAIN=org.apache.submarine.server.SubmarineServer
+JAVA_OPTS+="${SUBMARINE_SERVER_JAVA_OPTS:-""} ${SUBMARINE_SERVER_MEM:-""} -Dsubmarine.log.file=${SUBMARINE_SERVER_LOGFILE}"
+
+add_jar_in_dir "${BIN}/../lib"
+add_jar_in_dir "${BIN}/../lib/submitter"
+
+if [[ ! -d "${SUBMARINE_LOG_DIR}" ]]; then
+  echo "Log dir doesn't exist, create ${SUBMARINE_LOG_DIR}"
+  $(mkdir -p "${SUBMARINE_LOG_DIR}")
+fi
+
+exec $JAVA_RUNNER $JAVA_OPTS -cp ${SUBMARINE_SERVER_CLASSPATH} ${SUBMARINE_SERVER_MAIN} "$@" >> "${SUBMARINE_SERVER_LOGFILE}" 2>&1

--- a/dev-support/docker-images/submarine/Dockerfile
+++ b/dev-support/docker-images/submarine/Dockerfile
@@ -1,0 +1,48 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM submarinehub/alpine:3.10
+MAINTAINER Apache Software Foundation <dev@submarine.apache.org>
+
+# Update apk repositories
+RUN echo "http://mirrors.ustc.edu.cn/alpine/v3.10/main" > /etc/apk/repositories
+RUN echo "http://mirrors.ustc.edu.cn/alpine/v3.10/community" >> /etc/apk/repositories
+
+# INSTALL openjdk
+RUN apk update && \
+    apk add --no-cache openjdk8 tzdata tini && \
+    cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && \
+    echo Asia/Shanghai > /etc/timezone && \
+    apk del tzdata && \
+    rm -rf /tmp/* /var/cache/apk/*
+
+
+ENV JAVA_HOME /usr/lib/jvm/java-1.8-openjdk/jre
+
+# Install Submarine
+ADD ./tmp/submarine-dist-*.tar.gz /opt/
+RUN ln -s /opt/submarine-dist-* "/opt/submarine-current"
+RUN mv /opt/mysql-connector-java-*.jar /opt/submarine-current/lib/
+ADD ./tmp/submarine-site.xml "/opt/submarine-current/conf/"
+ADD ./tmp/submarine.sh "/opt/submarine-current/bin/"
+
+WORKDIR /opt/submarine-current
+
+# Submarine port
+EXPOSE 8080
+
+ENTRYPOINT ["/sbin/tini", "--"]
+
+CMD ["/bin/bash", "-c", "/opt/submarine-current/bin/submarine.sh start"]

--- a/dev-support/docker-images/submarine/build.sh
+++ b/dev-support/docker-images/submarine/build.sh
@@ -16,7 +16,7 @@
 
 set -eo pipefail
 
-SUBMARINE_VERSION=0.3.0
+SUBMARINE_VERSION=0.3.0-SNAPSHOT
 SUBMARINE_IMAGE_NAME="apache/submarine:submarine-${SUBMARINE_VERSION}"
 
 if [ -L ${BASH_SOURCE-$0} ]; then
@@ -30,7 +30,7 @@ export SUBMARINE_HOME=${CURRENT_PATH}/../../..
 if [ ! -d "${SUBMARINE_HOME}/submarine-dist/target" ]; then
   mkdir "${SUBMARINE_HOME}/submarine-dist/target"
 fi
-submarine_dist_exists=$(find -L "${SUBMARINE_HOME}/submarine-dist/target" -name "submarine-dist-${submarine_v}*.tar.gz")
+submarine_dist_exists=$(find -L "${SUBMARINE_HOME}/submarine-dist/target" -name "submarine-dist-${SUBMARINE_VERSION}*.tar.gz")
 # Build source code if the package doesn't exist.
 if [[ -z "${submarine_dist_exists}" ]]; then
   # update tony code
@@ -49,7 +49,7 @@ cp ${SUBMARINE_HOME}/submarine-dist/target/submarine-dist-${SUBMARINE_VERSION}*.
 # Replace the mysql jdbc.url in the submarine-site.xml file with the link name of the submarine container
 # `submarine-database` is submarine database container name
 cp ${SUBMARINE_HOME}/conf/submarine-site.xml "${CURRENT_PATH}/tmp/"
-sed -i ".bak" 's/127.0.0.1:3306/submarine-database:3306/g' "${CURRENT_PATH}/tmp/submarine-site.xml"
+sed -i.bak 's/127.0.0.1:3306/submarine-database:3306/g' "${CURRENT_PATH}/tmp/submarine-site.xml"
 
 cp ${SUBMARINE_HOME}/bin/submarine.sh "${CURRENT_PATH}/tmp/"
 

--- a/dev-support/docker-images/submarine/build.sh
+++ b/dev-support/docker-images/submarine/build.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eo pipefail
+
+SUBMARINE_VERSION=0.3.0
+SUBMARINE_IMAGE_NAME="apache/submarine:submarine-${SUBMARINE_VERSION}"
+
+if [ -L ${BASH_SOURCE-$0} ]; then
+  PWD=$(dirname $(readlink "${BASH_SOURCE-$0}"))
+else
+  PWD=$(dirname ${BASH_SOURCE-$0})
+fi
+export CURRENT_PATH=$(cd "${PWD}">/dev/null; pwd)
+export SUBMARINE_HOME=${CURRENT_PATH}/../../..
+
+if [ ! -d "${SUBMARINE_HOME}/submarine-dist/target" ]; then
+  mkdir "${SUBMARINE_HOME}/submarine-dist/target"
+fi
+submarine_dist_exists=$(find -L "${SUBMARINE_HOME}/submarine-dist/target" -name "submarine-dist-${submarine_v}*.tar.gz")
+# Build source code if the package doesn't exist.
+if [[ -z "${submarine_dist_exists}" ]]; then
+  # update tony code
+  if is_empty_dir "${SUBMARINE_HOME}/submodules/tony" ]; then
+    git submodule update --init --recursive
+  else
+    git submodule update --recursive
+  fi
+  cd "${SUBMARINE_HOME}"
+  mvn clean package -DskipTests
+fi
+
+mkdir -p "${CURRENT_PATH}/tmp"
+cp ${SUBMARINE_HOME}/submarine-dist/target/submarine-dist-${SUBMARINE_VERSION}*.tar.gz "${CURRENT_PATH}/tmp"
+
+# Replace the mysql jdbc.url in the submarine-site.xml file with the link name of the submarine container
+# `submarine-database` is submarine database container name
+cp ${SUBMARINE_HOME}/conf/submarine-site.xml "${CURRENT_PATH}/tmp/"
+sed -i ".bak" 's/127.0.0.1:3306/submarine-database:3306/g' "${CURRENT_PATH}/tmp/submarine-site.xml"
+
+cp ${SUBMARINE_HOME}/bin/submarine.sh "${CURRENT_PATH}/tmp/"
+
+# build image
+cd ${CURRENT_PATH}
+echo "Start building the ${SUBMARINE_IMAGE_NAME} docker image ..."
+docker build -t ${SUBMARINE_IMAGE_NAME} .
+
+# clean temp file
+rm -rf "${CURRENT_PATH}/tmp"

--- a/docs/workbench/HowToRun.md
+++ b/docs/workbench/HowToRun.md
@@ -14,29 +14,40 @@
 -->
 # How To Run Submarine Workbench
 
-## Run Workbench
+## Run Submarine on docker
 
-```$xslt
+By using the official image of submarine, only one docker command is required to run submarine workbench.
+
+It should be noted that since the submarine workbench depends on the submarine database, so you need to run the docker container of the submarine database first.
+
+```
+docker run -it -p 3306:3306 -d --name submarine-data -e MYSQL_ROOT_PASSWORD=password apache/submarine:database-0.3.0
+docker run -it -d --link=submarine-data:submarine-data --name submarine-server apache/submarine:submarine-0.3.0
+```
+
+## Run submarine workbench
+
+```
 cd submarine
-./bin/workbench-daemon.sh [start|stop|restart]
+./bin/submarine-daemon.sh [start|stop|restart]
 ```
 To start workbench server, you need to download mysql jdbc jar and put it in the
 path of workbench/lib for the first time. Or you can add parameter, getMysqlJar,
 to get mysql jar automatically.
-```$xslt
+```
 cd submarine
-./bin/workbench-daemon.sh start getMysqlJar
+./bin/submarine-daemon.sh start getMysqlJar
 ```
 
 ## submarine-env.sh
 
-`submarine-env.sh` is automatically executed each time the `workbench.sh` script is executed, so we can set the `workbench.sh` script and the environment variables in the `WorkbenchServer` process via `submarine-env.sh`.
+`submarine-env.sh` is automatically executed each time the `submarine-daemon.sh` script is executed, so we can set the `submarine-daemon.sh` script and the environment variables in the `SubmarineServer` process via `submarine-env.sh`.
 
 | Name                | Variable                                                     |
 | ------------------- | ------------------------------------------------------------ |
 | JAVA_HOME           | Set your java home path, default is `java`.                  |
-| WORKBENCH_JAVA_OPTS | Set the JAVA OPTS parameter when the Workbench process starts. If you need to debug the Workbench process, you can set it to `-agentlib:jdwp=transport=dt_socket, server=y,suspend=n,address=5005` |
-| WORKBENCH_MEM       | Set the java memory parameter when the Workbench process starts. |
+| SUBMARINE_JAVA_OPTS | Set the JAVA OPTS parameter when the submarine workbench process starts. If you need to debug the submarine workbench process, you can set it to `-agentlib:jdwp=transport=dt_socket, server=y,suspend=n,address=5005` |
+| SUBMARINE_MEM       | Set the java memory parameter when the submarine workbench process starts. |
 | MYSQL_JAR_URL       | The customized URL to download mysql jdbc jar.               |
 | MYSQL_VERSION       | The version of mysql jdbc jar to downloaded. The default value is 5.1.39. It's used to generate the default value of MYSQL_JDBC_URL |
 
@@ -46,18 +57,18 @@ cd submarine
 
 | Name                               | Variable                                                     |
 | ---------------------------------- | ------------------------------------------------------------ |
-| workbench.server.addr              | workbench server address, default is `0.0.0.0`               |
-| workbench.server.port              | workbench server port, default `8080`                        |
-| workbench.ssl                      | Should SSL be used by the workbench servers?, default `false` |
-| workbench.server.ssl.port          | Server ssl port. (used when ssl property is set to true), default `8483` |
-| workbench.ssl.client.auth          | Should client authentication be used for SSL connections?    |
-| workbench.ssl.keystore.path        | Path to keystore relative to submarine configuration directory |
-| workbench.ssl.keystore.type        | The format of the given keystore (e.g. JKS or PKCS12)        |
-| workbench.ssl.keystore.password    | Keystore password. Can be obfuscated by the Jetty Password tool |
-| workbench.ssl.key.manager.password | Key Manager password. Defaults to keystore password. Can be obfuscated. |
-| workbench.ssl.truststore.path      | Path to truststore relative to submarine configuration directory. Defaults to the keystore path |
-| workbench.ssl.truststore.type      | The format of the given truststore (e.g. JKS or PKCS12). Defaults to the same type as the keystore type |
-| workbench.ssl.truststore.password  | Truststore password. Can be obfuscated by the Jetty Password tool. Defaults to the keystore password |
+| submarine.server.addr              | submarine server address, default is `0.0.0.0`               |
+| submarine.server.port              | submarine server port, default `8080`                        |
+| submarine.ssl                      | Should SSL be used by the submarine servers?, default `false` |
+| submarine.server.ssl.port          | Server ssl port. (used when ssl property is set to true), default `8483` |
+| submarine.ssl.client.auth          | Should client authentication be used for SSL connections?    |
+| submarine.ssl.keystore.path        | Path to keystore relative to submarine configuration directory |
+| submarine.ssl.keystore.type        | The format of the given keystore (e.g. JKS or PKCS12)        |
+| submarine.ssl.keystore.password    | Keystore password. Can be obfuscated by the Jetty Password tool |
+| submarine.ssl.key.manager.password | Key Manager password. Defaults to keystore password. Can be obfuscated. |
+| submarine.ssl.truststore.path      | Path to truststore relative to submarine configuration directory. Defaults to the keystore path |
+| submarine.ssl.truststore.type      | The format of the given truststore (e.g. JKS or PKCS12). Defaults to the same type as the keystore type |
+| submarine.ssl.truststore.password  | Truststore password. Can be obfuscated by the Jetty Password tool. Defaults to the keystore password |
 | workbench.web.war                  | Submarine workbench web war file path.                       |
 
 
@@ -68,5 +79,5 @@ cd submarine
 
 ```$xslt
 cd submarine/submarine-dist/target/submarine-dist-<version>/submarine-dist-<version>/
-./bin/workbench-daemon.sh [start|stop|restart]
+./bin/submarine-daemon.sh [start|stop|restart]
 ```


### PR DESCRIPTION
### What is this PR for?
In order to enable submarine to support deployment in k8s,
We need to enable each service of subarine to be deployed independently.
The problem that jira solves is that it can run the subarine server independently in docker.
Let users only need a docker command to run the submarine service.
like., 
```
docker run -it -d --link=submarine-database:submarine-database --name submarine apache/submarine:submarine-0.3.0-SNAPSHOT
```

### What type of PR is it?
[Feature]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/SUBMARINE-341

### How should this be tested?
* https://travis-ci.org/liuxunorg/submarine/builds/635308111

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? Yes
