### PR TITLE
Exclude workbench-web-ng/dist and node_modules in source distribution

### DIFF
--- a/submarine-dist/src/assembly/src-distribution.xml
+++ b/submarine-dist/src/assembly/src-distribution.xml
@@ -40,6 +40,8 @@
         <exclude>submarine-workbench/workbench-web/dist/**</exclude>
         <exclude>submarine-workbench/workbench-web/node_modules/**</exclude>
         <exclude>submarine-workbench/workbench-web/node/**</exclude>
+        <exclude>submarine-workbench/workbench-web-ng/dist/**</exclude>
+        <exclude>submarine-workbench/workbench-web-ng/node_modules/**</exclude>
         <!-- until the code that does this is fixed -->
         <exclude>**/*.log</exclude>
         <exclude>**/build/**</exclude>


### PR DESCRIPTION
### What is this PR for?
When generating source tarball of submarine with below command, there's unneeded files zipped in the tarball. The workbench-web-ng/dist and workbench-web-ng/node_modules should be excluded from submarine-dist/src/assembly/src-distribution.xml.
mvn clean install package -DskipTests -Psrc

### What type of PR is it?
Improvement

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-345

### How should this be tested?
mvn clean install package -DskipTests -Psrc
du -sm submarine-dist/target/submarine-dist-0.3.0-SNAPSHOT-src
The size of the dir should be about 30MB

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
