### PR TITLE
SUBMARINE-349. Support using existing artifacts to build mini-submarine image

### DIFF
--- a/dev-support/mini-submarine/Dockerfile
+++ b/dev-support/mini-submarine/Dockerfile
@@ -116,7 +116,7 @@ ENV IMAGE_N=${IMAGE_NAME}
 # Install Submarine
 ARG SUBMARINE_VERSION=
 ENV SUBMARINE_VER=${SUBMARINE_VERSION}
-ADD submarine-dist-${SUBMARINE_VER}*.tar.gz /opt
+ADD submarine-dist-${SUBMARINE_VER}-hadoop*.tar.gz /opt
 ADD pysubmarine /opt/pysubmarine
 RUN ln -s /opt/submarine-dist-${SUBMARINE_VER}* /opt/submarine-current
 ADD submarine /home/yarn/submarine

--- a/dev-support/mini-submarine/README.md
+++ b/dev-support/mini-submarine/README.md
@@ -52,6 +52,24 @@ mvn clean install package -DskipTests
 cd submarine/dev-support/mini-submarine/
 ./build_mini-submarine.sh
 ```
+#### Package An Existing Release Candidates
+When doing release, there will be a need that release manager needs to package a artifact candidatesin this docker image and public the image candidate for a vote.
+In this scenario, you can do this:
+
+Put submarine candidate aritifacts to a folder like "~/releases/submarine-release"
+```
+$ ls $release_candidates_path
+submarine-dist-0.3.0-hadoop-2.9.tar.gz        submarine-dist-0.3.0-src.tar.gz.asc
+submarine-dist-0.3.0-hadoop-2.9.tar.gz.asc    submarine-dist-0.3.0-src.tar.gz.sha512
+submarine-dist-0.3.0-hadoop-2.9.tar.gz.sha512 submarine-dist-0.3.0-src.tar.gz
+```
+```
+export submarine_version=0.3.0
+export release_candidates_path=~/releases/submarine-release 
+./build_mini-submarine.sh
+docker run -it -h submarine-dev --net=bridge --privileged -P local/mini-submarine:0.3.0 /bin/bash
+```
+In the container, we can verify that the submarine jar version is the expected 0.3.0. Then we can upload this image with a "RC" tag for a vote.
 
 ### Run mini-submarine image
 

--- a/dev-support/mini-submarine/README.md
+++ b/dev-support/mini-submarine/README.md
@@ -53,8 +53,8 @@ cd submarine/dev-support/mini-submarine/
 ./build_mini-submarine.sh
 ```
 #### Package An Existing Release Candidates
-When doing release, there will be a need that release manager needs to package a artifact candidatesin this docker image and public the image candidate for a vote.
-In this scenario, you can do this:
+When doing release, the release manager might needs to package a artifact candidatesin this docker image and public the image candidate for a vote.
+In this scenario, we can do this:
 
 Put submarine candidate aritifacts to a folder like "~/releases/submarine-release"
 ```
@@ -67,7 +67,9 @@ submarine-dist-0.3.0-hadoop-2.9.tar.gz.sha512 submarine-dist-0.3.0-src.tar.gz
 export submarine_version=0.3.0
 export release_candidates_path=~/releases/submarine-release 
 ./build_mini-submarine.sh
-docker run -it -h submarine-dev --net=bridge --privileged -P local/mini-submarine:0.3.0 /bin/bash
+#docker run -it -h submarine-dev --net=bridge --privileged -P local/mini-submarine:0.3.0 /bin/bash
+docker tag local/mini-submarine:0.3.0 apache/mini-submarine:0.3.0:RC0
+docker push apache/mini-submarine:0.3.0:RC0
 ```
 In the container, we can verify that the submarine jar version is the expected 0.3.0. Then we can upload this image with a "RC" tag for a vote.
 

--- a/dev-support/mini-submarine/README.md
+++ b/dev-support/mini-submarine/README.md
@@ -53,7 +53,7 @@ cd submarine/dev-support/mini-submarine/
 ./build_mini-submarine.sh
 ```
 #### Package An Existing Release Candidates
-When doing release, the release manager might needs to package a artifact candidatesin this docker image and public the image candidate for a vote.
+When doing release, the release manager might needs to package a artifact candidates in this docker image and public the image candidate for a vote.
 In this scenario, we can do this:
 
 Put submarine candidate aritifacts to a folder like "~/releases/submarine-release"

--- a/dev-support/mini-submarine/build_mini-submarine.sh
+++ b/dev-support/mini-submarine/build_mini-submarine.sh
@@ -17,10 +17,7 @@ set -e
 hadoop_v=2.9.2
 spark_v=2.4.4
 
-submarine_v=$submarine_version
-if [[ -z $submarine_v ]]; then
-  submarine_v=0.3.0-SNAPSHOT
-fi
+submarine_v=${submarine_version:-"0.3.0-SNAPSHOT"}
 echo "Using submarine version: $submarine_v"
 
 image_name="local/mini-submarine:${submarine_v}"

--- a/dev-support/mini-submarine/submarine/run_customized_submarine-all_mnist.sh
+++ b/dev-support/mini-submarine/submarine/run_customized_submarine-all_mnist.sh
@@ -49,7 +49,11 @@ else
   WORKER_CMD="myvenv.zip/venv/bin/python mnist_distributed.py --steps 2 --data_dir /tmp/data --working_dir /tmp/mode"
 fi
 
-SUBMARINE_VERSION=0.3.0-SNAPSHOT
+SUBMARINE_VERSION=$SUBMARINE_VER
+if [[ -z $SUBMARINE_VER ]]; then
+  SUBMARINE_VERSION=0.3.0-SNAPSHOT
+fi
+
 HADOOP_VERSION=2.9
 
 ${JAVA_CMD} -cp /tmp/submarine-all-${SUBMARINE_VERSION}-hadoop-${HADOOP_VERSION}.jar:/usr/local/hadoop/etc/hadoop \

--- a/dev-support/mini-submarine/submarine/run_customized_submarine-all_mnist.sh
+++ b/dev-support/mini-submarine/submarine/run_customized_submarine-all_mnist.sh
@@ -49,10 +49,7 @@ else
   WORKER_CMD="myvenv.zip/venv/bin/python mnist_distributed.py --steps 2 --data_dir /tmp/data --working_dir /tmp/mode"
 fi
 
-SUBMARINE_VERSION=$SUBMARINE_VER
-if [[ -z $SUBMARINE_VER ]]; then
-  SUBMARINE_VERSION=0.3.0-SNAPSHOT
-fi
+SUBMARINE_VERSION=${SUBMARINE_VER:-"0.3.0-SNAPSHOT"}
 
 HADOOP_VERSION=2.9
 

--- a/dev-support/mini-submarine/submarine/run_submarine_mnist_tony.sh
+++ b/dev-support/mini-submarine/submarine/run_submarine_mnist_tony.sh
@@ -17,8 +17,10 @@
 
 # Below are configurable variables, please adapt base on your local environment.
 # Version of submarine jar
-SUBMARINE_VERSION=0.3.0-SNAPSHOT
-
+SUBMARINE_VERSION=$SUBMARINE_VER
+if [[ -z $SUBMARINE_VER ]]; then
+  SUBMARINE_VERSION=0.3.0-SNAPSHOT
+fi
 # Version of affiliated Hadoop version for this Submarine jar.
 SUBMARINE_HADOOP_VERSION=2.9
 
@@ -74,7 +76,7 @@ else
   WORKER_CMD="myvenv.zip/$WORKER_CMD"
 fi
 
-${JAVA_CMD} -cp $(${HADOOP_HOME}/bin/hadoop classpath --glob):${SUBMARINE_PATH}/submarine-all-${SUBMARINE_VERSION}-hadoop-${SUBMARINE_HADOOP_VERSION}.jar:${HADOOP_CONF_PATH} \
+${JAVA_CMD} -cp $(${HADOOP_COMMON_HOME}/bin/hadoop classpath --glob):${SUBMARINE_PATH}/submarine-all-${SUBMARINE_VERSION}-hadoop-${SUBMARINE_HADOOP_VERSION}.jar:${HADOOP_CONF_PATH} \
  org.apache.submarine.client.cli.Cli job run --name tf-job-001 \
  --framework tensorflow \
  --verbose \

--- a/dev-support/mini-submarine/submarine/run_submarine_mnist_tony.sh
+++ b/dev-support/mini-submarine/submarine/run_submarine_mnist_tony.sh
@@ -17,10 +17,8 @@
 
 # Below are configurable variables, please adapt base on your local environment.
 # Version of submarine jar
-SUBMARINE_VERSION=$SUBMARINE_VER
-if [[ -z $SUBMARINE_VER ]]; then
-  SUBMARINE_VERSION=0.3.0-SNAPSHOT
-fi
+SUBMARINE_VERSION=${SUBMARINE_VER:-"0.3.0-SNAPSHOT"}
+
 # Version of affiliated Hadoop version for this Submarine jar.
 SUBMARINE_HADOOP_VERSION=2.9
 

--- a/dev-support/mini-submarine/submarine/run_submarine_mnist_tony_rpc.sh
+++ b/dev-support/mini-submarine/submarine/run_submarine_mnist_tony_rpc.sh
@@ -47,10 +47,7 @@ else
   WORKER_CMD="myvenv.zip/venv/bin/python mnist_distributed.py --steps 2 --data_dir /tmp/data --working_dir /tmp/mode"
 fi 
 
-SUBMARINE_VERSION=$SUBMARINE_VER
-if [[ -z $SUBMARINE_VER ]]; then
-  SUBMARINE_VERSION=0.3.0-SNAPSHOT
-fi
+SUBMARINE_VERSION=${SUBMARINE_VER:-"0.3.0-SNAPSHOT"}
 
 HADOOP_VERSION=2.9
 

--- a/dev-support/mini-submarine/submarine/run_submarine_mnist_tony_rpc.sh
+++ b/dev-support/mini-submarine/submarine/run_submarine_mnist_tony_rpc.sh
@@ -47,7 +47,11 @@ else
   WORKER_CMD="myvenv.zip/venv/bin/python mnist_distributed.py --steps 2 --data_dir /tmp/data --working_dir /tmp/mode"
 fi 
 
-SUBMARINE_VERSION=0.3.0-SNAPSHOT
+SUBMARINE_VERSION=$SUBMARINE_VER
+if [[ -z $SUBMARINE_VER ]]; then
+  SUBMARINE_VERSION=0.3.0-SNAPSHOT
+fi
+
 HADOOP_VERSION=2.9
 
 ${JAVA_CMD} -cp /opt/submarine-dist-${SUBMARINE_VERSION}-hadoop-${HADOOP_VERSION}/submarine-all-${SUBMARINE_VERSION}-hadoop-${HADOOP_VERSION}.jar:/usr/local/hadoop/etc/hadoop:/opt/submarine-dist-${SUBMARINE_VERSION}-hadoop-${HADOOP_VERSION}/conf \


### PR DESCRIPTION
### What is this PR for?
The hard-coded submarine version(0.3.0-SNAPSHOT) in build_mini-submarine.sh is not convenient. When doing a release, we need the image to package a candidate artifacts like 0.3.0.
This JIRA is for extending the build script to package specified artifacts. Setting environment variable submarine_version and release_candidates_path can trigger this code path.
It will copy binary tarball with the submarine_version to the local dir and build the image.

### What type of PR is it?
Improvement

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-349

### How should this be tested?
Put submarine candidate aritifacts to a folder like "~/releases/submarine-release"
$ ls $release_candidates_path
submarine-dist-0.3.0-hadoop-2.9.tar.gz        submarine-dist-0.3.0-src.tar.gz.asc
submarine-dist-0.3.0-hadoop-2.9.tar.gz.asc    submarine-dist-0.3.0-src.tar.gz.sha512
submarine-dist-0.3.0-hadoop-2.9.tar.gz.sha512 submarine-dist-0.3.0-src.tar.gz

export submarine_version=0.3.0
export release_candidates_path=~/releases/submarine-release 
./build_mini-submarine.sh
docker run -it -h submarine-dev --net=bridge --privileged -P local/mini-submarine:0.3.0 /bin/bash
In the container, check the submarine jar version is 0.3.0

### Questions:
* Does the licenses files need an update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? Yes
