### PR TITLE
SUBMARINE-356. ParameterProto should support getOptionValue method

### DIFF
--- a/submarine-client/src/main/java/org/apache/submarine/client/cli/param/ParametersHolder.java
+++ b/submarine-client/src/main/java/org/apache/submarine/client/cli/param/ParametersHolder.java
@@ -461,4 +461,32 @@ public final class ParametersHolder implements Parameter {
     this.parameters = parameters;
     return this;
   }
+
+  public CommandLine getParsedCommandLine() {
+    return parsedCommandLine;
+  }
+
+  public Parameter setParsedCommandLine(CommandLine parsedCommandLine) {
+    this.parsedCommandLine = parsedCommandLine;
+    return this;
+  }
+
+  public Map<String, String> getYamlStringConfigs() {
+    return yamlStringConfigs;
+  }
+
+  public Parameter setYamlStringConfigs(Map<String, String> yamlStringConfigs) {
+    this.yamlStringConfigs = yamlStringConfigs;
+    return this;
+  }
+
+  public Map<String, List<String>> getYamlListConfigs() {
+    return yamlListConfigs;
+  }
+
+  public Parameter setYamlListConfigs(
+      Map<String, List<String>> yamlListConfigs) {
+    this.yamlListConfigs = yamlListConfigs;
+    return this;
+  }
 }

--- a/submarine-client/src/main/java/org/apache/submarine/client/cli/runjob/RunJobCli.java
+++ b/submarine-client/src/main/java/org/apache/submarine/client/cli/runjob/RunJobCli.java
@@ -321,6 +321,7 @@ public class RunJobCli extends AbstractCli {
 
     parseCommandLineAndGetRunJobParameters(args);
     ApplicationId applicationId = jobSubmitter.submitJob(parametersHolder);
+    LOG.info("Submarine job is submitted, the job id is " + applicationId);
     RunJobParameters parameters =
         (RunJobParameters) parametersHolder.getParameters();
     storeJobInformation(parameters, applicationId, args);

--- a/submarine-commons/commons-rpc/src/main/proto/SubmarineServerProtocol.proto
+++ b/submarine-commons/commons-rpc/src/main/proto/SubmarineServerProtocol.proto
@@ -60,7 +60,15 @@ message ParameterProto {
   TensorFlowRunJobParameterProto tensorflow_run_job_parameter = 3;
   ShowJobParameterProto show_job_parameter = 4;
   map<string, string> submarine_job_config_map = 5;
+  CommandLineProto command_line = 6;
+  map<string, string> yaml_string_configs = 7;
+  map<string, ListOfString> yaml_list_configs = 8;
 }
+
+message ListOfString {
+   repeated string values = 1;
+}
+
 
 message ResourceProto {
   map<string, int64> resource_map = 1;
@@ -126,4 +134,14 @@ message ShowJobParameterProto {
 message ApplicationIdProto {
   // One corner of the rectangle.
   string application_id = 1;
+}
+
+message CommandLineProto {
+  repeated OptionProto options = 1;
+}
+
+message OptionProto {
+  string opt = 1;
+  string long_opt = 2;
+  repeated string values = 3;
 }


### PR DESCRIPTION
### What is this PR for?
To enable yaml configuration, the method of getOptionValue in ParameterHolder is used to keep job configuration.  ParameterProto should support this method as well.

### What type of PR is it?
Bug Fix

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-356

### How should this be tested?
https://travis-ci.org/yuanzac/hadoop-submarine/builds/639866700?utm_source=github_status&utm_medium=notification

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
