### PR TITLE
SUBMARINE-355. mvn version:set seems not working as expected

### DIFF
--- a/submarine-all/pom.xml
+++ b/submarine-all/pom.xml
@@ -32,13 +32,6 @@
   <version>0.3.0-SNAPSHOT</version>
   <name>Submarine: All</name>
 
-  <properties>
-    <!-- Needed for generating FindBugs warnings using parent pom -->
-    <!--yarn.basedir>${project.parent.parent.basedir}</yarn.basedir-->
-    <project.artifactId>submarine-all</project.artifactId>
-    <project.version>0.3.0-SNAPSHOT</project.version>
-  </properties>
-
   <dependencyManagement>
     <dependencies>
       <dependency>

--- a/submarine-dist/pom.xml
+++ b/submarine-dist/pom.xml
@@ -28,16 +28,10 @@
     <version>0.3.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
-  <artifactId>${project.artifactId}</artifactId>
-  <version>${project.version}</version>
+  <artifactId>submarine-dist</artifactId>
+  <version>0.3.0-SNAPSHOT</version>
   <name>Submarine: Dist</name>
   <packaging>pom</packaging>
-
-  <properties>
-    <!-- Needed for generating FindBugs warnings using parent pom -->
-    <project.artifactId>submarine-dist</project.artifactId>
-    <project.version>0.3.0-SNAPSHOT</project.version>
-  </properties>
 
   <dependencyManagement>
     <dependencies>


### PR DESCRIPTION
### What is this PR for?
Restore missing submarine-all-0.3.0-hadoop-2.9.jar

### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-355

### How should this be tested?
https://travis-ci.org/pingsutw/hadoop-submarine/builds/639891729

### Screenshots (if appropriate)
![Screenshot from 2020-01-21 19-12-18](https://user-images.githubusercontent.com/37936015/72800610-b77c1980-3c82-11ea-8f07-36a16571356f.png)


### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
