### PR TITLE
SUBMARINE-373. Upgrade cluster module dependent library

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@
     <derby.version>10.15.1.3</derby.version>
     <zeppelin.version>0.9.0-SNAPSHOT</zeppelin.version>
     <jgit.version>5.5.1.201910021850-r</jgit.version>
-    <atomix.version>3.0.0-rc4</atomix.version>
+    <atomix.version>3.1.5</atomix.version>
     <spark.scala.version>2.11.8</spark.scala.version>
     <spark.scala.binary.version>2.11</spark.scala.binary.version>
     <hive.version>2.3.6</hive.version>
@@ -138,7 +138,8 @@
   <modules>
     <module>submarine-commons</module>
     <module>submarine-client</module>
-    <module>submarine-cloud</module>
+    <!-- There is a problem with the submarine-cloud pom, the compilation is very slow, and it is temporarily closed
+    <module>submarine-cloud</module-->
     <module>submodules/tony</module>
     <module>submarine-server</module>
     <module>submarine-all</module>

--- a/submarine-commons/commons-cluster/src/main/java/org/apache/submarine/commons/cluster/UnicastServiceAdapter.java
+++ b/submarine-commons/commons-cluster/src/main/java/org/apache/submarine/commons/cluster/UnicastServiceAdapter.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.submarine.commons.cluster;
+
+import io.atomix.cluster.messaging.UnicastService;
+import io.atomix.utils.net.Address;
+
+import java.util.concurrent.Executor;
+import java.util.function.BiConsumer;
+
+public class UnicastServiceAdapter implements UnicastService {
+  @Override
+  public void unicast(Address address, String subject, byte[] message) {
+
+  }
+
+  @Override
+  public void addListener(String subject, BiConsumer<Address, byte[]> listener, Executor executor) {
+
+  }
+
+  @Override
+  public void removeListener(String subject, BiConsumer<Address, byte[]> listener) {
+
+  }
+}

--- a/submarine-commons/commons-metastore/pom.xml
+++ b/submarine-commons/commons-metastore/pom.xml
@@ -330,6 +330,14 @@
                   <pattern>com.google</pattern>
                   <shadedPattern>${shaded.dependency.prefix}.com.google</shadedPattern>
                 </relocation>
+                <relocation>
+                  <pattern>org.eclipse.jetty</pattern>
+                  <shadedPattern>${shaded.dependency.prefix}.org.eclipse.jetty</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>javax.ws.rs.core</pattern>
+                  <shadedPattern>${shaded.dependency.prefix}.javax.ws.rs.core</shadedPattern>
+                </relocation>
               </relocations>
             </configuration>
           </execution>

--- a/submarine-dist/src/assembly/distribution.xml
+++ b/submarine-dist/src/assembly/distribution.xml
@@ -166,7 +166,7 @@
         <exclude>mysql-connector-java-*.jar</exclude>
         <!-- atomix & netty-4.1.27.Final already shade in submarine-commons-cluster-${project.version}-shade.jar -->
         <exclude>atomix-*.jar</exclude>
-        <exclude>netty-*-4.1.27.Final.jar</exclude>
+        <exclude>netty-*-4.1.27.Final*.jar</exclude>
       </excludes>
     </fileSet>
     <fileSet>

--- a/submarine-dist/src/assembly/distribution.xml
+++ b/submarine-dist/src/assembly/distribution.xml
@@ -91,7 +91,14 @@
       <directory>../submarine-commons/commons-cluster/target</directory>
       <outputDirectory>/lib</outputDirectory>
       <includes>
-        <include>submarine-commons-cluster-${project.version}.jar</include>
+        <include>submarine-commons-cluster-${project.version}-shade.jar</include>
+      </includes>
+    </fileSet>
+    <fileSet>
+      <directory>../submarine-commons/commons-metastore/target</directory>
+      <outputDirectory>/lib</outputDirectory>
+      <includes>
+        <include>submarine-commons-metastore-${project.version}-shade.jar</include>
       </includes>
     </fileSet>
     <fileSet>
@@ -152,10 +159,14 @@
         <exclude>commons-runtime-${project.version}.jar</exclude>
         <exclude>commons-cluster-${project.version}.jar</exclude>
         <exclude>commons-rpc-${project.version}.jar</exclude>
+        <exclude>commons-metastore-${project.version}.jar</exclude>
         <exclude>grpc-*.jar</exclude>
         <exclude>protobuf-java*.jar</exclude>
         <!-- mysql-connector-java uses the GPL license. So we need exclude mysql-connector-java jar -->
         <exclude>mysql-connector-java-*.jar</exclude>
+        <!-- atomix & netty-4.1.27.Final already shade in submarine-commons-cluster-${project.version}-shade.jar -->
+        <exclude>atomix-*.jar</exclude>
+        <exclude>netty-*-4.1.27.Final.jar</exclude>
       </excludes>
     </fileSet>
     <fileSet>


### PR DESCRIPTION
### What is this PR for?
The atomix raft library used by the submarine cluster module is version 3.0, 
Need to know the list of all servers ip in the cluster to create a cluster.

In the k8s environment, since the IP of the POD is not fixed, we need to upgrade to the atomix-3.1.0 + version and create a cluster through broadcast discovery.


### What type of PR is it?
[Refactoring]

### Todos
* [ ] - Create a cluster through broadcast discovery.

### What is the Jira issue?
* https://issues.apache.org/jira/browse/SUBMARINE-373

### How should this be tested?
* https://travis-ci.org/liuxunorg/submarine/builds/645828692

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
