### PR TITLE
SUBMARINE-381. Temporarily disable interpreter module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ env:
     # If you need to compile Phadoop-3.1 or Phadoop-3.2, you need to add `!submarine-server/server-submitter/submitter-yarnservice` in EXCLUDE_SUBMARINE
     - EXCLUDE_SUBMARINE="!submarine-all,!submarine-client,!submarine-commons,!submarine-commons/commons-runtime,!submarine-dist,!submarine-server/server-submitter/submitter-yarn,!submarine-server/server-core,!submarine-server/server-rpc"
     - EXCLUDE_WORKBENCH="!submarine-workbench,!submarine-workbench/workbench-web,!submarine-workbench/workbench-web-ng"
-    - EXCLUDE_INTERPRETER="!submarine-workbench/interpreter,!submarine-workbench/interpreter/interpreter-engine,!submarine-workbench/interpreter/python-interpreter,!submarine-workbench/interpreter/spark-interpreter"
+    - EXCLUDE_INTERPRETER="" # Template disable by SUBMARINE-381 "!submarine-workbench/interpreter,!submarine-workbench/interpreter/interpreter-engine,!submarine-workbench/interpreter/python-interpreter,!submarine-workbench/interpreter/spark-interpreter
     - EXCLUDE_K8S="!submarine-server/server-submitter/submitter-k8s"
     - EXCLUDE_COMMON_RPC="!submarine-commons/commons-rpc"
     - MOZ_HEADLESS=1
@@ -157,12 +157,6 @@ matrix:
         - yarn run lint --no-fix && yarn run build
       env: NAME="Build workbench-web"
 
-    - name: Test submarine workbench-web VUE
-      language: java
-      jdk: "openjdk8"
-      dist: xenial
-      env: PROFILE="-Phadoop-2.9" BUILD_FLAG="clean package install -DskipTests" TEST_FLAG="test -DskipRat -am" MODULES="-pl org.apache.submarine:workbench-web" TEST_MODULES="-pl org.apache.submarine:workbench-web" TEST_PROJECTS=""
-
     - name: Test submarine test-e2e
       language: java
       jdk: "openjdk8"
@@ -171,11 +165,12 @@ matrix:
         chrome: stable
       env: PROFILE="-Phadoop-2.9" BUILD_FLAG="clean package -DskipTests" TEST_FLAG="verify -DskipRat -am" TEST_MODULES="-pl submarine-test/e2e" TEST_PROJECTS=""
 
-    - name: Test submarine interpreter
-      language: java
-      jdk: "openjdk8"
-      dist: xenial
-      env: PYTHON="3" PROFILE="-Phadoop-2.9" BUILD_FLAG="clean package install -DskipTests" TEST_FLAG="test -DskipRat -am" MODULES="-pl ${EXCLUDE_K8S},${EXCLUDE_SUBMARINE},${EXCLUDE_WORKBENCH}" TEST_MODULES="-pl $(echo ${EXCLUDE_INTERPRETER} | sed 's/!//g')" TEST_PROJECTS=""
+    # Template disable by SUBMARINE-381
+    #- name: Test submarine interpreter
+    #  language: java
+    #  jdk: "openjdk8"
+    #  dist: xenial
+    #  env: PYTHON="3" PROFILE="-Phadoop-2.9" BUILD_FLAG="clean package install -DskipTests" TEST_FLAG="test -DskipRat -am" MODULES="-pl ${EXCLUDE_K8S},${EXCLUDE_SUBMARINE},${EXCLUDE_WORKBENCH}" TEST_MODULES="-pl $(echo ${EXCLUDE_INTERPRETER} | sed 's/!//g')" TEST_PROJECTS=""
 
     - name: Test submarine-sdk
       language: python

--- a/bin/submarine-daemon.sh
+++ b/bin/submarine-daemon.sh
@@ -39,7 +39,6 @@ SUBMARINE_SERVER_MAIN=org.apache.submarine.server.SubmarineServer
 JAVA_OPTS+="${SUBMARINE_SERVER_JAVA_OPTS} ${SUBMARINE_SERVER_MEM} -Dsubmarine.log.file=${SUBMARINE_SERVER_LOGFILE}"
 
 add_jar_in_dir "${BIN}/../lib"
-add_jar_in_dir "${BIN}/../lib/submitter"
 
 function initialize_default_directories() {
   if [[ ! -d "${SUBMARINE_LOG_DIR}" ]]; then

--- a/bin/submarine.sh
+++ b/bin/submarine.sh
@@ -49,7 +49,6 @@ SUBMARINE_SERVER_MAIN=org.apache.submarine.server.SubmarineServer
 JAVA_OPTS+="${SUBMARINE_SERVER_JAVA_OPTS:-""} ${SUBMARINE_SERVER_MEM:-""} -Dsubmarine.log.file=${SUBMARINE_SERVER_LOGFILE}"
 
 add_jar_in_dir "${BIN}/../lib"
-add_jar_in_dir "${BIN}/../lib/submitter"
 
 if [[ ! -d "${SUBMARINE_LOG_DIR}" ]]; then
   echo "Log dir doesn't exist, create ${SUBMARINE_LOG_DIR}"

--- a/pom.xml
+++ b/pom.xml
@@ -494,6 +494,7 @@
             <exclude>NOTICE-binary</exclude>
             <exclude>**/go.mod</exclude>
             <exclude>**/go.sum</exclude>
+            <exclude>**/workbench-web/**</exclude>
           </excludes>
         </configuration>
       </plugin>

--- a/submarine-commons/commons-cluster/pom.xml
+++ b/submarine-commons/commons-cluster/pom.xml
@@ -156,6 +156,12 @@
                   </excludes>
                 </filter>
               </filters>
+              <artifactSet>
+                <excludes>
+                  <exclude>org.slf4j:*</exclude>
+                  <exclude>log4j:log4j</exclude>
+                </excludes>
+              </artifactSet>
               <transformers>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                   <mainClass>org.apache.submarine.interpreter.AbstractInterpreter</mainClass>
@@ -165,7 +171,7 @@
               <relocations>
                 <relocation>
                   <pattern>org</pattern>
-                  <shadedPattern>${shaded.dependency.prefix}.org</shadedPattern>
+                  <shadedPattern>${shaded.dependency.prefix}.cluster.org</shadedPattern>
                   <excludes>
                     <exclude>org/apache/submarine/*</exclude>
                     <exclude>org/apache/submarine/**/*</exclude>
@@ -177,6 +183,8 @@
                     <exclude>org/apache/commons/logging/**/*</exclude>
                     <exclude>org/apache/commons/exec/*</exclude>
                     <exclude>org/apache/commons/exec/**/*</exclude>
+                    <exclude>org/apache/commons/collections/*</exclude>
+                    <exclude>org/apache/commons/collections/**/*</exclude>
                     <exclude>org/apache/log4j/*</exclude>
                     <exclude>org/apache/log4j/**/*</exclude>
                     <exclude>org/sonatype/*</exclude>
@@ -194,15 +202,15 @@
                 </relocation>
                 <relocation>
                   <pattern>com.google</pattern>
-                  <shadedPattern>${shaded.dependency.prefix}.com.google</shadedPattern>
+                  <shadedPattern>${shaded.dependency.prefix}.cluster.com.google</shadedPattern>
                 </relocation>
                 <relocation>
                   <pattern>io</pattern>
-                  <shadedPattern>${shaded.dependency.prefix}.io</shadedPattern>
+                  <shadedPattern>${shaded.dependency.prefix}.cluster.io</shadedPattern>
                 </relocation>
                 <relocation>
                   <pattern>com.esotericsoftware</pattern>
-                  <shadedPattern>${shaded.dependency.prefix}.com.esotericsoftware</shadedPattern>
+                  <shadedPattern>${shaded.dependency.prefix}.cluster.com.esotericsoftware</shadedPattern>
                 </relocation>
               </relocations>
             </configuration>

--- a/submarine-commons/commons-metastore/pom.xml
+++ b/submarine-commons/commons-metastore/pom.xml
@@ -325,18 +325,36 @@
                   </excludes>
                 </filter>
               </filters>
+              <artifactSet>
+                <excludes>
+                  <exclude>org.slf4j:*</exclude>
+                  <exclude>log4j:log4j</exclude>
+                </excludes>
+              </artifactSet>
               <relocations>
                 <relocation>
                   <pattern>com.google</pattern>
-                  <shadedPattern>${shaded.dependency.prefix}.com.google</shadedPattern>
+                  <shadedPattern>${shaded.dependency.prefix}.metastore.com.google</shadedPattern>
                 </relocation>
                 <relocation>
                   <pattern>org.eclipse.jetty</pattern>
-                  <shadedPattern>${shaded.dependency.prefix}.org.eclipse.jetty</shadedPattern>
+                  <shadedPattern>${shaded.dependency.prefix}.metastore.org.eclipse.jetty</shadedPattern>
                 </relocation>
                 <relocation>
-                  <pattern>javax.ws.rs.core</pattern>
-                  <shadedPattern>${shaded.dependency.prefix}.javax.ws.rs.core</shadedPattern>
+                  <pattern>javax</pattern>
+                  <shadedPattern>${shaded.dependency.prefix}.metastore.javax</shadedPattern>
+                  <excludes>
+                    <exclude>javax.xml/*</exclude>
+                    <exclude>javax.xml/**/*</exclude>
+                  </excludes>
+                </relocation>
+                <relocation>
+                  <pattern>io.netty</pattern>
+                  <shadedPattern>${shaded.dependency.prefix}.metastore.io.netty</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.apache.hadoop</pattern>
+                  <shadedPattern>${shaded.dependency.prefix}.metastore.org.apache.hadoop</shadedPattern>
                 </relocation>
               </relocations>
             </configuration>

--- a/submarine-commons/commons-rpc/pom.xml
+++ b/submarine-commons/commons-rpc/pom.xml
@@ -125,7 +125,11 @@
               <relocations>
                 <relocation>
                   <pattern>com.google.protobuf</pattern>
-                  <shadedPattern>submarine.commons.rpc.com.google.protobuf</shadedPattern>
+                  <shadedPattern>${shaded.dependency.prefix}.rpc.com.google.protobuf</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>com.google.common</pattern>
+                  <shadedPattern>${shaded.dependency.prefix}.rpc.com.google.common</shadedPattern>
                 </relocation>
               </relocations>
             </configuration>

--- a/submarine-workbench/pom.xml
+++ b/submarine-workbench/pom.xml
@@ -38,6 +38,7 @@
 
   <modules>
     <!--module>interpreter</module-->
+    <module>workbench-web</module>
     <module>workbench-web-ng</module>
   </modules>
 

--- a/submarine-workbench/pom.xml
+++ b/submarine-workbench/pom.xml
@@ -37,8 +37,7 @@
   <description>Submarine Workbench</description>
 
   <modules>
-    <module>interpreter</module>
-    <module>workbench-web</module>
+    <!--module>interpreter</module-->
     <module>workbench-web-ng</module>
   </modules>
 


### PR DESCRIPTION
### What is this PR for?
1. Temporarily disable the interpreter module
submarine currently depends the zeppelin-0.9.0-SNAPSHORT version of the interpreter,
Perform python syntax execution.
As zeppelin is ready to officially release version 0.9, the zeppelin-0.9.0-SNAPSHORT version of the interpreter has been removed from the apache mvn repo.
Therefore, the submarine needs to temporarily block the submarine-interpreter. Otherwise, in travis, it will fail because it cannot download the zeppelin-0.9.0-SNAPSHORT interpreter.
After zeppelin 0.9 is released, it will be reintroduced.

2. Fixed travis failure problem


### What type of PR is it?
[Refactoring]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/SUBMARINE-381

### How should this be tested?
* https://travis-ci.org/liuxunorg/submarine/builds/648053292

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
