### PR TITLE
SUBMARINE-344. Support update submarine site in CICD image

### DIFF
--- a/dev-support/cicd/Dockerfile
+++ b/dev-support/cicd/Dockerfile
@@ -36,4 +36,15 @@ ADD \
 ENV \
   SUBMARINE_HOME=/submarine \
   PYTHON_VENV_PATH=/root
+
+RUN apt-get update && apt-get -y install bundler
+
+RUN \
+  cd / && \
+  git clone https://gitbox.apache.org/repos/asf/submarine-site.git && \
+  cd /submarine-site && bundle update
+
+ENV \
+  SUBMARINE_SITE=/submarine-site
+
 CMD /entry.sh

--- a/dev-support/cicd/README.md
+++ b/dev-support/cicd/README.md
@@ -45,22 +45,21 @@ export APACHE_NAME='Your apache name'
 
 And you'll see output like below and then you can decide what to accomplish.
 ```
-$ docker run -it -e JIRA_USERNAME="${JIRA_USERNAME}" -e JIRA_PASSWORD="${JIRA_PASSWORD}" -e APACHE_ID="${APACHE_ID}" -e APACHE_NAME="${APACHE_NAME}" --rm submarine-cicd
+$ docker run -it -e JIRA_USERNAME="${JIRA_USERNAME}" -e JIRA_PASSWORD="${JIRA_PASSWORD}" -e APACHE_ID="${APACHE_ID}" -e APACHE_NAME="${APACHE_NAME}" -p 4000:4000 --rm submarine-cicd
 ```
 
 The screen outputs the following information: 
 
 ```
 Menu:
-    1. Merge PR
-Enter Menu ID:1
-==== Merge PR Begin ====
-Got JIRA name: username
-
-Enter Your Apache committer ID:
+	1. Merge PR
+	2. Update Submarine Website
+Enter Menu ID:
 ```
 
-## Manual mode
+As you can see, the Docker mode support several features like merging PR and updating the web site. Choose the task you need to do and follow the popup tip to go on.
+
+## Manual mode (Not Recommended)
 
 First, You need install `python 2.7.13` and `pip insall jira`
 

--- a/dev-support/cicd/build_and_start_cicd_image.sh
+++ b/dev-support/cicd/build_and_start_cicd_image.sh
@@ -18,4 +18,4 @@ set -e
 printf "Building Submarine CI/CD Image.\n"
 docker build -t submarine-cicd .
 printf "Start Submarine CI/CD.\n"
-docker run -it --rm submarine-cicd
+docker run -it --rm -p 4000:4000 submarine-cicd

--- a/dev-support/cicd/entry.sh
+++ b/dev-support/cicd/entry.sh
@@ -71,8 +71,8 @@ function merge_pr(){
   echo "Got Apache name: ${apache_name}"
 
   cd $SUBMARINE_HOME
-  git pull
   git checkout master
+  git pull
   git config user.name "${apache_name}"
   git config user.email "${apache_id}@apache.org"
   export JIRA_USERNAME=${jira_name}
@@ -102,8 +102,8 @@ function update_submarine_site(){
   echo "Got Apache name: ${apache_name}"
 
   cd $SUBMARINE_SITE
-  git pull
   git checkout master
+  git pull
   git config user.name "${apache_name}"
   git config user.email "${apache_id}@apache.org"
   git config credential.helper store

--- a/dev-support/cicd/entry.sh
+++ b/dev-support/cicd/entry.sh
@@ -72,6 +72,7 @@ function merge_pr(){
 
   cd $SUBMARINE_HOME
   git pull
+  git checkout master
   git config user.name "${apache_name}"
   git config user.email "${apache_id}@apache.org"
   export JIRA_USERNAME=${jira_name}
@@ -102,6 +103,7 @@ function update_submarine_site(){
 
   cd $SUBMARINE_SITE
   git pull
+  git checkout master
   git config user.name "${apache_name}"
   git config user.email "${apache_id}@apache.org"
   git config credential.helper store
@@ -149,6 +151,7 @@ function update_submarine_site(){
     esac
   done
   printf "\n"
+  printf "==== Update Submarine Site END ====\n"
   echo "==== Enter shell again incase any unexpected error happens ===="
   bash
   echo "Exiting CICD.."

--- a/dev-support/cicd/entry.sh
+++ b/dev-support/cicd/entry.sh
@@ -20,10 +20,14 @@ set -e
 function start_menu(){
   printf "Menu:\n"
   printf "\t1. Merge PR\n"
+  printf "\t2. Update Submarine Website\n"
   read -p "Enter Menu ID:" menu_id
   case $menu_id in
     "1")
       merge_pr
+    ;;
+    "2")
+      update_submarine_site
     ;;
     "*")
       printf "unknown. Exiting."
@@ -74,6 +78,80 @@ function merge_pr(){
   export JIRA_PASSWORD=${jira_pwd}
   python dev-support/cicd/merge_submarine_pr.py
   printf "==== Merge PR END ====\n"
+}
+
+function update_submarine_site(){
+  printf "==== Update Submarine Site Begin ====\n"
+  apache_id="id"
+  apache_name="name"
+
+  if [ -z "$APACHE_ID" ]; then
+    printf "\n"
+    read -p "Enter Your Apache committer ID: "  apache_id
+  else
+    apache_id=$APACHE_ID
+  fi
+  echo "Got Apache ID: ${apache_id}"
+
+  if [ -z "$APACHE_NAME" ]; then
+    read -p "Enter Your Apache committer name: "  apache_name
+  else
+    apache_name=$APACHE_NAME
+  fi
+  echo "Got Apache name: ${apache_name}"
+
+  cd $SUBMARINE_SITE
+  git pull
+  git config user.name "${apache_name}"
+  git config user.email "${apache_id}@apache.org"
+  git config credential.helper store
+  bundle update
+  bundle exec jekyll serve --watch --host=0.0.0.0 > /tmp/jekyll.log 2>&1 &
+  echo "==== Please use vim to edit md files and check http://localhost:4000/ for the update ===="
+  while true; do
+    echo "==== Edit Mode: Type 'exit' when you finish the changes (you don't need to perform git commit/push). ===="
+    bash
+    read -p "Have you finished updating the MD files? y/n/quit " commit
+    case $commit in
+      "y")
+        echo "Start committing changes.."
+        cd $SUBMARINE_SITE
+        git add .
+        git status
+        read -p "Please input the commit message: " message
+        git commit -m "${message} (master branch)"
+        git push origin master
+        cp -r _site /_site
+        git checkout asf-site
+        cp -r /_site/* ./
+        git add .
+        git status
+        git commit -m "${message} (asf-site branch)"
+        git push origin asf-site
+        echo "Exiting edit mode.."
+        break
+      ;;
+      "n")
+        continue
+      ;;
+      "quit")
+        printf "Exiting edit mode.."
+        break
+      ;;
+      "q")
+        printf "Exiting edit mode.."
+        break
+      ;;
+      "*")
+        printf "Unknown. Exiting edit mode.."
+        break
+      ;;
+    esac
+  done
+  printf "\n"
+  echo "==== Enter shell again incase any unexpected error happens ===="
+  bash
+  echo "Exiting CICD.."
 }
 
 start_menu


### PR DESCRIPTION
### What is this PR for?
Support update submarine site in CICD image

### What type of PR is it?
Feature

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-344

### How should this be tested?
A committer use the build_and_start_cicd_image.sh to start the CICD image.
Choose item 2 on the menu.
Use vim to edit the submarine-site files and access 0.0.0.0:4000 with a browser.
Type "exit" when finishing all the changes.
Input the commit message.
Check the submarine.apache.org to see changes take effect.

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? Yes
