### PR TITLE
SUBAMRINE-382. Output submarine server run log in travis

### DIFF
--- a/submarine-test/e2e/src/test/java/org/apache/submarine/ChromeWebDriverProvider.java
+++ b/submarine-test/e2e/src/test/java/org/apache/submarine/ChromeWebDriverProvider.java
@@ -104,7 +104,7 @@ public class ChromeWebDriverProvider implements WebDriverProvider {
     try {
       String versionCmd = "google-chrome --version";
       if (System.getProperty("os.name").startsWith("Mac OS")) {
-        versionCmd = "/Applications/Google Chrome.app/Contents/MacOS/google chrome --version";
+        versionCmd = "/Applications/Google\\ Chrome.app/Contents/MacOS/google\\ chrome --version";
       }
       String versionString = (String) CommandExecutor
           .executeCommandLocalHost(versionCmd, false, ProcessData.Types_Of_Data.OUTPUT);

--- a/submarine-test/e2e/src/test/java/org/apache/submarine/integration/SubmarineLogIT.java
+++ b/submarine-test/e2e/src/test/java/org/apache/submarine/integration/SubmarineLogIT.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.submarine.integration;
+
+import bsh.StringUtil;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.submarine.AbstractSubmarineIT;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.Test;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+
+public class SubmarineLogIT extends AbstractSubmarineIT {
+  public final static Logger LOG = LoggerFactory.getLogger(SubmarineLogIT.class);
+
+  @Test
+  public void submarineLog() throws Exception {
+    printSubmarineLog();
+  }
+
+  @Test
+  public void listSubmarineLibFiles() throws Exception {
+    File directory = new File(".");
+    String submarineDistModulePath = directory.getCanonicalPath() + "/../../submarine-dist/";
+    LOG.info("submarine-dist module path = {}", submarineDistModulePath);
+
+    listTargetDirFiles(new File(submarineDistModulePath), "lib");
+  }
+}

--- a/submarine-test/e2e/src/test/java/org/apache/submarine/integration/loginIT.java
+++ b/submarine-test/e2e/src/test/java/org/apache/submarine/integration/loginIT.java
@@ -27,16 +27,17 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 public class loginIT extends AbstractSubmarineIT {
-
   public final static Logger LOG = LoggerFactory.getLogger(loginIT.class);
 
   @BeforeClass
   public static void startUp(){
+    printSubmarineLog();
     driver =  WebDriverManager.getWebDriver();
   }
 
   @AfterClass
   public static void tearDown(){
+    printSubmarineLog();
     driver.quit();
   }
 


### PR DESCRIPTION
### What is this PR for?
Outputting the log of the submarine startup in the submarine-e2e test can help us check the reason why the submarine server cannot be started normally in travis.

called function `printSubmarineLog()`.

like, https://api.travis-ci.org/v3/job/648240038/log.txt
You can see submarine/logs/submarine.log context in travis log.

```
================= logs/submarine.log BEGIN =================
2020-02-10 05:04:38,668 INFO  [main]: submarine.AbstractSubmarineIT (AbstractSubmarineIT.java:printSubmarineLog(183)) - SUBMARINE_SERVER_CLASSPATH: /home/travis/build/liuxunorg/submarine/submarine-dist/target/submarine-dist-0.4.0-SNAPSHOT-hadoop-2.9/submarine-dist-0.4.0-SNAPSHOT-hadoop-2.9/bin/../lib/*::/home/travis/build/liuxunorg/submarine/submarine-dist/target/submarine-dist-0.4.0-SNAPSHOT-hadoop-2.9/submarine-dist-0.4.0-SNAPSHOT-hadoop-2.9/conf
log4j:ERROR Could not find value for key log4j.appender.EventCounter
log4j:ERROR Could not instantiate appender named "EventCounter".
20/02/10 05:04:37 [main]: INFO utils.SubmarineConfiguration: Load configuration from file:/home/travis/build/liuxunorg/submarine/submarine-dist/target/submarine-dist-0.4.0-SNAPSHOT-hadoop-2.9/submarine-dist-0.4.0-SNAPSHOT-hadoop-2.9/conf/submarine-site.xml
[INFO ] 2020-02-10 05:04:37,556 method:org.apache.submarine.server.SubmarineServer.main(SubmarineServer.java:78)
Submarine server Host: 0.0.0.0
[INFO ] 2020-02-10 05:04:37,556 method:org.apache.submarine.server.SubmarineServer.main(SubmarineServer.java:80)
Submarine server Port: 8080
[INFO ] 2020-02-10 05:04:37,604 method:org.eclipse.jetty.util.log.Log.initialized(Log.java:193)
Logging initialized @705ms to org.eclipse.jetty.util.log.Slf4jLog
[WARN ] 2020-02-10 05:04:37,896 method:org.eclipse.jetty.server.ServerConnector.setSoLingerTime(ServerConnector.java:458)
Ignoring deprecated socket close linger time
[INFO ] 2020-02-10 05:04:38,060 method:org.apache.submarine.server.SubmarineServer.setupWebAppContext(SubmarineServer.java:170)
workbench web war file path is ../workbench-web-ng.war.
[INFO ] 2020-02-10 05:04:38,445 method:org.apache.submarine.server.workbench.websocket.NotebookServer.<init>(NotebookServer.java:76)
NotebookServer instantiated: org.apache.submarine.server.workbench.websocket.NotebookServer@3943a2be
================= logs/submarine.log END =================
```



### What type of PR is it?
[Improvement]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/SUBMARINE-382

### How should this be tested?
* https://travis-ci.org/liuxunorg/submarine/builds/648240030

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
