### PR TITLE
SUBMARINE-390. Add yarn submitter with classloader

### DIFF
--- a/bin/common.sh
+++ b/bin/common.sh
@@ -88,7 +88,7 @@ function download_mysql_jdbc_jar(){
   echo "Mysql jdbc jar is downloaded and put in the path of submarine/lib."
 }
 
-JAVA_OPTS+=" ${SUBMARINE_SERVER_JAVA_OPTS} -Dfile.encoding=UTF-8 ${SUBMARINE_SERVER_MEM}"
+JAVA_OPTS+=" -Dfile.encoding=UTF-8"
 JAVA_OPTS+=" -Dlog4j.configuration=file://${SUBMARINE_CONF_DIR}/log4j.properties"
 export JAVA_OPTS
 

--- a/conf/submarine-site.xml
+++ b/conf/submarine-site.xml
@@ -144,7 +144,7 @@
   </property>
 
   <property>
-    <name>submarine.server.remote.execution.enabled</name>
+    <name>submarine.server.rpc.enabled</name>
     <value>false</value>
     <description>Run jobs using rpc server.</description>
   </property>

--- a/conf/submarine-site.xml
+++ b/conf/submarine-site.xml
@@ -143,6 +143,12 @@
     <description>RuntimeFactory for Submarine jobs</description>
   </property>
 
+  <property>
+    <name>submarine.server.remote.execution.enabled</name>
+    <value>false</value>
+    <description>Run jobs using rpc server.</description>
+  </property>
+
   <!-- Submarine Submitters Configuration  -->
   <property>
     <name>submarine.submitters</name>

--- a/conf/submarine-site.xml
+++ b/conf/submarine-site.xml
@@ -149,6 +149,12 @@
     <description>Run jobs using rpc server.</description>
   </property>
 
+  <property>
+    <name>submarine.server.rpc.port</name>
+    <value>8980</value>
+    <description>Rpc server port</description>
+  </property>
+
   <!-- Submarine Submitters Configuration  -->
   <property>
     <name>submarine.submitters</name>

--- a/conf/submarine-site.xml.template
+++ b/conf/submarine-site.xml.template
@@ -144,7 +144,7 @@
   </property>
 
   <property>
-    <name>submarine.server.remote.execution.enabled</name>
+    <name>submarine.server.rpc.enabled</name>
     <value>false</value>
     <description>Run jobs using rpc server.</description>
   </property>

--- a/conf/submarine-site.xml.template
+++ b/conf/submarine-site.xml.template
@@ -145,7 +145,7 @@
 
   <property>
     <name>submarine.server.remote.execution.enabled</name>
-    <value>true</value>
+    <value>false</value>
     <description>Run jobs using rpc server.</description>
   </property>
 

--- a/conf/submarine-site.xml.template
+++ b/conf/submarine-site.xml.template
@@ -149,4 +149,10 @@
     <description>Run jobs using rpc server.</description>
   </property>
 
+  <property>
+    <name>submarine.server.rpc.port</name>
+    <value>8980</value>
+    <description>Rpc server port</description>
+  </property>
+
 </configuration>

--- a/dev-support/mini-submarine/README.md
+++ b/dev-support/mini-submarine/README.md
@@ -162,11 +162,11 @@ Submarine server is supposed to manage jobs lifecycle. Clients can just submit
 job parameters or yaml file to submarine server instead of submitting jobs
 directly by themselves. Submarine server can handle the rest of the work.
 
-Set submarine.server.remote.execution.enabled to true in the file of
+Set submarine.server.rpc.enabled to true in the file of
 /opt/submarine-current/conf/submarine-site
 ```
   <property>
-    <name>submarine.server.remote.execution.enabled</name>
+    <name>submarine.server.rpc.enabled</name>
     <value>true</value>
     <description>Run jobs using rpc server.</description>
   </property>

--- a/dev-support/mini-submarine/conf/submarine-site.xml
+++ b/dev-support/mini-submarine/conf/submarine-site.xml
@@ -114,7 +114,7 @@
   </property>
 
   <property>
-    <name>submarine.server.remote.execution.enabled</name>
+    <name>submarine.server.rpc.enabled</name>
     <value>false</value>
     <description>Run jobs using rpc server.</description>
   </property>

--- a/submarine-client/src/main/java/org/apache/submarine/client/cli/Cli.java
+++ b/submarine-client/src/main/java/org/apache/submarine/client/cli/Cli.java
@@ -51,7 +51,7 @@ public class Cli {
     RuntimeFactory runtimeFactory;
     if (clientContext.getSubmarineConfig().getBoolean(
         SubmarineConfVars.ConfVars.
-            SUBMARINE_SERVER_REMOTE_EXECUTION_ENABLED)) {
+          SUBMARINE_SERVER_RPC_ENABLED)) {
       runtimeFactory = new RpcRuntimeFactory(clientContext);
     } else {
       Configuration conf = new YarnConfiguration();

--- a/submarine-client/src/main/java/org/apache/submarine/client/cli/Cli.java
+++ b/submarine-client/src/main/java/org/apache/submarine/client/cli/Cli.java
@@ -56,7 +56,8 @@ public class Cli {
     } else {
       Configuration conf = new YarnConfiguration();
       clientContext.setYarnConfig(conf);
-      runtimeFactory = RuntimeFactory.getRuntimeFactory(clientContext);
+      runtimeFactory = RuntimeFactory.getRuntimeFactory(clientContext,
+          Thread.currentThread().getContextClassLoader());
     }
     clientContext.setRuntimeFactory(runtimeFactory);
     return clientContext;

--- a/submarine-client/src/main/java/org/apache/submarine/client/cli/remote/RpcRuntimeFactory.java
+++ b/submarine-client/src/main/java/org/apache/submarine/client/cli/remote/RpcRuntimeFactory.java
@@ -37,7 +37,7 @@ public class RpcRuntimeFactory extends RuntimeFactory {
     super(clientContext);
     String remoteHost = clientContext.getSubmarineConfig().getServerAddress();
     int port = clientContext.getSubmarineConfig().getInt(
-        SubmarineConfVars.ConfVars.SUBMARINE_SERVER_REMOTE_EXECUTION_PORT);
+        SubmarineConfVars.ConfVars.SUBMARINE_SERVER_RPC_PORT);
     submitter = new JobSubmitterRpcImpl(remoteHost, port, clientContext);
   }
 

--- a/submarine-commons/commons-runtime/src/main/java/org/apache/submarine/commons/runtime/RuntimeFactory.java
+++ b/submarine-commons/commons-runtime/src/main/java/org/apache/submarine/commons/runtime/RuntimeFactory.java
@@ -38,14 +38,14 @@ public abstract class RuntimeFactory {
   }
 
   public static RuntimeFactory getRuntimeFactory(
-      ClientContext clientContext) {
+      ClientContext clientContext, ClassLoader classLoader) {
     SubmarineConfiguration submarineConfiguration =
         clientContext.getSubmarineConfig();
     String runtimeClass = submarineConfiguration.getString(
         SubmarineConfVars.ConfVars.SUBMARINE_RUNTIME_CLASS);
 
     try {
-      Class<?> runtimeClazz = Class.forName(runtimeClass);
+      Class<?> runtimeClazz = Class.forName(runtimeClass, true, classLoader);
       if (RuntimeFactory.class.isAssignableFrom(runtimeClazz)) {
         return (RuntimeFactory) runtimeClazz.getConstructor(ClientContext.class).newInstance(clientContext);
       } else {

--- a/submarine-commons/commons-utils/src/main/java/org/apache/submarine/commons/utils/SubmarineConfVars.java
+++ b/submarine-commons/commons-utils/src/main/java/org/apache/submarine/commons/utils/SubmarineConfVars.java
@@ -44,10 +44,10 @@ public class SubmarineConfVars {
     SUBMARINE_SERVER_SSL_TRUSTSTORE_TYPE("submarine.server.ssl.truststore.type", null),
     SUBMARINE_SERVER_SSL_TRUSTSTORE_PASSWORD("submarine.server.ssl.truststore.password", null),
     SUBMARINE_CLUSTER_ADDR("submarine.cluster.addr", ""),
-    SUBMARINE_SERVER_REMOTE_EXECUTION_ENABLED(
-        "submarine.server.remote.execution.enabled", false),
-    SUBMARINE_SERVER_REMOTE_EXECUTION_PORT(
-        "submarine.server.remote.execution.port", 8980),
+    SUBMARINE_SERVER_RPC_ENABLED(
+        "submarine.server.rpc.enabled", false),
+    SUBMARINE_SERVER_RPC_PORT(
+        "submarine.server.rpc.port", 8980),
     CLUSTER_HEARTBEAT_INTERVAL("cluster.heartbeat.interval", 3000),
     CLUSTER_HEARTBEAT_TIMEOUT("cluster.heartbeat.timeout", 9000),
 

--- a/submarine-dist/src/assembly/distribution.xml
+++ b/submarine-dist/src/assembly/distribution.xml
@@ -23,7 +23,7 @@
 
   <dependencySets>
     <dependencySet>
-      <outputDirectory>/lib/submitter</outputDirectory>
+      <outputDirectory>/lib/submitter/yarn</outputDirectory>
       <includes>
         <include>com.linkedin.tony:tony-core</include>
       </includes>
@@ -137,14 +137,14 @@
 
     <fileSet>
       <directory>../submarine-server/server-submitter/submitter-yarn/target</directory>
-      <outputDirectory>/lib/submitter</outputDirectory>
+      <outputDirectory>/lib/submitter/yarn</outputDirectory>
       <includes>
         <include>submarine-submitter-yarn-${project.version}-shade.jar</include>
       </includes>
     </fileSet>
     <fileSet>
       <directory>../submarine-server/server-submitter/submitter-yarnservice/target</directory>
-      <outputDirectory>/lib/submitter</outputDirectory>
+      <outputDirectory>/lib/submitter/yarnservice</outputDirectory>
       <includes>
         <include>submarine-submitter-yarnservice-${project.version}.jar</include>
       </includes>

--- a/submarine-server/server-rpc/src/main/java/org/apache/submarine/server/rpc/SubmarineRpcServer.java
+++ b/submarine-server/server-rpc/src/main/java/org/apache/submarine/server/rpc/SubmarineRpcServer.java
@@ -50,6 +50,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import static org.apache.submarine.commons.utils.SubmarineConfVars.ConfVars.SUBMARINE_RUNTIME_CLASS;
+
 /**
  * A gRPC server that provides submarine service.
  */
@@ -116,7 +118,14 @@ public class SubmarineRpcServer {
     ClientContext clientContext = new ClientContext();
     clientContext.setYarnConfig(conf);
     mergeSubmarineConfiguration(clientContext.getSubmarineConfig(), rpcContext);
-    ClassLoader classLoader = new URLClassLoader(constructUrlsFromClasspath("../lib/submitter"));
+    String runtimeclass =
+      clientContext.getSubmarineConfig().getString(SUBMARINE_RUNTIME_CLASS);
+    ClassLoader classLoader = null;
+    if (runtimeclass.contains("YarnServiceRuntimeFactory")) {
+      classLoader = new URLClassLoader(constructUrlsFromClasspath("../lib/submitter/yarnservice"));
+    } else {
+      classLoader = new URLClassLoader(constructUrlsFromClasspath("../lib/submitter/yarn"));
+    }
 
     RuntimeFactory runtimeFactory = RuntimeFactory.getRuntimeFactory(
         clientContext, classLoader);

--- a/submarine-server/server-rpc/src/main/java/org/apache/submarine/server/rpc/SubmarineRpcServer.java
+++ b/submarine-server/server-rpc/src/main/java/org/apache/submarine/server/rpc/SubmarineRpcServer.java
@@ -42,7 +42,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
-import java.lang.reflect.Constructor;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
@@ -118,10 +117,10 @@ public class SubmarineRpcServer {
     ClientContext clientContext = new ClientContext();
     clientContext.setYarnConfig(conf);
     mergeSubmarineConfiguration(clientContext.getSubmarineConfig(), rpcContext);
-    String runtimeclass =
+    String runtimeClass =
       clientContext.getSubmarineConfig().getString(SUBMARINE_RUNTIME_CLASS);
     ClassLoader classLoader = null;
-    if (runtimeclass.contains("YarnServiceRuntimeFactory")) {
+    if (runtimeClass.contains("YarnServiceRuntimeFactory")) {
       classLoader = new URLClassLoader(constructUrlsFromClasspath("../lib/submitter/yarnservice"));
     } else {
       classLoader = new URLClassLoader(constructUrlsFromClasspath("../lib/submitter/yarn"));
@@ -180,7 +179,7 @@ public class SubmarineRpcServer {
     SubmarineConfiguration submarineConfiguration =
         SubmarineConfiguration.getInstance();
     int rpcServerPort = submarineConfiguration.getInt(
-        SubmarineConfVars.ConfVars.SUBMARINE_SERVER_REMOTE_EXECUTION_PORT);
+        SubmarineConfVars.ConfVars.SUBMARINE_SERVER_RPC_PORT);
     SubmarineRpcServer server = new SubmarineRpcServer(rpcServerPort);
     server.start();
     return server;

--- a/submarine-server/server-rpc/src/test/java/org/apache/submarine/server/rpc/MockRpcServer.java
+++ b/submarine-server/server-rpc/src/test/java/org/apache/submarine/server/rpc/MockRpcServer.java
@@ -76,7 +76,7 @@ public class MockRpcServer extends SubmarineRpcServer {
     SubmarineConfiguration submarineConfiguration =
         SubmarineConfiguration.getInstance();
     int rpcServerPort = submarineConfiguration.getInt(
-        SubmarineConfVars.ConfVars.SUBMARINE_SERVER_REMOTE_EXECUTION_PORT);
+        SubmarineConfVars.ConfVars.SUBMARINE_SERVER_RPC_PORT);
     SubmarineRpcServer server = new MockRpcServer(rpcServerPort);
     server.start();
     return server;

--- a/submarine-server/server-rpc/src/test/java/org/apache/submarine/server/rpc/SubmarineRpcClient.java
+++ b/submarine-server/server-rpc/src/test/java/org/apache/submarine/server/rpc/SubmarineRpcClient.java
@@ -20,7 +20,6 @@ package org.apache.submarine.server.rpc;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import io.grpc.StatusRuntimeException;
-import org.apache.submarine.commons.rpc.ApplicationIdProto;
 import org.apache.submarine.commons.rpc.ParametersHolderProto;
 import org.apache.submarine.commons.rpc.SubmarineServerProtocolGrpc;
 import org.apache.submarine.commons.rpc.SubmarineServerProtocolGrpc.SubmarineServerProtocolBlockingStub;
@@ -50,7 +49,7 @@ public class SubmarineRpcClient extends RpcServerTestUtils {
             SubmarineConfVars.ConfVars.SUBMARINE_SERVER_ADDR),
           config.getInt(
             SubmarineConfVars.ConfVars.
-                SUBMARINE_SERVER_REMOTE_EXECUTION_PORT))
+                SUBMARINE_SERVER_RPC_PORT))
         .usePlaintext());
   }
 


### PR DESCRIPTION
### What is this PR for?
Submitter dependencies are excluded from submarine server. Submarine rpc server should initialize yarn submitter through a classloader. 


### What type of PR is it?
Improvement

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-390

### How should this be tested?
https://travis-ci.org/yuanzac/hadoop-submarine/builds/652407783?utm_source=github_status&utm_medium=notification

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
