### PR TITLE
SUBMARINE-391. Submarine build failed for jackson-databind version conflicts with hadoop 3.1

### DIFF
--- a/submarine-server/server-submitter/submitter-yarn/pom.xml
+++ b/submarine-server/server-submitter/submitter-yarn/pom.xml
@@ -290,6 +290,12 @@
           <artifactId>hadoop-hdfs-client</artifactId>
           <version>${hadoop.version}</version>
           <scope>compile</scope>
+          <exclusions>
+            <exclusion>
+              <groupId>com.fasterxml.jackson.core</groupId>
+              <artifactId>jackson-databind</artifactId>
+            </exclusion>
+          </exclusions>
         </dependency>
       </dependencies>
     </profile>
@@ -302,6 +308,12 @@
           <artifactId>hadoop-hdfs-client</artifactId>
           <version>${hadoop.version}</version>
           <scope>compile</scope>
+          <exclusions>
+            <exclusion>
+              <groupId>com.fasterxml.jackson.core</groupId>
+              <artifactId>jackson-databind</artifactId>
+            </exclusion>
+          </exclusions>
         </dependency>
       </dependencies>
     </profile>


### PR DESCRIPTION
### What is this PR for?
Submarine build failed for jackson-databind version conflicts with hadoop 3.1


### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-391

### How should this be tested?
https://travis-ci.org/lshmouse/submarine/jobs/654886926

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
