### PR TITLE
SUBMARINE-394. Change submit job response status in JobManagerRestApi

### DIFF
--- a/submarine-server/server-core/src/main/java/org/apache/submarine/server/rest/JobManagerRestApi.java
+++ b/submarine-server/server-core/src/main/java/org/apache/submarine/server/rest/JobManagerRestApi.java
@@ -67,16 +67,16 @@ public class JobManagerRestApi {
   public Response submitJob(JobSpec jobSpec) {
     if (!jobSpec.validate()) {
       return new JsonResponse.Builder<String>(Response.Status.ACCEPTED)
-          .success(true).result("Invalid params.").build();
+          .success(false).result("Invalid params.").build();
     }
 
     try {
       Job job = JobManager.getInstance().submitJob(jobSpec);
-      return new JsonResponse.Builder<Job>(Response.Status.ACCEPTED)
+      return new JsonResponse.Builder<Job>(Response.Status.OK)
           .success(true).result(job).build();
     } catch (UnsupportedJobTypeException e) {
       return new JsonResponse.Builder<String>(Response.Status.ACCEPTED)
-          .success(true).result(e.getMessage()).build();
+          .success(false).result(e.getMessage()).build();
     }
   }
 


### PR DESCRIPTION
### What is this PR for?
If job submit successfully we should return `OK`(200) instead of `ACCEPTED`(202) 
If job submit fail, success should be false


### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-394

### How should this be tested?
https://travis-ci.org/pingsutw/hadoop-submarine/builds/655167779

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
