### PR TITLE
SUBMARINE-396. Change submarine version to 0.4.0 in some docs

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -271,7 +271,7 @@ org.apache.hadoop:hadoop-hdfs-client:2.9.2
 org.apache.htrace:htrace-core4:4.1.0-incubating
 org.apache.httpcomponents:httpclient:4.5.2
 org.apache.httpcomponents:httpcore:4.4.4
-org.apache.submarine:submarine-core:0.3.0-SNAPSHOT
+org.apache.submarine:submarine-core:0.4.0-SNAPSHOT
 org.apache.zookeeper:zookeeper:3.4.6
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13

--- a/dev-support/mini-submarine/README.md
+++ b/dev-support/mini-submarine/README.md
@@ -22,10 +22,8 @@ This is a docker image built for submarine development and quick start test.
 
 ### Use the image we provide
 
-> Tag 0.3.0-SNAPSHOT indicates the version number of hadoop submarine in images
-
 ```
-docker pull hadoopsubmarine/mini-submarine:0.3.0-SNAPSHOT 
+docker pull apache/submarine:mini-0.3.0
 ```
 
 ### Create image by yourself
@@ -76,7 +74,7 @@ In the container, we can verify that the submarine jar version is the expected 0
 ### Run mini-submarine image
 
 ```
-docker run -it -h submarine-dev --name mini-submarine --net=bridge --privileged -P local/mini-submarine:0.3.0-SNAPSHOT /bin/bash
+docker run -it -h submarine-dev --name mini-submarine --net=bridge --privileged -P local/mini-submarine:0.4.0-SNAPSHOT /bin/bash
 
 # In the container, use root user to bootstrap hdfs and yarn
 /tmp/hadoop-config/bootstrap.sh
@@ -85,7 +83,7 @@ docker run -it -h submarine-dev --name mini-submarine --net=bridge --privileged 
 yarn node -list -showDetails
 ```
 
-If you pull the image directly, please replace "local/mini-submarine:0.3.0-SNAPSHOT" with "hadoopsubmarine/mini-submarine:0.3.0-SNAPSHOT".
+If you pull the image directly, please replace "local/mini-submarine:0.4.0-SNAPSHOT" with "apache/submarine:mini-0.3.0".
 
 ### You should see info like this:
 
@@ -231,7 +229,7 @@ When using mini-submarine, you can debug submarine client, applicationMaster and
 Run the following command to start mini-submarine.
 
 ```
-docker run -it -P -h submarine-dev --net=bridge --expose=8000 --privileged local/mini-submarine:0.3.0-SNAPSHOT /bin/bash
+docker run -it -P -h submarine-dev --net=bridge --expose=8000 --privileged local/mini-submarine:0.4.0-SNAPSHOT /bin/bash
 ```
 
 Debug submarine client with the parameter "--debug"
@@ -260,7 +258,7 @@ Then port 32804 can be used for remote debug.
 Run the following command to start mini-submarine.
 
 ```
-docker run -it -P -h submarine-dev --net=bridge --expose=8001 --privileged local/mini-submarine:0.3.0-SNAPSHOT /bin/bash
+docker run -it -P -h submarine-dev --net=bridge --expose=8001 --privileged local/mini-submarine:0.4.0-SNAPSHOT /bin/bash
 ```
 
 Add the following configuration in the file /usr/local/hadoop/etc/hadoop/tony.xml.
@@ -280,7 +278,7 @@ And the debug port mapping can be obtained using the way as [Debug submarine cli
 Run the following command to start mini-submarine.
 
 ```
-docker run -it -P -h submarine-dev --net=bridge --expose=8002 --privileged local/mini-submarine:0.3.0-SNAPSHOT /bin/bash
+docker run -it -P -h submarine-dev --net=bridge --expose=8002 --privileged local/mini-submarine:0.4.0-SNAPSHOT /bin/bash
 ```
 
 Add the following configuration in the file /usr/local/hadoop/etc/hadoop/tony.xml.

--- a/dev-support/mini-submarine/build_mini-submarine.sh
+++ b/dev-support/mini-submarine/build_mini-submarine.sh
@@ -17,7 +17,7 @@ set -e
 hadoop_v=2.9.2
 spark_v=2.4.4
 
-submarine_v=${submarine_version:-"0.3.0-SNAPSHOT"}
+submarine_v=${submarine_version:-"0.4.0-SNAPSHOT"}
 echo "Using submarine version: $submarine_v"
 
 image_name="local/mini-submarine:${submarine_v}"

--- a/dev-support/mini-submarine/submarine/run_customized_submarine-all_mnist.sh
+++ b/dev-support/mini-submarine/submarine/run_customized_submarine-all_mnist.sh
@@ -49,7 +49,7 @@ else
   WORKER_CMD="myvenv.zip/venv/bin/python mnist_distributed.py --steps 2 --data_dir /tmp/data --working_dir /tmp/mode"
 fi
 
-SUBMARINE_VERSION=${SUBMARINE_VER:-"0.3.0-SNAPSHOT"}
+SUBMARINE_VERSION=${SUBMARINE_VER:-"0.4.0-SNAPSHOT"}
 
 HADOOP_VERSION=2.9
 

--- a/dev-support/mini-submarine/submarine/run_submarine_mnist_tony.sh
+++ b/dev-support/mini-submarine/submarine/run_submarine_mnist_tony.sh
@@ -17,7 +17,7 @@
 
 # Below are configurable variables, please adapt base on your local environment.
 # Version of submarine jar
-SUBMARINE_VERSION=${SUBMARINE_VER:-"0.3.0-SNAPSHOT"}
+SUBMARINE_VERSION=${SUBMARINE_VER:-"0.4.0-SNAPSHOT"}
 
 # Version of affiliated Hadoop version for this Submarine jar.
 SUBMARINE_HADOOP_VERSION=2.9

--- a/dev-support/mini-submarine/submarine/run_submarine_mnist_tony_rpc.sh
+++ b/dev-support/mini-submarine/submarine/run_submarine_mnist_tony_rpc.sh
@@ -47,7 +47,7 @@ else
   WORKER_CMD="myvenv.zip/venv/bin/python mnist_distributed.py --steps 2 --data_dir /tmp/data --working_dir /tmp/mode"
 fi 
 
-SUBMARINE_VERSION=${SUBMARINE_VER:-"0.3.0-SNAPSHOT"}
+SUBMARINE_VERSION=${SUBMARINE_VER:-"0.4.0-SNAPSHOT"}
 
 HADOOP_VERSION=2.9
 

--- a/dev-support/mini-submarine/submarine/run_submarine_pytorch_mnist_tony.sh
+++ b/dev-support/mini-submarine/submarine/run_submarine_pytorch_mnist_tony.sh
@@ -39,7 +39,7 @@ else
   JAVA_CMD="java"
 fi
 
-SUBMARINE_VERSION=0.3.0-SNAPSHOT
+SUBMARINE_VERSION=0.4.0-SNAPSHOT
 HADOOP_VERSION=2.9
 SUBMARINE_PATH=/opt/submarine-current
 HADOOP_CONF_PATH=/usr/local/hadoop/etc/hadoop

--- a/docs/helper/RunningDistributedCifar10TFJobsWithYarnService.md
+++ b/docs/helper/RunningDistributedCifar10TFJobsWithYarnService.md
@@ -68,7 +68,7 @@ The file, named submarine-site.xml, is in the path of ${SUBMARINE_HOME}/conf.
 ### Run standalone training
 
 ```
-SUBMARINE_VERSION=0.3.0-SNAPSHOT
+SUBMARINE_VERSION=0.4.0-SNAPSHOT
 CLASSPATH=`${HADOOP_HOME}/bin/hadoop classpath --glob`:${SUBMARINE_HOME}/submarine-all-${SUBMARINE_VERSION}.jar:
 ${SUBMARINE_HOME}/conf: \
 java org.apache.submarine.client.cli.Cli job run \
@@ -89,7 +89,7 @@ Explanations:
 ### Run distributed training
 
 ```
-SUBMARINE_VERSION=0.3.0-SNAPSHOT
+SUBMARINE_VERSION=0.4.0-SNAPSHOT
 CLASSPATH=`${HADOOP_HOME}/bin/hadoop classpath --glob`:${SUBMARINE_HOME}/submarine-all-${SUBMARINE_VERSION}.jar:
 ${SUBMARINE_HOME}/conf: \
 java org.apache.submarine.client.cli.Cli job run \
@@ -190,7 +190,7 @@ When using YARN native service runtime, you can view multiple job training histo
 ```shell
 # Cleanup previous tensorboard service if needed
 
-SUBMARINE_VERSION=0.3.0-SNAPSHOT
+SUBMARINE_VERSION=0.4.0-SNAPSHOT
 CLASSPATH=`${HADOOP_HOME}/bin/hadoop classpath --glob`:${SUBMARINE_HOME}/submarine-all-${SUBMARINE_VERSION}.jar:
 ${SUBMARINE_HOME}/conf: \
 java org.apache.submarine.client.cli.Cli job run \

--- a/docs/helper/RunningSingleNodeCifar10PTJobsWithYarnService.md
+++ b/docs/helper/RunningSingleNodeCifar10PTJobsWithYarnService.md
@@ -48,7 +48,7 @@ The file, named submarine-site.xml, is in the path of ${SUBMARINE_HOME}/conf.
 ### Run standalone training
 
 ```shell
-SUBMARINE_VERSION=0.3.0-SNAPSHOT
+SUBMARINE_VERSION=0.4.0-SNAPSHOT
 CLASSPATH=`${HADOOP_HOME}/bin/hadoop classpath --glob`:${SUBMARINE_HOME}/submarine-all-${SUBMARINE_VERSION}.jar:
 ${SUBMARINE_HOME}/conf: \
 java org.apache.submarine.client.cli.Cli job run \

--- a/submarine-sdk/pysubmarine/setup.py
+++ b/submarine-sdk/pysubmarine/setup.py
@@ -18,7 +18,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='pysubmarine',
-    version='0.3.0-SNAPSHOT',
+    version='0.4.0-SNAPSHOT',
     description="A python SDK for submarine",
     url="https://github.com/apache/submarine",
     packages=find_packages(exclude=['tests', 'tests.*']),

--- a/submarine-workbench/interpreter/python-interpreter/README.md
+++ b/submarine-workbench/interpreter/python-interpreter/README.md
@@ -18,7 +18,7 @@
 
 ### Execute test command
 ```
-java -jar python-interpreter-0.3.0-SNAPSHOT-shade.jar python python-interpreter-id test
+java -jar python-interpreter-0.4.0-SNAPSHOT-shade.jar python python-interpreter-id test
 ```
 
 ### Print test result 
@@ -33,7 +33,7 @@ java -jar python-interpreter-0.3.0-SNAPSHOT-shade.jar python python-interpreter-
 ### Execute debug command
 
 ```
-java -jar python-interpreter-0.3.0-SNAPSHOT-shade.jar -agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005 python python-interpreter-id
+java -jar python-interpreter-0.4.0-SNAPSHOT-shade.jar -agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005 python python-interpreter-id
 ```
 
 Connect via remote debugging in IDEA


### PR DESCRIPTION
### What is this PR for?
The build scripts for mini-submarine still use version 0.3.0, which will cause some errors. We need to modify it to 0.4.0.

### What type of PR is it?
Improvement 

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-396

### How should this be tested?
https://travis-ci.org/yuanzac/hadoop-submarine/builds/655798779?utm_source=github_status&utm_medium=notification

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? Yes
* Does this needs documentation? Yes
