### PR TITLE
SUBMARINE-393. Drop Hadoop 2.7 support.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -95,12 +95,6 @@ matrix:
       dist: xenial
       env: PROFILE="" BUILD_FLAG="clean" TEST_FLAG="org.apache.rat:apache-rat-plugin:check" TEST_PROJECTS=""
 
-    - name: Build submarine submitter on hadoop-2.7
-      language: java
-      jdk: openjdk8
-      dist: xenial
-      env: PROFILE="-Phadoop-2.7" BUILD_FLAG="clean package install -DskipTests -DskipRat" TEST_FLAG="test -DskipRat" MODULES="-pl ${EXCLUDE_K8S},${EXCLUDE_WORKBENCH},${EXCLUDE_INTERPRETER},${EXCLUDE_CLOUD},!submarine-dist" TEST_MODULES="-pl ${EXCLUDE_K8S},${EXCLUDE_WORKBENCH},${EXCLUDE_INTERPRETER},${EXCLUDE_CLOUD},${EXCLUDE_COMMON_RPC},!submarine-dist" TEST_PROJECTS=""
-
     - name: Build submarine submitter on hadoop-2.9 (default)
       language: java
       jdk: openjdk8

--- a/docs/development/BuildFromCode.md
+++ b/docs/development/BuildFromCode.md
@@ -36,12 +36,6 @@ mvn clean org.apache.rat:apache-rat-plugin:check
 mvn clean install package -DskipTests
 ```
 
-+ Create binary distribution with hadoop-2.7.x version
-
-```
-mvn clean install package -DskipTests -Phadoop-2.7
-```
-
 + Create binary distribution with hadoop-2.9.x version
 
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -369,19 +369,6 @@
     </profile>
 
     <profile>
-      <id>hadoop-2.7</id>
-      <properties>
-        <hadoop.version>2.7.3</hadoop.version>
-        <jaxb-api.version>2.2.2</jaxb-api.version>
-        <commons-compress.version>1.4.1</commons-compress.version>
-        <guice-servlet.version>3.0</guice-servlet.version>
-        <guice.version>3.0</guice.version>
-        <zookeeper.version>3.4.6</zookeeper.version>
-        <profile-id>hadoop-2.7</profile-id>
-      </properties>
-    </profile>
-
-    <profile>
      <id>clover</id>
      <activation>
        <activeByDefault>false</activeByDefault>

--- a/submarine-all/pom.xml
+++ b/submarine-all/pom.xml
@@ -171,11 +171,6 @@
       </dependencies>
     </profile>
 
-    <profile>
-      <id>hadoop-2.7</id>
-      <dependencies>
-      </dependencies>
-    </profile>
   </profiles>
 
   <build>

--- a/submarine-dist/pom.xml
+++ b/submarine-dist/pom.xml
@@ -106,12 +106,6 @@
     </profile>
 
     <profile>
-      <id>hadoop-2.7</id>
-      <dependencies>
-      </dependencies>
-    </profile>
-
-    <profile>
       <id>src</id>
       <activation>
         <activeByDefault>false</activeByDefault>


### PR DESCRIPTION
### What is this PR for?
Remove the support of Hadoop 2.7 because
(1) Hadoop 2.7 is End of Life
(2) Removing Hadoop 2.7 reduces the amount of resource required for testing.

### What type of PR is it?
Improvement

### Todos
* [ ] - Task

### What is the Jira issue?
SUBMARINE-393

### How should this be tested?
https://travis-ci.org/jojochuang/hadoop-submarine/builds/656030433

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? Yes
* Does this needs documentation? Yes
