### PR TITLE
SUBMARINE-400. Support firefox in testing workbench-web with Angular

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -164,6 +164,7 @@ matrix:
       dist: xenial
       addons:
         chrome: stable
+        firefox: latest
       env: PROFILE="-Phadoop-2.9" BUILD_FLAG="clean package install -DskipTests" TEST_FLAG="verify -DskipRat -am" TEST_MODULES="-pl submarine-test/e2e" TEST_PROJECTS=""
 
     - name: Test submarine-test-k8s
@@ -210,8 +211,11 @@ matrix:
         npm install
       addons:
         chrome: stable
+        firefox: latest
       script:
         - npm run test -- --no-watch --no-progress --browsers=ChromeHeadlessCI
+        - npm run test -- --no-watch --no-progress --browsers=FirefoxHeadless
+        - npm run webdriver
         - npm run e2e -- --protractor-config=e2e/protractor-ci.conf.js
       env: BUILD_FLAG="clean package -DskipTests" TEST_FLAG="test -DskipRat -am" MODULES="-pl org.apache.submarine:workbench-web-ng" TEST_MODULES="-pl org.apache.submarine:workbench-web-ng" TEST_PROJECTS=""
 

--- a/submarine-test/e2e/src/test/java/org/apache/submarine/FirefoxWebDriverProvider.java
+++ b/submarine-test/e2e/src/test/java/org/apache/submarine/FirefoxWebDriverProvider.java
@@ -131,9 +131,6 @@ public class FirefoxWebDriverProvider implements WebDriverProvider {
     firefoxOptions.setBinary(ffox);
     firefoxOptions.setProfile(profile);
     firefoxOptions.setLogLevel(FirefoxDriverLogLevel.TRACE);
-    firefoxOptions.headless();
-    // provide access to console logs in Firefox
-    firefoxOptions.setPreference("devtools.console.stdout.content", true);
 
     return new FirefoxDriver(firefoxOptions);
   }

--- a/submarine-test/e2e/src/test/java/org/apache/submarine/FirefoxWebDriverProvider.java
+++ b/submarine-test/e2e/src/test/java/org/apache/submarine/FirefoxWebDriverProvider.java
@@ -131,6 +131,10 @@ public class FirefoxWebDriverProvider implements WebDriverProvider {
     firefoxOptions.setBinary(ffox);
     firefoxOptions.setProfile(profile);
     firefoxOptions.setLogLevel(FirefoxDriverLogLevel.TRACE);
+    firefoxOptions.headless();
+    // provide access to console logs in Firefox
+    firefoxOptions.setPreference("devtools.console.stdout.content", true);
+
     return new FirefoxDriver(firefoxOptions);
   }
 

--- a/submarine-workbench/workbench-web-ng/e2e/protractor-ci.conf.js
+++ b/submarine-workbench/workbench-web-ng/e2e/protractor-ci.conf.js
@@ -23,11 +23,17 @@
 
 const config = require('./protractor.conf').config;
 
-config.capabilities = {
+config.multiCapabilities = [{
   browserName: 'chrome',
   chromeOptions: {
     args: ['--headless', '--no-sandbox']
   }
-};
+},
+{
+  browserName: 'firefox',
+  'moz:firefoxOptions': {
+    args: ['--headless']
+  }  
+}];
 
 exports.config = config;

--- a/submarine-workbench/workbench-web-ng/e2e/protractor.conf.js
+++ b/submarine-workbench/workbench-web-ng/e2e/protractor.conf.js
@@ -31,9 +31,12 @@ exports.config = {
   specs: [
     './src/**/*.e2e-spec.ts'
   ],
-  capabilities: {
+  multiCapabilities: [{
     'browserName': 'chrome'
   },
+  {
+    'browserName': 'firefox'
+  }],
   directConnect: true,
   baseUrl: 'http://localhost:4200/',
   framework: 'jasmine',

--- a/submarine-workbench/workbench-web-ng/e2e/src/app.e2e-spec.ts
+++ b/submarine-workbench/workbench-web-ng/e2e/src/app.e2e-spec.ts
@@ -33,10 +33,14 @@ describe('workspace-project App', () => {
   });
 
   afterEach(async () => {
-    // Assert that there are no errors emitted from the browser
-    const logs = await browser.manage().logs().get(logging.Type.BROWSER);
-    expect(logs).not.toContain(jasmine.objectContaining({
-      level: logging.Level.SEVERE,
-    } as logging.Entry));
+    try {
+      // Assert that there are no errors emitted from the browser
+      const logs = await browser.manage().logs().get(logging.Type.BROWSER);
+      expect(logs).not.toContain(jasmine.objectContaining({
+        level: logging.Level.SEVERE,
+      } as logging.Entry));
+    } catch(err) {
+      console.error(err);
+    }
   });
 });

--- a/submarine-workbench/workbench-web-ng/karma.conf.js
+++ b/submarine-workbench/workbench-web-ng/karma.conf.js
@@ -27,6 +27,7 @@ module.exports = function (config) {
     plugins: [
       require('karma-jasmine'),
       require('karma-chrome-launcher'),
+      require('karma-firefox-launcher'),
       require('karma-jasmine-html-reporter'),
       require('karma-coverage-istanbul-reporter'),
       require('@angular-devkit/build-angular/plugins/karma')
@@ -44,11 +45,15 @@ module.exports = function (config) {
     colors: true,
     logLevel: config.LOG_INFO,
     autoWatch: true,
-    browsers: ['Chrome'],
+    browsers: ['Chrome', 'Firefox'],
     customLaunchers: {
       ChromeHeadlessCI: {
         base: 'ChromeHeadless',
         flags: ['--no-sandbox']
+      },
+      FirefoxHeadlessCI: {
+        base: 'Firefox',
+        flags: [ '-headless' ],        
       }
     },
     singleRun: false,

--- a/submarine-workbench/workbench-web-ng/package.json
+++ b/submarine-workbench/workbench-web-ng/package.json
@@ -7,7 +7,8 @@
     "build": "ng build",
     "test": "ng test",
     "lint": "ng lint",
-    "e2e": "ng e2e"
+    "e2e": "ng e2e",
+    "webdriver": "webdriver-manager update"
   },
   "private": true,
   "dependencies": {
@@ -42,6 +43,7 @@
     "jasmine-spec-reporter": "~4.2.1",
     "karma": "~4.1.0",
     "karma-chrome-launcher": "~2.2.0",
+    "karma-firefox-launcher": "~1.3.0",
     "karma-coverage-istanbul-reporter": "~2.0.1",
     "karma-jasmine": "~2.0.1",
     "karma-jasmine-html-reporter": "^1.4.0",


### PR DESCRIPTION
### What is this PR for?
This PR is going to enable the firefox support in testing workbench-web with Angular.

### What type of PR is it?
Improvement

### Todos
* [ ] - Solve the issue that firefox web driver cannot capture the console log

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-400

### How should this be tested?

https://travis-ci.com/cchung100m/submarine/builds/151222859

The Travis CI job shows that we can pass the workbench-web with Angular testing with `chrome` and `firefox` instances as shown below.

### Screenshots (if appropriate)
<img width="998" alt="2020-03-01 15 21 27" src="https://user-images.githubusercontent.com/6762509/75621532-a3580000-5bd0-11ea-834e-86ce8f34a53d.png">


### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
