### PR TITLE
SUBMARINE-410. Supplement submarine artifactId in pom.xml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,18 +45,18 @@ env:
     # If you need to compile Phadoop-3.1 or Phadoop-3.2, you need to add `!submarine-server/server-submitter/submitter-yarnservice` in EXCLUDE_SUBMARINE
     - SUBMARINE="org.apache.submarine"
     - EXCLUDE_SUBMARINE="!${SUBMARINE}:submarine-all,!${SUBMARINE}:submarine-client,!${SUBMARINE}:submarine-dist"
-    - EXCLUDE_SERVER="!${SUBMARINE}:server-api,!${SUBMARINE}:server-core,!${SUBMARINE}:server-rpc"
+    - EXCLUDE_SERVER="!${SUBMARINE}:submarine-server-api,!${SUBMARINE}:submarine-server-core,!${SUBMARINE}:submarine-server-rpc"
     - EXCLUDE_CLIENT="!${SUBMARINE}:submarine-client"
     - EXCLUDE_ALL="!${SUBMARINE}:submarine-all"
-    - EXCLUDE_WORKBENCH="!${SUBMARINE}:submarine-workbench,!${SUBMARINE}:workbench-web,!${SUBMARINE}:workbench-web-ng"
+    - EXCLUDE_WORKBENCH="!${SUBMARINE}:submarine-workbench,!${SUBMARINE}:submarine-workbench-web,!${SUBMARINE}:submarine-workbench-web-ng"
     - EXCLUDE_INTERPRETER="" # Template disable by SUBMARINE-381 "!submarine-workbench/interpreter,!submarine-workbench/interpreter/interpreter-engine,!submarine-workbench/interpreter/python-interpreter,!submarine-workbench/interpreter/spark-interpreter
-    - EXCLUDE_SUBMITTER_K8S="!${SUBMARINE}:submitter-k8s"
-    - EXCLUDE_SUBMITTER_YARN="!${SUBMARINE}:submitter-yarn"
-    - EXCLUDE_SUBMITTER="!${SUBMARINE}:server-submitter,${EXCLUDE_SUBMITTER_K8S},${EXCLUDE_SUBMITTER_YARN}"
-    - EXCLUDE_COMMONS="!${SUBMARINE}:commons-cluster,!${SUBMARINE}:commons-metastore,!${SUBMARINE}:commons-rpc,!${SUBMARINE}:commons-runtime,!${SUBMARINE}:commons-utils"
+    - EXCLUDE_SUBMITTER_K8S="!${SUBMARINE}:submarine-submitter-k8s"
+    - EXCLUDE_SUBMITTER_YARN="!${SUBMARINE}:submarine-submitter-yarn"
+    - EXCLUDE_SUBMITTER="!${SUBMARINE}:submarine-server-submitter,${EXCLUDE_SUBMITTER_K8S},${EXCLUDE_SUBMITTER_YARN}"
+    - EXCLUDE_COMMONS="!${SUBMARINE}:submarine-commons-cluster,!${SUBMARINE}:submarine-commons-metastore,!${SUBMARINE}:submarine-commons-rpc,!${SUBMARINE}:submarine-commons-runtime,!${SUBMARINE}:submarine-commons-utils"
     - EXCLUDE_CLOUD="!${SUBMARINE}:submarine-cloud"
     - EXCLUDE_DIST="!${SUBMARINE}:submarine-dist"
-    - EXCLUDE_TEST="!${SUBMARINE}:submarine-test,!${SUBMARINE}:test-e2e,!${SUBMARINE}:test-k8s"
+    - EXCLUDE_TEST="!${SUBMARINE}:submarine-test,!${SUBMARINE}:submarine-test-e2e,!${SUBMARINE}:submarine-test-k8s"
     - MOZ_HEADLESS=1
 
 before_install:
@@ -112,7 +112,7 @@ matrix:
         chrome: stable
         firefox: latest
       # Because submarine on k8s uses port 80, it needs to be set `-Durl=http://127.0.0.1`
-      env: PROFILE="-Phadoop-2.9" BUILD_FLAG="clean package install -DskipTests" TEST_FLAG="verify -DskipRat -am -Durl=http://127.0.0.1" MODULES="" TEST_MODULES="-pl ${EXCLUDE_SERVER},${EXCLUDE_COMMONS},${EXCLUDE_CLIENT},org.apache.submarine:test-k8s" TEST_PROJECTS=""
+      env: PROFILE="-Phadoop-2.9" BUILD_FLAG="clean package install -DskipTests" TEST_FLAG="verify -DskipRat -am -Durl=http://127.0.0.1" MODULES="" TEST_MODULES="-pl ${EXCLUDE_SERVER},${EXCLUDE_COMMONS},${EXCLUDE_CLIENT},org.apache.submarine:submarine-test-k8s" TEST_PROJECTS=""
 
     - name: Test submarine test-e2e
       language: java
@@ -121,37 +121,37 @@ matrix:
       addons:
         chrome: stable
         firefox: latest
-      env: PROFILE="-Phadoop-2.9" BUILD_FLAG="clean package install -DskipTests" TEST_FLAG="verify -DskipRat -am" TEST_MODULES="-pl org.apache.submarine:test-e2e" TEST_PROJECTS=""
+      env: PROFILE="-Phadoop-2.9" BUILD_FLAG="clean package install -DskipTests" TEST_FLAG="verify -DskipRat -am" TEST_MODULES="-pl org.apache.submarine:submarine-test-e2e" TEST_PROJECTS=""
 
     - name: Test submarine commons-cluster
       language: java
       jdk: openjdk8
       dist: xenial
-      env: PROFILE="-Phadoop-2.9" BUILD_FLAG="clean package install -DskipTests" TEST_FLAG="test -DskipRat -am" MODULES="-pl ${EXCLUDE_COMMONS},${EXCLUDE_SUBMITTER},${EXCLUDE_WORKBENCH},${EXCLUDE_INTERPRETER},${EXCLUDE_CLIENT},${EXCLUDE_CLOUD},${EXCLUDE_SERVER},${EXCLUDE_ALL},${EXCLUDE_DIST},${EXCLUDE_TEST}" TEST_MODULES="-pl org.apache.submarine:commons-cluster" TEST_PROJECTS=""
+      env: PROFILE="-Phadoop-2.9" BUILD_FLAG="clean package install -DskipTests" TEST_FLAG="test -DskipRat -am" MODULES="-pl ${EXCLUDE_COMMONS},${EXCLUDE_SUBMITTER},${EXCLUDE_WORKBENCH},${EXCLUDE_INTERPRETER},${EXCLUDE_CLIENT},${EXCLUDE_CLOUD},${EXCLUDE_SERVER},${EXCLUDE_ALL},${EXCLUDE_DIST},${EXCLUDE_TEST}" TEST_MODULES="-pl org.apache.submarine:submarine-commons-cluster" TEST_PROJECTS=""
 
     - name: Test submarine commons-metastore
       language: java
       jdk: openjdk8
       dist: xenial
-      env: PROFILE="-Phadoop-2.9" BUILD_FLAG="clean package install -DskipTests" TEST_FLAG="test -DskipRat -am" MODULES="-pl ${EXCLUDE_COMMONS},${EXCLUDE_SUBMITTER},${EXCLUDE_WORKBENCH},${EXCLUDE_INTERPRETER},${EXCLUDE_CLIENT},${EXCLUDE_CLOUD},${EXCLUDE_SERVER},${EXCLUDE_ALL},${EXCLUDE_DIST},${EXCLUDE_TEST}" TEST_MODULES="-pl org.apache.submarine:commons-metastore" TEST_PROJECTS=""
+      env: PROFILE="-Phadoop-2.9" BUILD_FLAG="clean package install -DskipTests" TEST_FLAG="test -DskipRat -am" MODULES="-pl ${EXCLUDE_COMMONS},${EXCLUDE_SUBMITTER},${EXCLUDE_WORKBENCH},${EXCLUDE_INTERPRETER},${EXCLUDE_CLIENT},${EXCLUDE_CLOUD},${EXCLUDE_SERVER},${EXCLUDE_ALL},${EXCLUDE_DIST},${EXCLUDE_TEST}" TEST_MODULES="-pl org.apache.submarine:submarine-commons-metastore" TEST_PROJECTS=""
 
     - name: Test submarine commons-rpc
       language: java
       jdk: openjdk8
       dist: xenial
-      env: PROFILE="-Phadoop-2.9" BUILD_FLAG="clean package install -DskipTests" TEST_FLAG="test -DskipRat -am" MODULES="-pl ${EXCLUDE_COMMONS},${EXCLUDE_SUBMITTER},${EXCLUDE_WORKBENCH},${EXCLUDE_INTERPRETER},${EXCLUDE_CLIENT},${EXCLUDE_CLOUD},${EXCLUDE_SERVER},${EXCLUDE_ALL},${EXCLUDE_DIST},${EXCLUDE_TEST}" TEST_MODULES="-pl org.apache.submarine:commons-rpc" TEST_PROJECTS=""
+      env: PROFILE="-Phadoop-2.9" BUILD_FLAG="clean package install -DskipTests" TEST_FLAG="test -DskipRat -am" MODULES="-pl ${EXCLUDE_COMMONS},${EXCLUDE_SUBMITTER},${EXCLUDE_WORKBENCH},${EXCLUDE_INTERPRETER},${EXCLUDE_CLIENT},${EXCLUDE_CLOUD},${EXCLUDE_SERVER},${EXCLUDE_ALL},${EXCLUDE_DIST},${EXCLUDE_TEST}" TEST_MODULES="-pl org.apache.submarine:submarine-commons-rpc" TEST_PROJECTS=""
 
     - name: Test submarine commons-runtime
       language: java
       jdk: openjdk8
       dist: xenial
-      env: PROFILE="-Phadoop-2.9" BUILD_FLAG="clean package install -DskipTests" TEST_FLAG="test -DskipRat -am" MODULES="-pl ${EXCLUDE_COMMONS},${EXCLUDE_SUBMITTER},${EXCLUDE_WORKBENCH},${EXCLUDE_INTERPRETER},${EXCLUDE_CLIENT},${EXCLUDE_CLOUD},${EXCLUDE_SERVER},${EXCLUDE_ALL},${EXCLUDE_DIST},${EXCLUDE_TEST}" TEST_MODULES="-pl org.apache.submarine:commons-runtime" TEST_PROJECTS=""
+      env: PROFILE="-Phadoop-2.9" BUILD_FLAG="clean package install -DskipTests" TEST_FLAG="test -DskipRat -am" MODULES="-pl ${EXCLUDE_COMMONS},${EXCLUDE_SUBMITTER},${EXCLUDE_WORKBENCH},${EXCLUDE_INTERPRETER},${EXCLUDE_CLIENT},${EXCLUDE_CLOUD},${EXCLUDE_SERVER},${EXCLUDE_ALL},${EXCLUDE_DIST},${EXCLUDE_TEST}" TEST_MODULES="-pl org.apache.submarine:submarine-commons-runtime" TEST_PROJECTS=""
 
     - name: Test submarine server
       language: java
       jdk: openjdk8
       dist: xenial
-      env: PROFILE="-Phadoop-2.9" BUILD_FLAG="clean package install -DskipTests" TEST_FLAG="test -DskipRat -am" MODULES="-pl ${EXCLUDE_SUBMITTER_K8S},${EXCLUDE_WORKBENCH},${EXCLUDE_INTERPRETER},${EXCLUDE_CLOUD},${EXCLUDE_ALL},${EXCLUDE_DIST},${EXCLUDE_TEST}" TEST_MODULES="-pl ${EXCLUDE_COMMONS},org.apache.submarine:server-core" TEST_PROJECTS=""
+      env: PROFILE="-Phadoop-2.9" BUILD_FLAG="clean package install -DskipTests" TEST_FLAG="test -DskipRat -am" MODULES="-pl ${EXCLUDE_SUBMITTER_K8S},${EXCLUDE_WORKBENCH},${EXCLUDE_INTERPRETER},${EXCLUDE_CLOUD},${EXCLUDE_ALL},${EXCLUDE_DIST},${EXCLUDE_TEST}" TEST_MODULES="-pl ${EXCLUDE_COMMONS},org.apache.submarine:submarine-server-core" TEST_PROJECTS=""
 
     - name: Test submarine submitter on hadoop-2.9 (default)
       language: java
@@ -182,7 +182,7 @@ matrix:
       services: docker
       language: java
       jdk: openjdk8
-      env: BUILD_FLAG="clean package install -DskipTests -am" TEST_FLAG="test -am" MODULES="-pl org.apache.submarine:submitter-k8s" TEST_MODULES="-pl org.apache.submarine:submitter-k8s" TEST_PROJECTS=""
+      env: BUILD_FLAG="clean package install -DskipTests -am" TEST_FLAG="test -am" MODULES="-pl org.apache.submarine:submarine-submitter-k8s" TEST_MODULES="-pl org.apache.submarine:submarine-submitter-k8s" TEST_PROJECTS=""
       before_install:
         # deploy Kubernetes cluster
         - curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl
@@ -251,7 +251,7 @@ matrix:
         - npm run test -- --no-watch --no-progress --browsers=FirefoxHeadless
         - npm run webdriver
         - npm run e2e -- --protractor-config=e2e/protractor-ci.conf.js
-      env: BUILD_FLAG="clean package -DskipTests" TEST_FLAG="test -DskipRat -am" MODULES="-pl org.apache.submarine:workbench-web-ng" TEST_MODULES="-pl org.apache.submarine:workbench-web-ng" TEST_PROJECTS=""
+      env: BUILD_FLAG="clean package -DskipTests" TEST_FLAG="test -DskipRat -am" MODULES="-pl org.apache.submarine:submarine-workbench-web-ng" TEST_MODULES="-pl org.apache.submarine:submarine-workbench-web-ng" TEST_PROJECTS=""
 
 install:
   - mvn --version

--- a/conf/submarine-site.xml
+++ b/conf/submarine-site.xml
@@ -103,7 +103,7 @@
 
   <property>
     <name>workbench.web.war</name>
-    <value>../workbench-web-ng.war</value>
+    <value>../submarine-workbench-web-ng.war</value>
     <description>Submarine workbench web war file path.</description>
   </property>
 

--- a/conf/submarine-site.xml.template
+++ b/conf/submarine-site.xml.template
@@ -103,7 +103,7 @@
 
   <property>
     <name>workbench.web.war</name>
-    <value>../workbench-web-ng.war</value>
+    <value>../submarine-workbench-web-ng.war</value>
     <description>Submarine workbench web war file path.</description>
   </property>
 

--- a/dev-support/mini-submarine/conf/submarine-site.xml
+++ b/dev-support/mini-submarine/conf/submarine-site.xml
@@ -103,7 +103,7 @@
 
   <property>
     <name>workbench.web.war</name>
-    <value>../workbench-web-ng.war</value>
+    <value>../submarine-workbench-web-ng.war</value>
     <description>Submarine workbench web war file path.</description>
   </property>
 

--- a/docs/workbench/HowToRun.md
+++ b/docs/workbench/HowToRun.md
@@ -19,12 +19,12 @@ We provide two methods to launch Submarine Workbench
 
 # Run Submarine Workbench on docker
 
-By using the official images of Submarine, only a few docker commands are required to launch **Submarine Workbench**. The document includes information about how to launch the Submarine Workbench via the new docker images and the information about how to switch between different Submarine Workbench versions(version Vue & version Angular). 
+By using the official images of Submarine, only a few docker commands are required to launch **Submarine Workbench**. The document includes information about how to launch the Submarine Workbench via the new docker images and the information about how to switch between different Submarine Workbench versions(version Vue & version Angular).
 
 ### Two versions of Submarine Workbench
 1. Angular (default)
 2. Vue (This is the old version, and it will be replaced by version Angular in the future.)
-#### (WARNING: Please restart a new **incognito window** when you switch to different versions of Submarine Workbench) 
+#### (WARNING: Please restart a new **incognito window** when you switch to different versions of Submarine Workbench)
 ### Launch the Submarine Workbench(Angular)
 * It should be noted that since Submarine Workbench depends on the Submarine database, so you need to run the docker container of the Submarine database first.
 ```
@@ -34,7 +34,7 @@ docker run -it -p 8080:8080 -d --link=submarine-database:submarine-database --na
 * The login page of Submarine Workbench will be shown in ```http://127.0.0.1:8080```.
 
 ### Switch from version Angular to version Vue
-*  Step1: Launch submarine-database and submarine-server containers 
+*  Step1: Launch submarine-database and submarine-server containers
 ```
 docker run -it -p 3306:3306 -d --name submarine-database -e MYSQL_ROOT_PASSWORD=password apache/submarine:database-0.3.0-SNAPSHOT
 docker run -it -p 8080:8080 -d --link=submarine-database:submarine-database --name submarine-server apache/submarine:server-0.3.0-SNAPSHOT
@@ -42,7 +42,7 @@ docker run -it -p 8080:8080 -d --link=submarine-database:submarine-database --na
 *  Step2: Compile Submarine in your host (not in the container)
 ```
 cd ./submarine
-mvn clean install package -DskipTests 
+mvn clean install package -DskipTests
 ```
 *  Step3: Copy workbench-web.war into the submarine-server container
 ```
@@ -50,10 +50,10 @@ cd submarine-workbench/workbench-web/target
 docker cp workbench-web.war submarine-server:/opt/submarine-dist-0.3.0-SNAPSHOT-hadoop-2.9
 ```
 *  Step4: Enter the submarine-server container
-``` 
+```
 docker exec -it submarine-server bash
 ```
-*  Step5: Modify the value of the configutation **workbench.web.war** in conf/submarine-site.xml from "../workbench-web-ng.war" to "../workbench-web.war". 
+*  Step5: Modify the value of the configutation **workbench.web.war** in conf/submarine-site.xml from "../submarine-workbench-web-ng.war" to "../submarine-workbench-web.war".
 
 *  Step6: Restart the Submarine Server
 ```
@@ -63,13 +63,13 @@ docker exec -it submarine-server bash
 ```
 docker start submarine-server
 ```
-*  Step8: Open a new **incognito window(not a tab)** and check ```http://127.0.0.1:8080``` 
+*  Step8: Open a new **incognito window(not a tab)** and check ```http://127.0.0.1:8080```
 ### Switch from version Vue to version Angular
 *  Step1: Enter the submarine-server container
 ```
 docker exec -it submarine-server bash
 ```
-*  Step2: Modify the value of the configutation **workbench.web.war** in conf/submarine-site.xml from "../workbench-web.war" to "../workbench-web-ng.war".
+*  Step2: Modify the value of the configutation **workbench.web.war** in conf/submarine-site.xml from "../workbench-web.war" to "../submarine-workbench-web-ng.war".
 *  Step3: Restart the Submarine Server
 ```
 ./bin/submarine-daemon.sh restart
@@ -78,17 +78,17 @@ docker exec -it submarine-server bash
 ```
 docker start submarine-server
 ```
-*  Step5: Open a **new incognito window(not a tab)** and check ```http://127.0.0.1:8080``` 
+*  Step5: Open a **new incognito window(not a tab)** and check ```http://127.0.0.1:8080```
 ### Check the data in the submarine-database
 *  Step1: Enter the submarine-database container
 ```
 docker exec -it submarine-database bash
 ```
-*  Step2: Enter MySQL database 
+*  Step2: Enter MySQL database
 ```
 mysql -uroot -ppassword
 ```
-*  Step3: List the data in the table 
+*  Step3: List the data in the table
 ```
 // list all databases
 show databases;

--- a/submarine-all/pom.xml
+++ b/submarine-all/pom.xml
@@ -50,7 +50,7 @@
   <dependencies>
     <dependency>
       <groupId>org.apache.submarine</groupId>
-      <artifactId>commons-runtime</artifactId>
+      <artifactId>submarine-commons-runtime</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
@@ -70,7 +70,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.submarine</groupId>
-      <artifactId>submitter-yarn</artifactId>
+      <artifactId>submarine-submitter-yarn</artifactId>
       <version>${project.version}</version>
     </dependency>
   </dependencies>
@@ -81,7 +81,7 @@
       <dependencies>
         <dependency>
           <groupId>org.apache.submarine</groupId>
-          <artifactId>submitter-yarnservice</artifactId>
+          <artifactId>submarine-submitter-yarnservice</artifactId>
           <version>${project.version}</version>
           <exclusions>
             <exclusion>
@@ -128,7 +128,7 @@
       <dependencies>
         <dependency>
           <groupId>org.apache.submarine</groupId>
-          <artifactId>submitter-yarnservice</artifactId>
+          <artifactId>submarine-submitter-yarnservice</artifactId>
           <version>${project.version}</version>
           <exclusions>
             <exclusion>

--- a/submarine-client/pom.xml
+++ b/submarine-client/pom.xml
@@ -35,7 +35,7 @@
   <dependencies>
     <dependency>
       <groupId>org.apache.submarine</groupId>
-      <artifactId>commons-runtime</artifactId>
+      <artifactId>submarine-commons-runtime</artifactId>
       <version>${project.version}</version>
       <exclusions>
         <exclusion>
@@ -64,7 +64,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.submarine</groupId>
-      <artifactId>commons-runtime</artifactId>
+      <artifactId>submarine-commons-runtime</artifactId>
       <version>${project.version}</version>
       <type>test-jar</type>
       <scope>test</scope>
@@ -133,7 +133,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.submarine</groupId>
-      <artifactId>commons-rpc</artifactId>
+      <artifactId>submarine-commons-rpc</artifactId>
       <version>${project.version}</version>
       <exclusions>
         <exclusion>

--- a/submarine-commons/commons-cluster/pom.xml
+++ b/submarine-commons/commons-cluster/pom.xml
@@ -26,14 +26,14 @@
     <version>0.4.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
-  <artifactId>commons-cluster</artifactId>
+  <artifactId>submarine-commons-cluster</artifactId>
   <version>0.4.0-SNAPSHOT</version>
   <name>Submarine: Commons Cluster</name>
 
   <dependencies>
     <dependency>
       <groupId>org.apache.submarine</groupId>
-      <artifactId>commons-utils</artifactId>
+      <artifactId>submarine-commons-utils</artifactId>
       <version>${project.version}</version>
     </dependency>
 
@@ -140,7 +140,6 @@
   </dependencies>
 
   <build>
-    <finalName>submarine-${project.artifactId}-${project.version}</finalName>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -153,7 +152,7 @@
               <goal>shade</goal>
             </goals>
             <configuration>
-              <outputFile>target/submarine-${project.artifactId}-${project.version}-shade.jar</outputFile>
+              <outputFile>target/${project.artifactId}-${project.version}-shade.jar</outputFile>
               <filters>
                 <filter>
                   <artifact>*:*</artifact>
@@ -166,6 +165,7 @@
               </filters>
               <artifactSet>
                 <excludes>
+                  <exclude>commons-logging:commons-logging</exclude>
                   <exclude>org.slf4j:*</exclude>
                   <exclude>log4j:log4j</exclude>
                 </excludes>

--- a/submarine-commons/commons-metastore/pom.xml
+++ b/submarine-commons/commons-metastore/pom.xml
@@ -30,14 +30,14 @@
   </parent>
 
   <groupId>org.apache.submarine</groupId>
-  <artifactId>commons-metastore</artifactId>
+  <artifactId>submarine-commons-metastore</artifactId>
   <version>0.4.0-SNAPSHOT</version>
   <name>Submarine: Commons MetaStore</name>
 
   <dependencies>
     <dependency>
       <groupId>org.apache.submarine</groupId>
-      <artifactId>commons-utils</artifactId>
+      <artifactId>submarine-commons-utils</artifactId>
       <version>${project.version}</version>
     </dependency>
 
@@ -311,7 +311,6 @@
   </dependencies>
 
   <build>
-    <finalName>submarine-${project.artifactId}-${project.version}</finalName>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -324,7 +323,7 @@
               <goal>shade</goal>
             </goals>
             <configuration>
-              <outputFile>target/submarine-${project.artifactId}-${project.version}-shade.jar</outputFile>
+              <outputFile>target/${project.artifactId}-${project.version}-shade.jar</outputFile>
               <minimizeJar>true</minimizeJar>
               <filters>
                 <filter>

--- a/submarine-commons/commons-rpc/pom.xml
+++ b/submarine-commons/commons-rpc/pom.xml
@@ -30,7 +30,7 @@
   </parent>
 
   <groupId>org.apache.submarine</groupId>
-  <artifactId>commons-rpc</artifactId>
+  <artifactId>submarine-commons-rpc</artifactId>
   <version>0.4.0-SNAPSHOT</version>
   <name>Submarine: Commons RPC</name>
 
@@ -68,7 +68,6 @@
   </dependencies>
 
   <build>
-    <finalName>submarine-${project.artifactId}-${project.version}</finalName>
     <extensions>
       <extension>
         <groupId>kr.motd.maven</groupId>

--- a/submarine-commons/commons-runtime/pom.xml
+++ b/submarine-commons/commons-runtime/pom.xml
@@ -29,14 +29,14 @@
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>org.apache.submarine</groupId>
-  <artifactId>commons-runtime</artifactId>
+  <artifactId>submarine-commons-runtime</artifactId>
   <version>0.4.0-SNAPSHOT</version>
   <name>Submarine: Commons Runtime</name>
 
   <dependencies>
     <dependency>
       <groupId>org.apache.submarine</groupId>
-      <artifactId>commons-utils</artifactId>
+      <artifactId>submarine-commons-utils</artifactId>
       <version>${project.version}</version>
       <exclusions>
         <exclusion>
@@ -194,7 +194,6 @@
   </dependencies>
 
   <build>
-    <finalName>submarine-${project.artifactId}-${project.version}</finalName>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/submarine-commons/commons-utils/pom.xml
+++ b/submarine-commons/commons-utils/pom.xml
@@ -30,7 +30,7 @@
   </parent>
 
   <groupId>org.apache.submarine</groupId>
-  <artifactId>commons-utils</artifactId>
+  <artifactId>submarine-commons-utils</artifactId>
   <version>0.4.0-SNAPSHOT</version>
   <name>Submarine: Commons Utils</name>
 
@@ -73,7 +73,6 @@
   </dependencies>
 
   <build>
-    <finalName>submarine-${project.artifactId}-${project.version}</finalName>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/submarine-dist/pom.xml
+++ b/submarine-dist/pom.xml
@@ -46,7 +46,7 @@
   <dependencies>
     <dependency>
       <groupId>org.apache.submarine</groupId>
-      <artifactId>commons-runtime</artifactId>
+      <artifactId>submarine-commons-runtime</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
@@ -56,7 +56,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.submarine</groupId>
-      <artifactId>submitter-yarn</artifactId>
+      <artifactId>submarine-submitter-yarn</artifactId>
       <version>${project.version}</version>
     </dependency>
   </dependencies>
@@ -67,7 +67,7 @@
       <dependencies>
         <dependency>
           <groupId>org.apache.submarine</groupId>
-          <artifactId>submitter-yarnservice</artifactId>
+          <artifactId>submarine-submitter-yarnservice</artifactId>
           <version>${project.version}</version>
           <exclusions>
             <exclusion>
@@ -84,7 +84,7 @@
       <dependencies>
         <dependency>
           <groupId>org.apache.submarine</groupId>
-          <artifactId>submitter-yarnservice</artifactId>
+          <artifactId>submarine-submitter-yarnservice</artifactId>
           <version>${project.version}</version>
           <exclusions>
             <exclusion>

--- a/submarine-dist/src/assembly/distribution.xml
+++ b/submarine-dist/src/assembly/distribution.xml
@@ -70,7 +70,7 @@
       <directory>../submarine-workbench/workbench-web-ng/target</directory>
       <outputDirectory>/</outputDirectory>
       <includes>
-        <include>workbench-web-ng.war</include>
+        <include>submarine-workbench-web-ng.war</include>
       </includes>
     </fileSet>
     <fileSet>
@@ -95,14 +95,14 @@
       <outputDirectory>/dev-support/docker-images</outputDirectory>
     </fileSet>
     <fileSet>
-      <directory>../submarine-commons/commons-utils/target</directory>
+      <directory>../submarine-commons/submarine-commons-utils/target</directory>
       <outputDirectory>/lib</outputDirectory>
       <includes>
         <include>submarine-commons-utils-${project.version}.jar</include>
       </includes>
     </fileSet>
     <fileSet>
-      <directory>../submarine-commons/commons-runtime/target</directory>
+      <directory>../submarine-commons/submarine-commons-runtime/target</directory>
       <outputDirectory>/lib</outputDirectory>
       <includes>
         <include>submarine-commons-runtime-${project.version}.jar</include>
@@ -176,11 +176,8 @@
       <outputDirectory>/lib</outputDirectory>
       <excludes>
         <!-- exclude rename to submarine-commons-*.jar -->
-        <exclude>commons-utils-${project.version}.jar</exclude>
-        <exclude>commons-runtime-${project.version}.jar</exclude>
-        <exclude>commons-cluster-${project.version}.jar</exclude>
-        <exclude>commons-rpc-${project.version}.jar</exclude>
-        <exclude>commons-metastore-${project.version}.jar</exclude>
+        <exclude>submarine-commons-cluster-${project.version}.jar</exclude>
+        <exclude>submarine-commons-metastore-${project.version}.jar</exclude>
         <exclude>grpc-*.jar</exclude>
         <exclude>protobuf-java*.jar</exclude>
         <!-- mysql-connector-java uses the GPL license. So we need exclude mysql-connector-java jar -->

--- a/submarine-server/pom.xml
+++ b/submarine-server/pom.xml
@@ -44,7 +44,7 @@
     <dependencies>
       <dependency>
         <groupId>org.apache.submarine</groupId>
-        <artifactId>commons-runtime</artifactId>
+        <artifactId>submarine-commons-runtime</artifactId>
         <version>${project.version}</version>
         <exclusions>
           <exclusion>
@@ -67,7 +67,7 @@
       </dependency>
       <dependency>
         <groupId>org.apache.submarine</groupId>
-        <artifactId>commons-utils</artifactId>
+        <artifactId>submarine-commons-utils</artifactId>
         <version>${project.version}</version>
       </dependency>
       <dependency>

--- a/submarine-server/server-api/pom.xml
+++ b/submarine-server/server-api/pom.xml
@@ -28,14 +28,29 @@
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
-  <artifactId>server-api</artifactId>
+  <artifactId>submarine-server-api</artifactId>
   <name>Submarine: Server API</name>
 
   <dependencies>
     <dependency>
       <groupId>org.apache.submarine</groupId>
-      <artifactId>commons-utils</artifactId>
+      <artifactId>submarine-commons-utils</artifactId>
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+        <configuration>
+          <skip>false</skip>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <artifactId>maven-enforcer-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/submarine-server/server-api/src/main/java/org/apache/submarine/server/api/JobHandler.java
+++ b/submarine-server/server-api/src/main/java/org/apache/submarine/server/api/JobHandler.java
@@ -42,7 +42,7 @@ public interface JobHandler {
    * @throws UnsupportedJobTypeException caused by the unsupported job type
    */
   default Job getJob(JobSpec jobSpec) throws UnsupportedJobTypeException {
-    // TODO should implementing later
+    // TODO(submarine) should implementing later
     return null;
   }
 
@@ -53,7 +53,7 @@ public interface JobHandler {
    * @throws UnsupportedJobTypeException caused by the unsupported job type
    */
   default Job updateJob(JobSpec jobSpec) throws UnsupportedJobTypeException {
-    // TODO should implementing later
+    // TODO(submarine) should implementing later
     return null;
   }
 
@@ -64,7 +64,7 @@ public interface JobHandler {
    * @throws UnsupportedJobTypeException caused by the unsupported job type
    */
   default Job deleteJob(JobSpec jobSpec) throws UnsupportedJobTypeException {
-    // TODO should implementing later
+    // TODO(submarine) should implementing later
     return null;
   }
 }

--- a/submarine-server/server-api/src/main/java/org/apache/submarine/server/api/job/Job.java
+++ b/submarine-server/server-api/src/main/java/org/apache/submarine/server/api/job/Job.java
@@ -19,8 +19,6 @@
 
 package org.apache.submarine.server.api.job;
 
-import org.apache.submarine.server.api.spec.JobSpec;
-
 /**
  * The Generic Machine Learning Job in Submarine.
  */
@@ -61,7 +59,7 @@ public class Job {
   }
 
   /**
-   * Get the job name which specified by user through the {@link JobSpec}
+   * Get the job name which specified by user through the JobSpec
    * @return the job name
    */
   public String getName() {

--- a/submarine-server/server-core/pom.xml
+++ b/submarine-server/server-core/pom.xml
@@ -28,25 +28,25 @@
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
-  <artifactId>server-core</artifactId>
+  <artifactId>submarine-server-core</artifactId>
   <name>Submarine: Server Core</name>
 
   <dependencies>
     <dependency>
       <groupId>org.apache.submarine</groupId>
-      <artifactId>commons-cluster</artifactId>
+      <artifactId>submarine-commons-cluster</artifactId>
       <version>${project.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.apache.submarine</groupId>
-      <artifactId>server-api</artifactId>
+      <artifactId>submarine-server-api</artifactId>
       <version>${project.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.apache.submarine</groupId>
-      <artifactId>commons-metastore</artifactId>
+      <artifactId>submarine-commons-metastore</artifactId>
       <version>${project.version}</version>
       <exclusions>
         <exclusion>
@@ -134,7 +134,7 @@
 
     <dependency>
       <groupId>org.apache.submarine</groupId>
-      <artifactId>server-rpc</artifactId>
+      <artifactId>submarine-server-rpc</artifactId>
       <version>${project.version}</version>
       <exclusions>
         <exclusion>
@@ -405,7 +405,6 @@
   </dependencies>
 
   <build>
-    <finalName>submarine-${project.artifactId}-${project.version}</finalName>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/submarine-server/server-core/src/main/resources/submarine-site.xml
+++ b/submarine-server/server-core/src/main/resources/submarine-site.xml
@@ -103,7 +103,7 @@
 
   <property>
     <name>workbench.web.war</name>
-    <value>submarine-workbench/workbench-web-ng/target/workbench-web-ng.war</value>
+    <value>submarine-workbench/workbench-web-ng/target/submarine-workbench-web-ng.war</value>
     <description>Submarine workbench web war file path.</description>
   </property>
 

--- a/submarine-server/server-rpc/pom.xml
+++ b/submarine-server/server-rpc/pom.xml
@@ -28,14 +28,14 @@
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
-  <artifactId>server-rpc</artifactId>
+  <artifactId>submarine-server-rpc</artifactId>
   <version>0.4.0-SNAPSHOT</version>
   <name>Submarine: Server RPC</name>
 
   <dependencies>
     <dependency>
       <groupId>org.apache.submarine</groupId>
-      <artifactId>commons-rpc</artifactId>
+      <artifactId>submarine-commons-rpc</artifactId>
       <version>${project.version}</version>
       <exclusions>
         <exclusion>
@@ -80,7 +80,7 @@
 
     <dependency>
       <groupId>org.apache.submarine</groupId>
-      <artifactId>submitter-yarn</artifactId>
+      <artifactId>submarine-submitter-yarn</artifactId>
       <version>${project.version}</version>
       <exclusions>
         <exclusion>
@@ -92,7 +92,7 @@
 
     <dependency>
       <groupId>org.apache.submarine</groupId>
-      <artifactId>commons-runtime</artifactId>
+      <artifactId>submarine-commons-runtime</artifactId>
       <version>${project.version}</version>
       <exclusions>
         <exclusion>
@@ -108,4 +108,19 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+        <configuration>
+          <skip>false</skip>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <artifactId>maven-enforcer-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/submarine-server/server-rpc/src/main/java/org/apache/submarine/server/rpc/SubmarineRpcServer.java
+++ b/submarine-server/server-rpc/src/main/java/org/apache/submarine/server/rpc/SubmarineRpcServer.java
@@ -117,8 +117,7 @@ public class SubmarineRpcServer {
     ClientContext clientContext = new ClientContext();
     clientContext.setYarnConfig(conf);
     mergeSubmarineConfiguration(clientContext.getSubmarineConfig(), rpcContext);
-    String runtimeClass =
-      clientContext.getSubmarineConfig().getString(SUBMARINE_RUNTIME_CLASS);
+    String runtimeClass = clientContext.getSubmarineConfig().getString(SUBMARINE_RUNTIME_CLASS);
     ClassLoader classLoader = null;
     if (runtimeClass.contains("YarnServiceRuntimeFactory")) {
       classLoader = new URLClassLoader(constructUrlsFromClasspath("../lib/submitter/yarnservice"));
@@ -159,9 +158,9 @@ public class SubmarineRpcServer {
 
   private static void mergeSubmarineConfiguration(
       SubmarineConfiguration submarineConfiguration, RpcContext rpcContext) {
-    Map<String, String> submarineJobConfigMap =
-        rpcContext.getSubmarineJobConfigMap();
-    for(Map.Entry<String, String> entry: submarineJobConfigMap.entrySet()){
+    Map<String, String> submarineJobConfigMap
+        = rpcContext.getSubmarineJobConfigMap();
+    for (Map.Entry<String, String> entry: submarineJobConfigMap.entrySet()){
       submarineConfiguration.updateConfiguration(
           entry.getKey(), entry.getValue());
     }
@@ -225,7 +224,7 @@ public class SubmarineRpcServer {
 
     protected ApplicationId run(ClientContext clientContext, Parameter parameter)
         throws IOException, YarnException, SubmarineException {
-      // TODO replaced with JobManager
+      // TODO(who) replaced with JobManager
       JobSubmitter jobSubmitter =
           clientContext.getRuntimeFactory().getJobSubmitterInstance();
       ApplicationId applicationId = jobSubmitter.submitJob(parameter);

--- a/submarine-server/server-rpc/src/main/java/org/apache/submarine/server/rpc/SubmarineRpcServerProto.java
+++ b/submarine-server/server-rpc/src/main/java/org/apache/submarine/server/rpc/SubmarineRpcServerProto.java
@@ -78,7 +78,7 @@ public class SubmarineRpcServerProto {
 
   public static void setCommandLineYamlConfigIfNeeded(
       Parameter parameter, ParameterProto parameterProto) {
-    if(parameter instanceof ParametersHolder) {
+    if (parameter instanceof ParametersHolder) {
       ParametersHolder parametersHolder = ((ParametersHolder) parameter);
       CommandLine commandLine = convertCommandLineProtoToCommandLine(
           parameterProto.getCommandLine());
@@ -93,7 +93,7 @@ public class SubmarineRpcServerProto {
   public static Map<String, List<String>> covertYamlListConfigs(
       Map<String, ListOfString> yamlListConfigs) {
     Map<String, List<String>> map = new HashMap<>();
-    for(Map.Entry<String, ListOfString> entry : yamlListConfigs.entrySet()) {
+    for (Map.Entry<String, ListOfString> entry : yamlListConfigs.entrySet()) {
       List<String> value =
           entry.getValue().getValuesList();
       map.put(entry.getKey(), value);
@@ -119,7 +119,7 @@ public class SubmarineRpcServerProto {
         Class optionClass = Option.class;
         Method add = optionClass.getDeclaredMethod("add", String.class);
         add.setAccessible(true);
-        for(String value : optionProto.getValuesList()) {
+        for (String value : optionProto.getValuesList()) {
           add.invoke(option, value);
         }
       } catch (Exception e) {

--- a/submarine-server/server-rpc/src/test/java/org/apache/submarine/server/rpc/MockRpcServer.java
+++ b/submarine-server/server-rpc/src/test/java/org/apache/submarine/server/rpc/MockRpcServer.java
@@ -55,7 +55,7 @@ public class MockRpcServer extends SubmarineRpcServer {
   }
 
   private static void checkProtoConversion(ParametersHolder parametersHolder) throws YarnException {
-    if(parametersHolder.getParameters()
+    if (parametersHolder.getParameters()
         instanceof TensorFlowRunJobParameters) {
       TensorFlowRunJobParameters tensorParameter =
           (TensorFlowRunJobParameters) parametersHolder.getParameters();

--- a/submarine-server/server-rpc/src/test/java/org/apache/submarine/server/rpc/RpcServerTestUtils.java
+++ b/submarine-server/server-rpc/src/test/java/org/apache/submarine/server/rpc/RpcServerTestUtils.java
@@ -64,7 +64,7 @@ public class RpcServerTestUtils {
     boolean isRunning = false;
     try {
       isRunning = client.testRpcConnection();
-    } catch(InterruptedException e) {
+    } catch (InterruptedException e) {
       LOG.error(e.getMessage(), e);
     }
     return isRunning;

--- a/submarine-server/server-rpc/src/test/java/org/apache/submarine/server/rpc/SubmarineRpcClient.java
+++ b/submarine-server/server-rpc/src/test/java/org/apache/submarine/server/rpc/SubmarineRpcClient.java
@@ -31,7 +31,6 @@ import org.slf4j.LoggerFactory;
 
 import java.util.concurrent.TimeUnit;
 
-
 /**
  * Sample client code that makes gRPC calls to the server.
  */
@@ -79,13 +78,12 @@ public class SubmarineRpcClient extends RpcServerTestUtils {
       blockingStub.testRpc(request);
       isRunning = true;
     } catch (StatusRuntimeException e) {
-      LOG.error(e.getMessage(),e);
+      LOG.error(e.getMessage(), e);
     } finally {
       shutdown();
     }
     return isRunning;
   }
-
 
   public static void main(String[] args) throws InterruptedException {
     SubmarineRpcClient client = new SubmarineRpcClient("localhost", 8980);

--- a/submarine-server/server-rpc/src/test/java/org/apache/submarine/server/rpc/SubmarineRpcServerTest.java
+++ b/submarine-server/server-rpc/src/test/java/org/apache/submarine/server/rpc/SubmarineRpcServerTest.java
@@ -58,7 +58,9 @@ public class SubmarineRpcServerTest {
         "--num_ps", "1",
         "--ps_resources", "memory=1G,vcores=1",
         "--worker_launch_cmd", "${WORKER_CMD}",
-        "--ps_launch_cmd", "myvenv.zip/venv/bin/python mnist_distributed.py --steps 2 --data_dir /tmp/data --working_dir /tmp/mode",
+        "--ps_launch_cmd",
+        "myvenv.zip/venv/bin/python mnist_distributed.py " +
+          "--steps 2 --data_dir /tmp/data --working_dir /tmp/mode",
         "--insecure"
     };
     new RunJobCli(clientContext).run(moduleArgs);

--- a/submarine-server/server-submitter/pom.xml
+++ b/submarine-server/server-submitter/pom.xml
@@ -28,7 +28,7 @@
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
-  <artifactId>server-submitter</artifactId>
+  <artifactId>submarine-server-submitter</artifactId>
   <version>0.4.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Submarine: Submitter</name>

--- a/submarine-server/server-submitter/submitter-k8s/pom.xml
+++ b/submarine-server/server-submitter/submitter-k8s/pom.xml
@@ -22,13 +22,13 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <parent>
-    <artifactId>server-submitter</artifactId>
+    <artifactId>submarine-server-submitter</artifactId>
     <groupId>org.apache.submarine</groupId>
     <version>0.4.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
-  <artifactId>submitter-k8s</artifactId>
+  <artifactId>submarine-submitter-k8s</artifactId>
   <version>0.4.0-SNAPSHOT</version>
   <name>Submarine: Kubernetes Submitter</name>
 
@@ -53,7 +53,7 @@
 
     <dependency>
       <groupId>org.apache.submarine</groupId>
-      <artifactId>server-api</artifactId>
+      <artifactId>submarine-server-api</artifactId>
       <version>${project.version}</version>
     </dependency>
 
@@ -65,7 +65,6 @@
   </dependencies>
 
   <build>
-    <finalName>submarine-${project.artifactId}-${project.version}</finalName>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/submarine-server/server-submitter/submitter-yarn/pom.xml
+++ b/submarine-server/server-submitter/submitter-yarn/pom.xml
@@ -19,12 +19,12 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.apache.submarine</groupId>
-    <artifactId>server-submitter</artifactId>
+    <artifactId>submarine-server-submitter</artifactId>
     <version>0.4.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
-  <artifactId>submitter-yarn</artifactId>
+  <artifactId>submarine-submitter-yarn</artifactId>
   <version>0.4.0-SNAPSHOT</version>
   <name>Submarine: YARN Submitter</name>
 
@@ -277,7 +277,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.submarine</groupId>
-      <artifactId>commons-runtime</artifactId>
+      <artifactId>submarine-commons-runtime</artifactId>
       <type>test-jar</type>
       <scope>test</scope>
       <version>${project.version}</version>
@@ -329,7 +329,6 @@
   </profiles>
 
   <build>
-    <finalName>submarine-${project.artifactId}-${project.version}</finalName>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -342,7 +341,7 @@
               <goal>shade</goal>
             </goals>
             <configuration>
-              <outputFile>target/submarine-${project.artifactId}-${project.version}-shade.jar</outputFile>
+              <outputFile>target/${project.artifactId}-${project.version}-shade.jar</outputFile>
               <filters>
                 <filter>
                   <artifact>*:*</artifact>

--- a/submarine-server/server-submitter/submitter-yarnservice/pom.xml
+++ b/submarine-server/server-submitter/submitter-yarnservice/pom.xml
@@ -24,11 +24,11 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.apache.submarine</groupId>
-    <artifactId>server-submitter</artifactId>
+    <artifactId>submarine-server-submitter</artifactId>
     <version>0.4.0-SNAPSHOT</version>
   </parent>
 
-  <artifactId>submitter-yarnservice</artifactId>
+  <artifactId>submarine-submitter-yarnservice</artifactId>
   <version>0.4.0-SNAPSHOT</version>
   <name>Submarine: YARN Service Submitter</name>
 
@@ -40,7 +40,7 @@
   <dependencies>
     <dependency>
       <groupId>org.apache.submarine</groupId>
-      <artifactId>commons-runtime</artifactId>
+      <artifactId>submarine-commons-runtime</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
@@ -57,7 +57,7 @@
 
     <dependency>
       <groupId>org.apache.submarine</groupId>
-      <artifactId>commons-runtime</artifactId>
+      <artifactId>submarine-commons-runtime</artifactId>
       <version>${project.version}</version>
       <type>test-jar</type>
       <scope>test</scope>
@@ -199,14 +199,14 @@
     </dependency>
     <dependency>
       <groupId>org.apache.submarine</groupId>
-      <artifactId>commons-runtime</artifactId>
+      <artifactId>submarine-commons-runtime</artifactId>
       <version>${project.version}</version>
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.submarine</groupId>
-      <artifactId>commons-runtime</artifactId>
+      <artifactId>submarine-commons-runtime</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
@@ -322,7 +322,6 @@
   </dependencies>
 
   <build>
-    <finalName>submarine-${artifactId}-${project.version}</finalName>
     <plugins>
       <plugin>
         <artifactId>maven-jar-plugin</artifactId>

--- a/submarine-test/test-e2e/pom.xml
+++ b/submarine-test/test-e2e/pom.xml
@@ -28,7 +28,7 @@
     <version>0.4.0-SNAPSHOT</version>
   </parent>
 
-  <artifactId>test-e2e</artifactId>
+  <artifactId>submarine-test-e2e</artifactId>
   <version>0.4.0-SNAPSHOT</version>
   <name>Submarine: E2E Test</name>
 

--- a/submarine-test/test-k8s/pom.xml
+++ b/submarine-test/test-k8s/pom.xml
@@ -28,7 +28,7 @@
     <version>0.4.0-SNAPSHOT</version>
   </parent>
 
-  <artifactId>test-k8s</artifactId>
+  <artifactId>submarine-test-k8s</artifactId>
   <version>0.4.0-SNAPSHOT</version>
   <name>Submarine: Kubernetes Test</name>
 
@@ -39,13 +39,13 @@
   <dependencies>
     <dependency>
       <groupId>org.apache.submarine</groupId>
-      <artifactId>server-core</artifactId>
+      <artifactId>submarine-server-core</artifactId>
       <version>${project.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.apache.submarine</groupId>
-      <artifactId>server-core</artifactId>
+      <artifactId>submarine-server-core</artifactId>
       <version>${project.version}</version>
       <type>test-jar</type>
       <classifier>tests</classifier>

--- a/submarine-workbench/interpreter/interpreter-engine/pom.xml
+++ b/submarine-workbench/interpreter/interpreter-engine/pom.xml
@@ -25,12 +25,12 @@
 
   <parent>
     <groupId>org.apache.submarine</groupId>
-    <artifactId>interpreter</artifactId>
+    <artifactId>submarine-interpreter</artifactId>
     <version>0.4.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
-  <artifactId>interpreter-engine</artifactId>
+  <artifactId>submarine-interpreter-engine</artifactId>
   <version>0.4.0-SNAPSHOT</version>
   <name>Submarine: Interpreter Engine</name>
   <description>Submarine Interpreter Engine</description>
@@ -38,13 +38,13 @@
   <dependencies>
     <dependency>
       <groupId>org.apache.submarine</groupId>
-      <artifactId>commons-utils</artifactId>
+      <artifactId>submarine-commons-utils</artifactId>
       <version>${project.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.apache.submarine</groupId>
-      <artifactId>commons-cluster</artifactId>
+      <artifactId>submarine-commons-cluster</artifactId>
       <version>${project.version}</version>
     </dependency>
 
@@ -106,7 +106,6 @@
     </dependency>
   </dependencies>
   <build>
-    <finalName>submarine-${artifactId}-${project.version}</finalName>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/submarine-workbench/interpreter/pom.xml
+++ b/submarine-workbench/interpreter/pom.xml
@@ -30,7 +30,7 @@
     <relativePath>../pom.xml</relativePath>
   </parent>
 
-  <artifactId>interpreter</artifactId>
+  <artifactId>submarine-interpreter</artifactId>
   <version>0.4.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Submarine: Interpreter Parent</name>

--- a/submarine-workbench/interpreter/python-interpreter/pom.xml
+++ b/submarine-workbench/interpreter/python-interpreter/pom.xml
@@ -30,7 +30,7 @@
     <relativePath>../pom.xml</relativePath>
   </parent>
 
-  <artifactId>python-interpreter</artifactId>
+  <artifactId>submarine-python-interpreter</artifactId>
   <version>0.4.0-SNAPSHOT</version>
   <name>Submarine: Interpreter Python</name>
   <description>Submarine Python Interpreter</description>
@@ -38,7 +38,7 @@
   <dependencies>
     <dependency>
       <groupId>org.apache.submarine</groupId>
-      <artifactId>interpreter-engine</artifactId>
+      <artifactId>submarine-interpreter-engine</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
@@ -201,7 +201,6 @@
   </dependencies>
 
   <build>
-    <finalName>submarine-${artifactId}-${project.version}</finalName>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/submarine-workbench/interpreter/spark-interpreter/pom.xml
+++ b/submarine-workbench/interpreter/spark-interpreter/pom.xml
@@ -25,7 +25,7 @@
 
   <parent>
     <groupId>org.apache.submarine</groupId>
-    <artifactId>interpreter</artifactId>
+    <artifactId>submarine-interpreter</artifactId>
     <version>0.4.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
@@ -38,7 +38,7 @@
   <dependencies>
     <dependency>
       <groupId>org.apache.submarine</groupId>
-      <artifactId>interpreter-engine</artifactId>
+      <artifactId>submarine-interpreter-engine</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
@@ -179,7 +179,6 @@
   </dependencies>
 
   <build>
-    <finalName>submarine-${artifactId}-${project.version}</finalName>
     <testResources>
       <testResource>
         <directory>${project.basedir}/src/test/resources</directory>

--- a/submarine-workbench/workbench-web-ng/pom.xml
+++ b/submarine-workbench/workbench-web-ng/pom.xml
@@ -30,7 +30,7 @@
   </parent>
 
   <groupId>org.apache.submarine</groupId>
-  <artifactId>workbench-web-ng</artifactId>
+  <artifactId>submarine-workbench-web-ng</artifactId>
   <packaging>war</packaging>
   <version>0.4.0-SNAPSHOT</version>
   <name>Submarine: Workbench Web Angular</name>

--- a/submarine-workbench/workbench-web/pom.xml
+++ b/submarine-workbench/workbench-web/pom.xml
@@ -28,7 +28,7 @@
   </parent>
 
   <groupId>org.apache.submarine</groupId>
-  <artifactId>workbench-web</artifactId>
+  <artifactId>submarine-workbench-web</artifactId>
   <packaging>war</packaging>
   <version>0.4.0-SNAPSHOT</version>
   <name>Submarine: Workbench Web</name>


### PR DESCRIPTION
### What is this PR for?
At present, the artifactId of some submarine modules does not contain submarine, resulting in the compiled jar file without the submarine prefix.


### What type of PR is it?
[Bug Fix | Improvement | Refactoring]

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/SUBMARINE-410

### How should this be tested?
* https://travis-ci.org/liuxunorg/submarine

### Screenshots (if appropriate)
```
find ./lib -name "*0.4.0*.jar" 
./lib/submarine-commons-metastore-0.4.0-SNAPSHOT-shade.jar
./lib/submarine-server-rpc-0.4.0-SNAPSHOT.jar
./lib/submarine-commons-cluster-0.4.0-SNAPSHOT-shade.jar
./lib/submarine-commons-rpc-0.4.0-SNAPSHOT.jar
./lib/submarine-server-api-0.4.0-SNAPSHOT.jar
./lib/submarine-submitter-yarn-0.4.0-SNAPSHOT.jar
./lib/submarine-commons-utils-0.4.0-SNAPSHOT.jar
./lib/submarine-commons-runtime-0.4.0-SNAPSHOT.jar
./lib/submarine-server-core-0.4.0-SNAPSHOT.jar
./lib/submitter/k8s/submarine-server-api-0.4.0-SNAPSHOT.jar
./lib/submitter/k8s/submarine-commons-utils-0.4.0-SNAPSHOT.jar
./lib/submitter/k8s/submarine-submitter-k8s-0.4.0-SNAPSHOT.jar
./lib/submitter/yarn/submarine-submitter-yarn-0.4.0-SNAPSHOT-shade.jar
./lib/submarine-client-0.4.0-SNAPSHOT.jar
```


### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
