### PR TITLE
SUBMARINE-78. Make RemoteDirectoryManager interface more consistent

### DIFF
--- a/submarine-commons/commons-runtime/src/main/java/org/apache/submarine/commons/runtime/fs/DefaultRemoteDirectoryManager.java
+++ b/submarine-commons/commons-runtime/src/main/java/org/apache/submarine/commons/runtime/fs/DefaultRemoteDirectoryManager.java
@@ -134,13 +134,13 @@ public class DefaultRemoteDirectoryManager implements RemoteDirectoryManager {
   }
 
   @Override
-  public boolean existsRemoteFile(Path url) throws IOException {
-    return getFileSystemByUri(url.toUri().toString()).exists(url);
+  public boolean existsRemoteFile(String remoteUri) throws IOException {
+    return getFileSystemByUri(remoteUri).exists(new Path(remoteUri));
   }
 
   @Override
-  public FileStatus getRemoteFileStatus(Path url) throws IOException {
-    return getFileSystemByUri(url.toUri().toString()).getFileStatus(url);
+  public FileStatus getRemoteFileStatus(String remoteUri) throws IOException {
+    return getFileSystemByUri(remoteUri).getFileStatus(new Path(remoteUri));
   }
 
   @Override

--- a/submarine-commons/commons-runtime/src/main/java/org/apache/submarine/commons/runtime/fs/DefaultRemoteDirectoryManager.java
+++ b/submarine-commons/commons-runtime/src/main/java/org/apache/submarine/commons/runtime/fs/DefaultRemoteDirectoryManager.java
@@ -134,13 +134,13 @@ public class DefaultRemoteDirectoryManager implements RemoteDirectoryManager {
   }
 
   @Override
-  public boolean existsRemoteFile(String remoteUri) throws IOException {
-    return getFileSystemByUri(remoteUri).exists(new Path(remoteUri));
+  public boolean existsRemoteFile(String uri) throws IOException {
+    return getFileSystemByUri(uri).exists(new Path(uri));
   }
 
   @Override
-  public FileStatus getRemoteFileStatus(String remoteUri) throws IOException {
-    return getFileSystemByUri(remoteUri).getFileStatus(new Path(remoteUri));
+  public FileStatus getRemoteFileStatus(String uri) throws IOException {
+    return getFileSystemByUri(uri).getFileStatus(new Path(uri));
   }
 
   @Override

--- a/submarine-commons/commons-runtime/src/main/java/org/apache/submarine/commons/runtime/fs/RemoteDirectoryManager.java
+++ b/submarine-commons/commons-runtime/src/main/java/org/apache/submarine/commons/runtime/fs/RemoteDirectoryManager.java
@@ -45,9 +45,9 @@ public interface RemoteDirectoryManager {
   boolean copyRemoteToLocal(String remoteUri, String localUri)
       throws IOException;
 
-  boolean existsRemoteFile(Path uri) throws IOException;
+  boolean existsRemoteFile(String uri) throws IOException;
 
-  FileStatus getRemoteFileStatus(Path uri) throws IOException;
+  FileStatus getRemoteFileStatus(String uri) throws IOException;
 
   long getRemoteFileSize(String uri) throws IOException;
 }

--- a/submarine-commons/commons-runtime/src/test/java/org/apache/submarine/commons/runtime/fs/MockRemoteDirectoryManager.java
+++ b/submarine-commons/commons-runtime/src/test/java/org/apache/submarine/commons/runtime/fs/MockRemoteDirectoryManager.java
@@ -183,16 +183,17 @@ public class MockRemoteDirectoryManager implements RemoteDirectoryManager {
   }
 
   @Override
-  public boolean existsRemoteFile(Path uri) throws IOException {
+  public boolean existsRemoteFile(String uri) throws IOException {
+    String dirName = new Path(uri).getName();
     String fakeLocalFilePath = this.jobDir.getAbsolutePath()
-        + "/" + uri.getName();
+        + "/" + dirName;
     return new File(fakeLocalFilePath).exists();
   }
 
   @Override
-  public FileStatus getRemoteFileStatus(Path p) throws IOException {
+  public FileStatus getRemoteFileStatus(String uri) throws IOException {
     return getDefaultFileSystem().getFileStatus(new Path(
-        convertToStagingPath(p.toUri().toString())));
+        convertToStagingPath(uri)));
   }
 
   @Override

--- a/submarine-server/server-submitter/submitter-yarnservice/src/main/java/org/apache/submarine/server/submitter/yarnservice/FileSystemOperations.java
+++ b/submarine-server/server-submitter/submitter-yarnservice/src/main/java/org/apache/submarine/server/submitter/yarnservice/FileSystemOperations.java
@@ -119,7 +119,7 @@ public class FileSystemOperations {
     if (remote) {
       // Append original modification time and size to zip file name
       FileStatus status =
-          remoteDirectoryManager.getRemoteFileStatus(new Path(remoteDir));
+          remoteDirectoryManager.getRemoteFileStatus(remoteDir);
       suffix = getSuffixOfRemoteDirectory(remoteDir, status);
       // Download them to temp dir
       downloadRemoteFile(remoteDir, destFilePath);

--- a/submarine-server/server-submitter/submitter-yarnservice/src/main/java/org/apache/submarine/server/submitter/yarnservice/utils/Localizer.java
+++ b/submarine-server/server-submitter/submitter-yarnservice/src/main/java/org/apache/submarine/server/submitter/yarnservice/utils/Localizer.java
@@ -170,10 +170,9 @@ public class Localizer {
     String remoteUri;
     for (Localization localization : localizations) {
       remoteUri = localization.getRemoteUri();
-      Path resourceToLocalize = new Path(remoteUri);
 
       if (remoteDirectoryManager.isRemote(remoteUri)) {
-        if (!remoteDirectoryManager.existsRemoteFile(resourceToLocalize)) {
+        if (!remoteDirectoryManager.existsRemoteFile(remoteUri)) {
           throw new FileNotFoundException(
               "File " + remoteUri + " doesn't exists.");
         }

--- a/submarine-server/server-submitter/submitter-yarnservice/src/test/java/org/apache/submarine/server/submitter/yarnservice/utils/LocalizerTest.java
+++ b/submarine-server/server-submitter/submitter-yarnservice/src/test/java/org/apache/submarine/server/submitter/yarnservice/utils/LocalizerTest.java
@@ -98,7 +98,7 @@ public class LocalizerTest {
 
   private void testLocalizeExistingRemoteFileInternal() throws IOException {
     when(remoteDirectoryManager.isRemote(anyString())).thenReturn(true);
-    when(remoteDirectoryManager.existsRemoteFile(any(Path.class)))
+    when(remoteDirectoryManager.existsRemoteFile(anyString()))
         .thenReturn(true);
 
     Localization localization = new Localization();
@@ -138,7 +138,7 @@ public class LocalizerTest {
   @Test(expected = FileNotFoundException.class)
   public void testLocalizeNotExistingRemoteFile() throws IOException {
     when(remoteDirectoryManager.isRemote(anyString())).thenReturn(true);
-    when(remoteDirectoryManager.existsRemoteFile(any(Path.class)))
+    when(remoteDirectoryManager.existsRemoteFile(anyString()))
         .thenReturn(false);
 
     Localization localization = new Localization();
@@ -244,7 +244,7 @@ public class LocalizerTest {
       throws IOException {
     when(remoteDirectoryManager.isDir(anyString())).thenReturn(true);
     when(remoteDirectoryManager.isRemote(anyString())).thenReturn(true);
-    when(remoteDirectoryManager.existsRemoteFile(any(Path.class)))
+    when(remoteDirectoryManager.existsRemoteFile(anyString()))
         .thenReturn(true);
     String remoteUri = "hdfs://remotedir1/remotedir2";
     when(fsOperations.uploadToRemoteFile(any(Path.class), anyString()))
@@ -265,7 +265,7 @@ public class LocalizerTest {
   public void testLocalizeExistingRemoteDirectory() throws IOException {
     when(remoteDirectoryManager.isDir(anyString())).thenReturn(true);
     when(remoteDirectoryManager.isRemote(anyString())).thenReturn(true);
-    when(remoteDirectoryManager.existsRemoteFile(any(Path.class)))
+    when(remoteDirectoryManager.existsRemoteFile(anyString()))
         .thenReturn(true);
     String remoteUri = "hdfs://remotedir1/remotedir2";
     when(fsOperations.uploadToRemoteFile(any(Path.class), anyString()))
@@ -303,7 +303,7 @@ public class LocalizerTest {
   @Test
   public void testLocalizeNonHdfsRemoteUri() throws IOException {
     when(remoteDirectoryManager.isRemote(anyString())).thenReturn(true);
-    when(remoteDirectoryManager.existsRemoteFile(any(Path.class)))
+    when(remoteDirectoryManager.existsRemoteFile(anyString()))
         .thenReturn(true);
     String remoteUri = "remote://remotedir1/remotedir2";
     when(fsOperations.uploadToRemoteFile(any(Path.class), anyString()))


### PR DESCRIPTION
### What is this PR for?

RemoteDirectoryManager contains many methods that receive a URI.
The types are sometimes Strings, sometimes Path.
We need to make this more consistent.


### What type of PR is it?
[Improvement | Refactoring]

### What is the Jira issue?

https://issues.apache.org/jira/browse/SUBMARINE-78

### How should this be tested?

https://travis-ci.com/cchung100m/submarine/builds/152425410

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
