### PR TITLE
SUBMARINE-415. Show databases command to allow exposing filtered databases

### DIFF
--- a/submarine-security/spark-security/src/main/scala/org/apache/spark/sql/execution/SubmarineShowTablesCommand.scala
+++ b/submarine-security/spark-security/src/main/scala/org/apache/spark/sql/execution/SubmarineShowTablesCommand.scala
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution
+
+import org.apache.spark.sql.{Row, SparkSession}
+import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.execution.command.{RunnableCommand, ShowTablesCommand}
+import org.apache.submarine.spark.security.{RangerSparkAuthorizer, SparkPrivilegeObject, SparkPrivilegeObjectType}
+
+case class SubmarineShowTablesCommand(child: ShowTablesCommand) extends RunnableCommand {
+
+  override val output: Seq[Attribute] = child.output
+  override def run(sparkSession: SparkSession): Seq[Row] = {
+    val rows = child.run(sparkSession)
+    rows.filter(r => RangerSparkAuthorizer.isAllowed(toSparkPrivilegeObject(r)))
+  }
+
+  private def toSparkPrivilegeObject(row: Row): SparkPrivilegeObject = {
+    val database = row.getString(0)
+    val table = row.getString(1)
+    new SparkPrivilegeObject(SparkPrivilegeObjectType.TABLE_OR_VIEW, database, table)
+  }
+}

--- a/submarine-security/spark-security/src/main/scala/org/apache/submarine/spark/security/RangerSparkSQLExtension.scala
+++ b/submarine-security/spark-security/src/main/scala/org/apache/submarine/spark/security/RangerSparkSQLExtension.scala
@@ -18,10 +18,10 @@
 package org.apache.submarine.spark.security
 
 import org.apache.spark.sql.SparkSessionExtensions
-import org.apache.spark.sql.catalyst.optimizer.RangerSparkAuthorizerExtension
+import org.apache.spark.sql.catalyst.optimizer.SubmarineSparkRangerAuthorizationExtension
 
 class RangerSparkSQLExtension extends Extensions {
   override def apply(ext: SparkSessionExtensions): Unit = {
-    ext.injectOptimizerRule(RangerSparkAuthorizerExtension)
+    ext.injectOptimizerRule(SubmarineSparkRangerAuthorizationExtension)
   }
 }

--- a/submarine-security/spark-security/src/test/scala/org/apache/spark/sql/RangerSparkTestUtils.scala
+++ b/submarine-security/spark-security/src/test/scala/org/apache/spark/sql/RangerSparkTestUtils.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql
 import java.security.PrivilegedExceptionAction
 
 import org.apache.hadoop.security.UserGroupInformation
-import org.apache.spark.sql.catalyst.optimizer.RangerSparkAuthorizerExtension
+import org.apache.spark.sql.catalyst.optimizer.SubmarineSparkRangerAuthorizationExtension
 
 object RangerSparkTestUtils {
 
@@ -32,6 +32,6 @@ object RangerSparkTestUtils {
   }
 
   def enableAuthorizer(spark: SparkSession): Unit = {
-    spark.extensions.injectOptimizerRule(RangerSparkAuthorizerExtension)
+    spark.extensions.injectOptimizerRule(SubmarineSparkRangerAuthorizationExtension)
   }
 }

--- a/submarine-security/spark-security/src/test/scala/org/apache/spark/sql/catalyst/optimizer/SubmarineSparkRangerAuthorizationExtensionTest.scala
+++ b/submarine-security/spark-security/src/test/scala/org/apache/spark/sql/catalyst/optimizer/SubmarineSparkRangerAuthorizationExtensionTest.scala
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.optimizer
+
+import org.scalatest.{BeforeAndAfterAll, FunSuite}
+import org.apache.spark.sql.execution.command.{CreateDatabaseCommand, ShowDatabasesCommand, ShowTablesCommand}
+import org.apache.spark.sql.execution.{SubmarineShowDatabasesCommand, SubmarineShowTablesCommand}
+import org.apache.spark.sql.hive.test.TestHive
+import org.apache.submarine.spark.security.SparkAccessControlException
+
+class SubmarineSparkRangerAuthorizationExtensionTest extends FunSuite with BeforeAndAfterAll {
+
+  private val spark = TestHive.sparkSession.newSession()
+
+  private val authz = SubmarineSparkRangerAuthorizationExtension(spark)
+
+  test("replace submarine show databases") {
+    val df = spark.sql("show databases")
+    val originalPlan = df.queryExecution.optimizedPlan
+    assert(originalPlan.isInstanceOf[ShowDatabasesCommand])
+    val newPlan = authz(originalPlan)
+    assert(newPlan.isInstanceOf[SubmarineShowDatabasesCommand])
+  }
+
+  test("replace submarine show tables") {
+    val df = spark.sql("show tables")
+    val originalPlan = df.queryExecution.optimizedPlan
+    assert(originalPlan.isInstanceOf[ShowTablesCommand])
+    val newPlan = authz(originalPlan)
+    assert(newPlan.isInstanceOf[SubmarineShowTablesCommand])
+  }
+
+  test("fail to create database by default") {
+    try {
+      val df = spark.sql("create database testdb1")
+      val originalPlan = df.queryExecution.optimizedPlan
+      assert(originalPlan.isInstanceOf[CreateDatabaseCommand])
+      intercept[SparkAccessControlException](authz(originalPlan))
+    } finally {
+      spark.sql("drop database testdb1")
+    }
+  }
+
+}

--- a/submarine-security/spark-security/src/test/scala/org/apache/submarine/spark/security/SparkRangerAuthorizerTest.scala
+++ b/submarine-security/spark-security/src/test/scala/org/apache/submarine/spark/security/SparkRangerAuthorizerTest.scala
@@ -75,7 +75,20 @@ class SparkRangerAuthorizerTest extends FunSuite with BeforeAndAfterAll {
     withUser("kent") {
       assert(sql("show databases").count() === 2)
     }
+
+    withUser("alice") {
+      assert(sql("show tables").count() === 7)
+    }
+    withUser("bob") {
+      assert(sql("show tables").count() === 7)
+    }
+
     enableAuthorizer(spark)
+  }
+
+  override def afterAll(): Unit = {
+    super.afterAll()
+    spark.reset()
   }
 
   test("show databases") {
@@ -88,6 +101,15 @@ class SparkRangerAuthorizerTest extends FunSuite with BeforeAndAfterAll {
     }
     withUser("kent") {
       assert(sql("show databases").count() === 1)
+    }
+  }
+
+  test("show tables") {
+    withUser("alice") {
+      assert(sql("show tables").count() === 0)
+    }
+    withUser("bob") {
+      assert(sql("show tables").count() === 7)
     }
   }
 


### PR DESCRIPTION
### What is this PR for?

add a new Command to replace spark's own ShowTablesCommand to filter out these not allowed.

### What type of PR is it?
Improvement

### Todos

* [ ] - Row-level filtering
* [ ] - Datamasking filtering
* [ ] - Configuration Restriction

### What is the Jira issue?
* Open an issue on Jira https://issues.apache.org/jira/browse/SUBMARINE-413

### How should this be tested?

unit tests added

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? Yes, will do after finish all