### PR TITLE
SUBMARINE-79. Solve potential NPE for MockRemoteDirectoryManager

### DIFF
--- a/submarine-commons/commons-runtime/src/test/java/org/apache/submarine/commons/runtime/fs/MockRemoteDirectoryManager.java
+++ b/submarine-commons/commons-runtime/src/test/java/org/apache/submarine/commons/runtime/fs/MockRemoteDirectoryManager.java
@@ -113,6 +113,7 @@ public class MockRemoteDirectoryManager implements RemoteDirectoryManager {
   @Override
   public Path getModelDir(String modelName, boolean create)
       throws IOException {
+    Objects.requireNonNull(modelParentDir, "Model parent dir must not be null!");
     File modelDir = new File(modelParentDir.getAbsolutePath(), modelName);
     if (create) {
       if (!modelDir.exists() && !modelDir.mkdirs()) {


### PR DESCRIPTION
### What is this PR for?

Solve potential NPE for MockRemoteDirectoryManager

MockRemoteDirectoryManager#getModelDir:

`File modelDir = new File(modelParentDir.getAbsolutePath(), modelName);`

If modelParentDir is null, we could have an NPE easily.

### What type of PR is it?
[Bug Fix | Improvement ]


### What is the Jira issue?

https://issues.apache.org/jira/browse/SUBMARINE-79

### How should this be tested?

https://travis-ci.com/cchung100m/submarine/builds/152619875

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
