### PR TITLE
SUBMARINE-428. Add job table in db to store job status.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -26,4 +26,4 @@ indent_size = 4
 # Don't enforce indent size for java. maven check-style will handle other styles
 [*.java]
 indent_style = space
-max_line_length = 100
+max_line_length = 110

--- a/docs/database/submarine.sql
+++ b/docs/database/submarine.sql
@@ -199,3 +199,23 @@ CREATE TABLE `project_files` (
   PRIMARY KEY  (`id`)/*,
   CONSTRAINT `FK_PROJECT_FILES_PRJ_ID` FOREIGN KEY (`project_id`) REFERENCES `project` (`id`)*/
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+-- ----------------------------
+-- Table structure for jobs
+-- ----------------------------
+DROP TABLE IF EXISTS `job`;
+CREATE TABLE `job` (
+  `id` int NOT NULL AUTO_INCREMENT,
+  `job_id` varchar(64) default NULL COMMENT 'job id',
+  `job_name` varchar(64) NOT NULL COMMENT 'job name',
+  `job_type` varchar(64) NOT NULL COMMENT 'job type',
+  `job_namespace` varchar(32) default NULL COMMENT 'job namespace',
+  `job_status` varchar(32) default NULL COMMENT 'job status',
+  `job_final_status` varchar(32) default NULL COMMENT 'job final status',
+  `user_name` varchar(32) default NULL COMMENT 'user name',
+  `create_by` varchar(32) default NULL COMMENT 'create user',
+  `create_time` datetime default NULL COMMENT 'create time',
+  `update_by` varchar(32) default NULL COMMENT 'last update user',
+  `update_time` datetime default NULL COMMENT 'last update time',
+  PRIMARY KEY  (`id`)
+  ) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/docs/submarine-server/setup-kubernetes.md
+++ b/docs/submarine-server/setup-kubernetes.md
@@ -1,4 +1,4 @@
-<!-- 
+<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information

--- a/submarine-server/server-core/src/main/java/org/apache/submarine/server/workbench/database/entity/Job.java
+++ b/submarine-server/server-core/src/main/java/org/apache/submarine/server/workbench/database/entity/Job.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.submarine.server.workbench.database.entity;
+
+public class Job extends BaseEntity {
+
+  // Todo(Zac) Add dict configuration.
+  private String jobId;
+
+  private String jobName;
+
+  private String jobType;
+
+  private String jobNamespace;
+
+  private String jobStatus;
+
+  private String jobFinalStatus;
+
+  private String userName;
+
+  public String getJobId() {
+    return jobId;
+  }
+
+  public void setJobId(String jobId) {
+    this.jobId = jobId;
+  }
+
+  public String getJobName() {
+    return jobName;
+  }
+
+  public void setJobName(String jobName) {
+    this.jobName = jobName;
+  }
+
+  public String getJobType() {
+    return jobType;
+  }
+
+  public void setJobType(String jobType) {
+    this.jobType = jobType;
+  }
+
+  public String getJobNamespace() {
+    return jobNamespace;
+  }
+
+  public void setJobNamespace(String jobNamespace) {
+    this.jobNamespace = jobNamespace;
+  }
+
+  public String getJobStatus() {
+    return jobStatus;
+  }
+
+  public void setJobStatus(String jobStatus) {
+    this.jobStatus = jobStatus;
+  }
+
+  public String getJobFinalStatus() {
+    return jobFinalStatus;
+  }
+
+  public void setJobFinalStatus(String jobFinalStatus) {
+    this.jobFinalStatus = jobFinalStatus;
+  }
+
+  public String getUserName() {
+    return userName;
+  }
+
+  public void setUserName(String userName) {
+    this.userName = userName;
+  }
+}

--- a/submarine-server/server-core/src/main/java/org/apache/submarine/server/workbench/database/mappers/JobMapper.java
+++ b/submarine-server/server-core/src/main/java/org/apache/submarine/server/workbench/database/mappers/JobMapper.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.submarine.server.workbench.database.mappers;
+
+import org.apache.ibatis.session.RowBounds;
+import org.apache.submarine.server.workbench.database.entity.Job;
+
+import java.util.List;
+import java.util.Map;
+
+public interface JobMapper {
+  List<Job> selectAll(Map<String, Object> where, RowBounds rowBounds);
+
+  int deleteByPrimaryKey(String id);
+
+  int deleteByJobId(String jobId);
+
+  int insert(Job job);
+
+  int insertSelective(Job job);
+
+  Job selectByPrimaryKey(String id);
+
+  Job selectByJobId(String jobId);
+
+  int updateByPrimaryKeySelective(Job job);
+
+  int updateByPrimaryKey(Job job);
+}

--- a/submarine-server/server-core/src/main/java/org/apache/submarine/server/workbench/database/service/JobService.java
+++ b/submarine-server/server-core/src/main/java/org/apache/submarine/server/workbench/database/service/JobService.java
@@ -1,0 +1,135 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.submarine.server.workbench.database.service;
+
+import org.apache.ibatis.session.RowBounds;
+import org.apache.ibatis.session.SqlSession;
+import org.apache.submarine.server.workbench.database.MyBatisUtil;
+import org.apache.submarine.server.workbench.database.entity.Job;
+import org.apache.submarine.server.workbench.database.mappers.JobMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class JobService {
+  private static final Logger LOG = LoggerFactory.getLogger(JobService.class);
+
+  public List<Job> queryJobList(String userName,
+      String column, String order, int pageNo, int pageSize) throws Exception {
+    LOG.info("queryJobList owner:{}, column:{}, order:{}, pageNo:{}, pageSize:{}",
+        userName, column, order, pageNo, pageSize);
+
+    List<Job> list = null;
+    try (SqlSession sqlSession = MyBatisUtil.getSqlSession()) {
+      JobMapper projectMapper = sqlSession.getMapper(JobMapper.class);
+      Map<String, Object> where = new HashMap<>();
+      where.put("userName", userName);
+      where.put("column", column);
+      where.put("order", order);
+      list = projectMapper.selectAll(where, new RowBounds(pageNo, pageSize));
+    } catch (Exception e) {
+      LOG.error(e.getMessage(), e);
+      throw new Exception(e);
+    }
+    return list;
+  }
+
+  public Job selectByJobId(String jobId) throws Exception {
+    LOG.info("select a job by jobid {}", jobId);
+    Job job;
+    try (SqlSession sqlSession = MyBatisUtil.getSqlSession()) {
+      JobMapper projectMapper = sqlSession.getMapper(JobMapper.class);
+      job = projectMapper.selectByJobId(jobId);
+    } catch (Exception e) {
+      LOG.error(e.getMessage(), e);
+      throw new Exception(e);
+    }
+    return job;
+  }
+
+  public Job selectById(String id) throws Exception {
+    LOG.info("select a job by id {}", id);
+    Job job;
+    try (SqlSession sqlSession = MyBatisUtil.getSqlSession()) {
+      JobMapper projectMapper = sqlSession.getMapper(JobMapper.class);
+      job = projectMapper.selectByPrimaryKey(id);
+    } catch (Exception e) {
+      LOG.error(e.getMessage(), e);
+      throw new Exception(e);
+    }
+    return job;
+  }
+
+  public boolean add(Job job) throws Exception {
+    LOG.info("add({})", job.toString());
+
+    try (SqlSession sqlSession = MyBatisUtil.getSqlSession()) {
+      JobMapper jobMapper = sqlSession.getMapper(JobMapper.class);
+      jobMapper.insert(job);
+      sqlSession.commit();
+    } catch (Exception e) {
+      LOG.error(e.getMessage(), e);
+      throw new Exception(e);
+    }
+    return true;
+  }
+
+  public boolean updateByPrimaryKeySelective(Job job) throws Exception {
+    LOG.info("updateByPrimaryKeySelective({})", job.toString());
+    try (SqlSession sqlSession = MyBatisUtil.getSqlSession()) {
+      JobMapper jobMapper = sqlSession.getMapper(JobMapper.class);
+      jobMapper.updateByPrimaryKeySelective(job);
+      sqlSession.commit();
+    } catch (Exception e) {
+      LOG.error(e.getMessage(), e);
+      throw new Exception(e);
+    }
+    return true;
+  }
+
+  public boolean delete(String id) throws Exception {
+    LOG.info("delete jobs by id {}", id);
+    try (SqlSession sqlSession = MyBatisUtil.getSqlSession()) {
+      JobMapper jobMapper = sqlSession.getMapper(JobMapper.class);
+      jobMapper.deleteByPrimaryKey(id);
+      sqlSession.commit();
+    } catch (Exception e) {
+      LOG.error(e.getMessage(), e);
+      throw new Exception(e);
+    }
+    return true;
+  }
+
+  public boolean deleteByJobId(String jobId) throws Exception {
+    LOG.info("delete jobs by jobId {}", jobId);
+    try (SqlSession sqlSession = MyBatisUtil.getSqlSession()) {
+      JobMapper jobMapper = sqlSession.getMapper(JobMapper.class);
+      jobMapper.deleteByJobId(jobId);
+      sqlSession.commit();
+    } catch (Exception e) {
+      LOG.error(e.getMessage(), e);
+      throw new Exception(e);
+    }
+    return true;
+  }
+
+}

--- a/submarine-server/server-core/src/main/resources/mybatis-config.xml
+++ b/submarine-server/server-core/src/main/resources/mybatis-config.xml
@@ -61,5 +61,6 @@
     <mapper resource='org/apache/submarine/database/mappers/TeamMemberMapper.xml'/>
     <mapper resource='org/apache/submarine/database/mappers/ProjectMapper.xml'/>
     <mapper resource='org/apache/submarine/database/mappers/ProjectFilesMapper.xml'/>
+    <mapper resource='org/apache/submarine/database/mappers/JobMapper.xml'/>
   </mappers>
 </configuration>

--- a/submarine-server/server-core/src/main/resources/org/apache/submarine/database/mappers/JobMapper.xml
+++ b/submarine-server/server-core/src/main/resources/org/apache/submarine/database/mappers/JobMapper.xml
@@ -1,0 +1,217 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="org.apache.submarine.server.workbench.database.mappers.JobMapper">
+  <resultMap id="BaseEntityResultMap" type="org.apache.submarine.server.workbench.database.entity.BaseEntity">
+    <id property="id" column="id"/>
+    <result column="create_by" property="createBy"/>
+    <result column="create_time" property="createTime"/>
+    <result column="update_by" property="updateBy"/>
+    <result column="update_time" property="updateTime"/>
+  </resultMap>
+
+  <resultMap id="resultMap" type="org.apache.submarine.server.workbench.database.entity.Job" extends="BaseEntityResultMap">
+    <result column="job_id" jdbcType="VARCHAR" property="jobId" />
+    <result column="job_name" jdbcType="VARCHAR" property="jobName" />
+    <result column="job_type" jdbcType="VARCHAR" property="jobType" />
+    <result column="job_namespace" jdbcType="VARCHAR" property="jobNamespace" />
+    <result column="job_status" jdbcType="VARCHAR" property="jobStatus" />
+    <result column="job_final_status" jdbcType="VARCHAR" property="jobFinalStatus" />
+    <result column="user_name" jdbcType="VARCHAR" property="userName" />
+  </resultMap>
+
+  <sql id="Base_Column_List">
+    id, job_id, job_name, job_type, job_namespace, job_status, job_final_status, user_name,
+    create_by, create_time, update_by, update_time
+  </sql>
+
+  <select id="selectAll" parameterType="java.util.Map" resultMap="resultMap">
+    SELECT
+    <include refid="Base_Column_List"/>
+    FROM job
+    WHERE 1 = 1
+    <if test="userName!=null and userName!=''">AND `user_name` = #{userName}</if>
+    ORDER BY #{column} #{order}
+  </select>
+
+  <select id="selectByPrimaryKey" parameterType="java.lang.String" resultMap="resultMap">
+    select
+    <include refid="Base_Column_List" />
+    from job
+    where id = #{id,jdbcType=VARCHAR}
+  </select>
+
+  <select id="selectByJobId" parameterType="java.lang.String" resultMap="resultMap">
+    select
+    <include refid="Base_Column_List" />
+    from job
+    where job_id = #{jobId,jdbcType=VARCHAR}
+  </select>
+
+  <delete id="deleteByPrimaryKey" parameterType="java.lang.String">
+    delete from job
+    where id = #{id,jdbcType=VARCHAR}
+  </delete>
+
+  <delete id="deleteByJobId" parameterType="java.lang.String">
+    delete from job
+    where job_id = #{jobId,jdbcType=VARCHAR}
+  </delete>
+
+  <insert id="insert" parameterType="org.apache.submarine.server.workbench.database.entity.Job"
+          useGeneratedKeys="true" keyProperty="id">
+    insert into job (job_id, job_name, job_type, job_namespace,
+      job_status, job_final_status, user_name,
+      create_by, create_time, update_by, update_time)
+    values (#{jobId,jdbcType=VARCHAR}, #{jobName,jdbcType=VARCHAR},
+      #{jobType,jdbcType=VARCHAR}, #{jobNamespace,jdbcType=VARCHAR}, #{jobStatus,jdbcType=VARCHAR},
+      #{jobFinalStatus,jdbcType=VARCHAR}, #{userName,jdbcType=VARCHAR},
+      #{createBy,jdbcType=VARCHAR}, now(), #{updateBy,jdbcType=VARCHAR}, now())
+  </insert>
+
+  <insert id="insertSelective" parameterType="org.apache.submarine.server.workbench.database.entity.Job">
+    insert into job
+    <trim prefix="(" suffix=")" suffixOverrides=",">
+      <if test="id != null">
+        id,
+      </if>
+      <if test="jobId != null">
+        job_id,
+      </if>
+      <if test="jobName != null">
+        job_name,
+      </if>
+      <if test="jobType != null">
+        job_type,
+      </if>
+      <if test="jobNamespace != null">
+        job_namespace,
+      </if>
+      <if test="jobStatus != null">
+        job_status,
+      </if>
+      <if test="jobFinalStatus != null">
+        job_final_status,
+      </if>
+      <if test="userName != null">
+        user_name,
+      </if>
+      <if test="createBy != null">
+        create_by,
+      </if>
+      <if test="createTime != null">
+        create_time,
+      </if>
+      <if test="updateBy != null">
+        update_by,
+      </if>
+      <if test="updateTime != null">
+        update_time,
+      </if>
+    </trim>
+    <trim prefix="values (" suffix=")" suffixOverrides=",">
+      <if test="id != null">
+        #{id,jdbcType=VARCHAR},
+      </if>
+      <if test="jobId != null">
+        #{jobId,jdbcType=VARCHAR},
+      </if>
+      <if test="jobName != null">
+        #{jobName,jdbcType=VARCHAR},
+      </if>
+      <if test="jobType != null">
+        #{jobType,jdbcType=VARCHAR},
+      </if>
+      <if test="jobNamespace != null">
+        #{jobNamespace,jdbcType=VARCHAR},
+      </if>
+      <if test="jobStatus != null">
+        #{jobStatus,jdbcType=VARCHAR},
+      </if>
+      <if test="jobFinalStatus != null">
+        #{jobFinalStatus,jdbcType=VARCHAR},
+      </if>
+      <if test="userName != null">
+        #{userName,jdbcType=VARCHAR},
+      </if>
+      <if test="createBy != null">
+        #{createBy,jdbcType=VARCHAR},
+      </if>
+      <if test="createTime != null">
+        #{createTime,jdbcType=TIMESTAMP},
+      </if>
+      <if test="updateBy != null">
+        #{updateBy,jdbcType=VARCHAR},
+      </if>
+      <if test="updateTime != null">
+        #{updateTime,jdbcType=TIMESTAMP},
+      </if>
+    </trim>
+  </insert>
+
+  <update id="updateByPrimaryKeySelective" parameterType="org.apache.submarine.server.workbench.database.entity.Job">
+    update job
+    <set>
+      <if test="jobId != null">
+        job_id = #{jobId,jdbcType=VARCHAR},
+      </if>
+      <if test="jobName != null">
+        job_name = #{jobName,jdbcType=VARCHAR},
+      </if>
+      <if test="jobType != null">
+        job_type = #{jobType,jdbcType=VARCHAR},
+      </if>
+      <if test="jobNamespace != null">
+        job_namespace = #{jobNamespace,jdbcType=VARCHAR},
+      </if>
+      <if test="jobStatus != null">
+        job_status = #{jobStatus,jdbcType=VARCHAR},
+      </if>
+      <if test="jobFinalStatus != null">
+        job_final_status = #{jobFinalStatus,jdbcType=VARCHAR},
+      </if>
+      <if test="userName != null">
+        user_name = #{userName,jdbcType=VARCHAR},
+      </if>
+      <if test="createBy != null">
+        create_by = #{createBy,jdbcType=VARCHAR},
+      </if>
+      <if test="updateBy != null">
+        update_by = #{updateBy,jdbcType=VARCHAR},
+      </if>
+      update_time = now()
+    </set>
+    where id = #{id,jdbcType=VARCHAR}
+  </update>
+
+  <update id="updateByPrimaryKey" parameterType="org.apache.submarine.server.workbench.database.entity.Job">
+    update job
+    set job_id = #{jobId,jdbcType=VARCHAR},
+      job_name = #{jobName,jdbcType=VARCHAR},
+      job_type = #{jobType,jdbcType=VARCHAR},
+      job_namespace = #{jobNamespace,jdbcType=VARCHAR},
+      job_status = #{jobStatus,jdbcType=VARCHAR},
+      job_final_status = #{jobFinalStatus,jdbcType=VARCHAR},
+      user_name = #{userName,jdbcType=VARCHAR},
+      update_by = #{updateBy,jdbcType=VARCHAR},
+      update_time = #{updateTime,jdbcType=TIMESTAMP}
+    where id = #{id,jdbcType=VARCHAR}
+  </update>
+</mapper>

--- a/submarine-server/server-core/src/test/java/org/apache/submarine/server/workbench/database/service/JobServiceTest.java
+++ b/submarine-server/server-core/src/test/java/org/apache/submarine/server/workbench/database/service/JobServiceTest.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.submarine.server.workbench.database.service;
+
+import org.apache.submarine.server.workbench.database.entity.Job;
+import org.junit.After;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+import static junit.framework.TestCase.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class JobServiceTest {
+  private static final Logger LOG = LoggerFactory.getLogger(JobServiceTest.class);
+  JobService jobService = new JobService();
+
+  @After
+  public void removeAllRecord() throws Exception {
+    List<Job> jobList = jobService.queryJobList(null, "create_time", "desc", 0, 100);
+    LOG.info("jobList.size():{}", jobList.size());
+    for (Job job : jobList) {
+      jobService.delete(job.getId());
+    }
+  }
+
+  @Test
+  public void testSelectJob() throws Exception {
+    Job job = new Job();
+    job.setJobId("9e93caeb-8a08-4278-a10a-ff60d5835716");
+    job.setJobName("mnist");
+    job.setJobNamespace("submarine");
+    job.setUserName("JobServiceTest-UserName");
+    job.setJobType("TFJob");
+    job.setJobStatus("Finished");
+    job.setJobFinalStatus("Succeeded");
+    job.setCreateBy("JobServiceTest-UserName");
+
+    Boolean ret = jobService.add(job);
+    assertTrue(ret);
+
+    List<Job> jobList = jobService.queryJobList("JobServiceTest-UserName", "create_time", "desc", 0, 100);
+    assertEquals(jobList.size(), 1);
+
+    Job jobDb = jobList.get(0);
+    compareJobs(job, jobDb);
+
+    Job jobDb2 = jobService.selectByJobId("9e93caeb-8a08-4278-a10a-ff60d5835716");
+    compareJobs(job, jobDb2);
+  }
+
+  @Test
+  public void testUpdateJob() throws Exception {
+    Job job = new Job();
+    job.setJobId("9e93caeb-8a08-4278-a10a-ff60d5835716");
+    job.setJobName("mnist");
+    job.setJobNamespace("submarine");
+    job.setUserName("JobServiceTest-UserName");
+    job.setJobType("TFJob");
+    job.setJobStatus("Finished");
+    job.setJobFinalStatus("Succeeded");
+    job.setCreateBy("JobServiceTest-UserName");
+
+    Boolean ret = jobService.add(job);
+    assertTrue(ret);
+
+    job.setJobName("mnistNew");
+    job.setJobNamespace("submarineNew");
+    job.setUserName("JobServiceTest-UserNameNew");
+    job.setJobType("TFJobNew");
+    job.setJobStatus("Running");
+    job.setJobFinalStatus("");
+    job.setUpdateBy("JobServiceTest-UserNameNew");
+
+    boolean editRet = jobService.updateByPrimaryKeySelective(job);
+    assertTrue(editRet);
+
+    Job jobDb2 = jobService.selectByJobId("9e93caeb-8a08-4278-a10a-ff60d5835716");
+    compareJobs(job, jobDb2);
+  }
+
+  @Test
+  public void delete() throws Exception {
+    Job job = new Job();
+    job.setJobId("9e93caeb-8a08-4278-a10a-ff60d5835716");
+    job.setJobName("mnist");
+    job.setJobNamespace("submarine");
+    job.setUserName("JobServiceTest-UserName");
+    job.setJobType("TFJob");
+    job.setJobStatus("Finished");
+    job.setJobFinalStatus("Succeeded");
+    job.setCreateBy("JobServiceTest-UserName");
+
+    Boolean ret = jobService.add(job);
+    assertTrue(ret);
+
+    Boolean deleteRet = jobService.delete(job.getId());
+    assertTrue(deleteRet);
+  }
+
+  private void compareJobs(Job job, Job jobDb) {
+    assertEquals(job.getJobId(), jobDb.getJobId());
+    assertEquals(job.getJobName(), jobDb.getJobName());
+    assertEquals(job.getJobNamespace(), jobDb.getJobNamespace());
+    assertEquals(job.getUserName(), jobDb.getUserName());
+    assertEquals(job.getJobType(), jobDb.getJobType());
+    assertEquals(job.getJobStatus(), jobDb.getJobStatus());
+    assertEquals(job.getJobFinalStatus(), jobDb.getJobFinalStatus());
+    assertEquals(job.getCreateBy(), jobDb.getCreateBy());
+    assertEquals(job.getUpdateBy(), jobDb.getUpdateBy());
+  }
+}


### PR DESCRIPTION
### What is this PR for?
We have to store job status in db. So that we don't need to get job status by k8s/yarn API every time.

### What type of PR is it?
Improvement

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-428

### How should this be tested?
https://travis-ci.org/github/yuanzac/hadoop-submarine/builds/661526991?utm_source=github_status&utm_medium=notification

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
