### PR TITLE
Fix conflicts of java indentation between .editorconfig and mvn plugin

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,7 +14,7 @@ trim_trailing_whitespace = true
 indent_style = tab
 
 # 2 space indentation
-[*.{java,sh,json,xml}]
+[*.{sh,json,xml}]
 indent_style = space
 indent_size = 2
 
@@ -23,5 +23,7 @@ indent_size = 2
 indent_style = space
 indent_size = 4
 
+# Don't enforce indent size for java. maven check-style will handle other styles
 [*.java]
+indent_style = space
 max_line_length = 100


### PR DESCRIPTION
### What is this PR for?
The ".editorconfig" enforced all the java indent size to 2 which will cause conflicts when maven check-style plugin does checking. We could remove this configuration from ".editorconfig".


### What type of PR is it?
[Bug Fix]

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-429

### How should this be tested?
Manually tested.
With this fix, the indent size in IDE like Intellij won't always be 2 and won't fail the mvn package.


### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
