### PR TITLE
SUBMARINE-432. [SDK] test_verify_rest_response is flaky in python 3.5

### DIFF
--- a/submarine-sdk/pysubmarine/submarine/utils/rest_utils.py
+++ b/submarine-sdk/pysubmarine/submarine/utils/rest_utils.py
@@ -45,8 +45,6 @@ def http_request(base_url, endpoint, method, json_body,
                                 timeout=timeout, **kwargs)
     verify_rest_response(response, endpoint)
 
-    print('test')
-    print(response.text)
     response = json.loads(response.text)
     result = response['result']
     return result

--- a/submarine-sdk/pysubmarine/tests/utils/test_rest_utils.py
+++ b/submarine-sdk/pysubmarine/tests/utils/test_rest_utils.py
@@ -48,7 +48,7 @@ def test_verify_rest_response():
     dummy_json = json.dumps(mock_json_body)
     mock_response.text = dummy_json
 
-    with pytest.raises(RestException, match=str(mock_json_body)):
+    with pytest.raises(RestException, match=str(json.loads(dummy_json))):
         verify_rest_response(mock_response, '/api/v1/jobs')
 
     # Test response status code not equal 200(OK) and response can not parse as JSON


### PR DESCRIPTION
### What is this PR for?
Fix test failure in python3.5 
if we use python3.5 `str({'a': 200, 'b': 2, 'c': 3})` will output different order like {'b': 2, 'c': 3, 'a': 200}
change to str(**json object**) will fix it.
```
with pytest.raises(RestException, match=str(mock_json_body)):
verify_rest_response(mock_response, '/api/v1/jobs')
E AssertionError: Pattern '{'b': 2, 'c': 3, 'a': 200}' not found in 'None: Response: {'c': 3, 'a': 200, 'b': 2}'
```

### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-432

### How should this be tested?
https://travis-ci.org/github/pingsutw/hadoop-submarine/builds/663060104
https://github.com/pingsutw/hadoop-submarine/runs/511082403

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
