### PR TITLE
SUBMARINE-433. Expose Spark Security API with Authz w/ w/o DataMasking and Row Filtering

### DIFF
--- a/submarine-security/spark-security/src/main/scala/org/apache/submarine/spark/security/api/RangerSparkAuthzExtension.scala
+++ b/submarine-security/spark-security/src/main/scala/org/apache/submarine/spark/security/api/RangerSparkAuthzExtension.scala
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.submarine.spark.security.api
+
+import org.apache.spark.sql.SparkSessionExtensions
+import org.apache.spark.sql.catalyst.optimizer.{SubmarineConfigurationCheckExtension, SubmarineSparkRangerAuthorizationExtension}
+import org.apache.submarine.spark.security.Extensions
+
+/**
+ * ACL Management for Apache Spark SQL with Apache Ranger, enabling:
+ * <ul>
+ *   <li>Table/Column level authorization</li>
+ * <ul>
+ *
+ * To work with Spark SQL, we need to enable it via spark extensions
+ *
+ * spark.sql.extensions=org.apache.submarine.spark.security.api.RangerSparkAuthzExtension
+ */
+class RangerSparkAuthzExtension extends Extensions {
+  override def apply(ext: SparkSessionExtensions): Unit = {
+    ext.injectCheckRule(SubmarineConfigurationCheckExtension)
+    ext.injectOptimizerRule(SubmarineSparkRangerAuthorizationExtension)
+  }
+}

--- a/submarine-security/spark-security/src/main/scala/org/apache/submarine/spark/security/api/RangerSparkSQLExtension.scala
+++ b/submarine-security/spark-security/src/main/scala/org/apache/submarine/spark/security/api/RangerSparkSQLExtension.scala
@@ -17,12 +17,25 @@
  * under the License.
  */
 
-package org.apache.submarine.spark.security
+package org.apache.submarine.spark.security.api
 
 import org.apache.spark.sql.SparkSessionExtensions
 import org.apache.spark.sql.catalyst.optimizer.{SubmarineConfigurationCheckExtension, SubmarineDataMaskingExtension, SubmarineRowFilterExtension, SubmarineSparkRangerAuthorizationExtension}
 import org.apache.spark.sql.execution.SubmarineSparkPlanOmitStrategy
+import org.apache.submarine.spark.security.Extensions
 
+/**
+ * ACL Management for Apache Spark SQL with Apache Ranger, enabling:
+ * <ul>
+ *   <li>Table/Column level authorization</li>
+ *   <li>Row level filtering</li>
+ *   <li>Data masking</li>
+ * <ul>
+ *
+ * To work with Spark SQL, we need to enable it via spark extensions
+ *
+ * spark.sql.extensions=org.apache.submarine.spark.security.api.RangerSparkSQLExtension
+ */
 class RangerSparkSQLExtension extends Extensions {
   override def apply(ext: SparkSessionExtensions): Unit = {
     ext.injectCheckRule(SubmarineConfigurationCheckExtension)


### PR DESCRIPTION
### What is this PR for?

Expose Spark Security API with Authz w/ w/o DataMasking and Row Filtering
Then one is only enabled with security features with authorization and conf restricting
the other is fully applied data masking and row filtering too.


### What type of PR is it?
Improvement
### Todos
* [ ] - Task

### What is the Jira issue?
* Open an issue on Jira https://issues.apache.org/jira/browse/SUBMARINE-433
* Put link here, and add [SUBMARINE-*Jira number*] in PR title, eg. [SUBMARINE-23]

### How should this be tested?
* First time? Setup Travis CI as described on https://submarine.apache.org/contribution/contributions.html#continuous-integration
* Strongly recommended: add automated unit tests for any new or changed behavior
* Outline any manual steps to test the PR here.

pass current travis

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
