### PR TITLE
SUBMARINE-434. Refine data masking plan resolution for spark security

### DIFF
--- a/submarine-security/spark-security/src/main/scala/org/apache/submarine/spark/security/RangerSparkAuditHandler.scala
+++ b/submarine-security/spark-security/src/main/scala/org/apache/submarine/spark/security/RangerSparkAuditHandler.scala
@@ -21,7 +21,7 @@ package org.apache.submarine.spark.security
 
 import org.apache.ranger.plugin.audit.RangerDefaultAuditHandler
 
-class RangerSparkAuditHandler extends RangerDefaultAuditHandler {
+case class RangerSparkAuditHandler() extends RangerDefaultAuditHandler {
 
   // TODO(Kent Yao): Implementing meaningfully audit functions
 

--- a/submarine-security/spark-security/src/test/scala/org/apache/submarine/spark/security/DataMaskingSQLTest.scala
+++ b/submarine-security/spark-security/src/test/scala/org/apache/submarine/spark/security/DataMaskingSQLTest.scala
@@ -113,6 +113,16 @@ case class DataMaskingSQLTest() extends FunSuite with BeforeAndAfterAll {
     }
   }
 
+  test("alias, non-alias coexists") {
+    val statement = "select key as k1, value, value v1 from default.src"
+    withUser("bob") {
+      val df = sql(statement)
+      val row = df.take(1)(0)
+      assert(row.getString(1).startsWith("x"), "values should be masked")
+      assert(row.getString(2).startsWith("x"), "values should be masked")
+    }
+  }
+
   test("agg") {
     val statement = "select sum(key) as k1, value v1 from default.src group by v1"
     withUser("bob") {
@@ -155,6 +165,16 @@ case class DataMaskingSQLTest() extends FunSuite with BeforeAndAfterAll {
       println(df.queryExecution.optimizedPlan)
       val row = df.take(1)(0)
       assert(row.getString(1) === DigestUtils.md5Hex("val_277"), "value is hashed")
+    }
+  }
+
+  test("MASK_NULL") {
+    val statement = "select * from default.rangertbl4 where value = 'val_277'"
+    withUser("bob") {
+      val df = sql(statement)
+      println(df.queryExecution.optimizedPlan)
+      val row = df.take(1)(0)
+      assert(row.getString(1) === null, "value is hashed")
     }
   }
 


### PR DESCRIPTION
### What is this PR for?
Refine data masking plan resolution for spark security

Now we use parseExpression to generate alias for masked out, it is neater.

### What type of PR is it?

Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
* Open an issue on Jira https://issues.apache.org/jira/browse/SUBMARINE-434

### How should this be tested?
add tests

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
