### PR TITLE
SUBMARINE-437. Fixed failed to build images from tf_1.13.1 Dockerfile

### DIFF
--- a/docs/helper/WriteDockerfileTF.md
+++ b/docs/helper/WriteDockerfileTF.md
@@ -42,7 +42,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         build-essential \
         curl \
         libfreetype6-dev \
-        libpng12-dev \
+        libpng-dev \
         libzmq3-dev \
         pkg-config \
         python \

--- a/docs/helper/docker/tensorflow/base/ubuntu-18.04/Dockerfile.cpu.tf_1.13.1
+++ b/docs/helper/docker/tensorflow/base/ubuntu-18.04/Dockerfile.cpu.tf_1.13.1
@@ -16,9 +16,10 @@
 FROM ubuntu:18.04
 
 # Pick up some TF dependencies
-RUN apt-get update && apt-get install -y --allow-downgrades --no-install-recommends \
+RUN export DEBIAN_FRONTEND=noninteractive && apt-get update && \
+        apt-get install -y --allow-downgrades --no-install-recommends \
         --allow-change-held-packages --allow-unauthenticated \
-        build-essential libfreetype6-dev libpng12-dev \
+        build-essential libfreetype6-dev libpng-dev \
         libzmq3-dev pkg-config python python-dev \
         rsync software-properties-common curl unzip wget grep sed vim iputils-ping net-tools gdb python2.7-dbg tzdata && \
         apt-get clean && rm -rf /var/lib/apt/lists/*
@@ -35,7 +36,7 @@ RUN echo "Install python related packages" && \
     apt-get update && \
     apt-get install -y --no-install-recommends gfortran \
     # numerical/algebra packages
-    libblas-dev libatlas-dev liblapack-dev \
+    libblas-dev libatlas-base-dev liblapack-dev \
     # font, image for matplotlib
     libpng-dev libxft-dev \
     # for tkinter
@@ -54,7 +55,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends git && \
 
 # Install hadoop
 ENV HADOOP_VERSION="3.1.2"
-RUN wget http://mirrors.shu.edu.cn/apache/hadoop/common/hadoop-${HADOOP_VERSION}/hadoop-${HADOOP_VERSION}.tar.gz
+RUN wget https://archive.apache.org/dist/hadoop/common/hadoop-${HADOOP_VERSION}/hadoop-${HADOOP_VERSION}.tar.gz
+# If you are in mainland China, you can use the following command.
+# RUN wget http://mirrors.shu.edu.cn/apache/hadoop/common/hadoop-${HADOOP_VERSION}/hadoop-${HADOOP_VERSION}.tar.gz
+
 RUN tar zxf hadoop-${HADOOP_VERSION}.tar.gz
 RUN ln -s hadoop-${HADOOP_VERSION} hadoop-current
 RUN rm hadoop-${HADOOP_VERSION}.tar.gz

--- a/docs/helper/docker/tensorflow/base/ubuntu-18.04/Dockerfile.gpu.tf_1.13.1
+++ b/docs/helper/docker/tensorflow/base/ubuntu-18.04/Dockerfile.gpu.tf_1.13.1
@@ -16,9 +16,10 @@
 FROM nvidia/cuda:10.0-cudnn7-devel-ubuntu18.04
 
 # Pick up some TF dependencies
-RUN apt-get update && apt-get install -y --allow-downgrades --no-install-recommends \
+RUN export DEBIAN_FRONTEND=noninteractive && apt-get update && \
+        apt-get install -y --allow-downgrades --no-install-recommends \
         --allow-change-held-packages --allow-unauthenticated \
-        build-essential libfreetype6-dev libpng12-dev \
+        build-essential libfreetype6-dev \
         libzmq3-dev pkg-config python python-dev \
         rsync software-properties-common curl unzip wget grep sed vim \
         iputils-ping net-tools gdb python2.7-dbg tzdata \
@@ -49,7 +50,7 @@ RUN echo "Install python related packages" && \
     apt-get -y update && \
     apt-get install -y --no-install-recommends gfortran \
     # numerical/algebra packages
-    libblas-dev libatlas-dev liblapack-dev \
+    libblas-dev libatlas-base-dev liblapack-dev \
     # font, image for matplotlib
     libpng-dev libxft-dev \
     # for tkinter
@@ -68,7 +69,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends git && \
 
 # Install hadoop
 ENV HADOOP_VERSION="3.1.2"
-RUN wget http://mirrors.shu.edu.cn/apache/hadoop/common/hadoop-${HADOOP_VERSION}/hadoop-${HADOOP_VERSION}.tar.gz
+RUN wget https://archive.apache.org/dist/hadoop/common/hadoop-${HADOOP_VERSION}/hadoop-${HADOOP_VERSION}.tar.gz
+# If you are in mainland China, you can use the following command.
+# RUN wget http://mirrors.shu.edu.cn/apache/hadoop/common/hadoop-${HADOOP_VERSION}/hadoop-${HADOOP_VERSION}.tar.gz
+
 RUN tar zxf hadoop-${HADOOP_VERSION}.tar.gz
 RUN ln -s hadoop-${HADOOP_VERSION} hadoop-current
 RUN rm hadoop-${HADOOP_VERSION}.tar.gz

--- a/docs/helper/docker/tensorflow/zeppelin-notebook-example/Dockerfile.gpu
+++ b/docs/helper/docker/tensorflow/zeppelin-notebook-example/Dockerfile.gpu
@@ -21,7 +21,7 @@ RUN  echo "$LOG_TAG update and install basic packages" && \
         build-essential \
         curl \
         libfreetype6-dev \
-        libpng12-dev \
+        libpng-dev \
         libzmq3-dev \
         pkg-config \
         rsync \


### PR DESCRIPTION
### What is this PR for?
Update Dockerfile and replace some package dropped in Ubuntu 18

### What type of PR is it?
[Bug Fix]

### Todos

### What is the Jira issue?
[SUBMARINE-437](https://issues.apache.org/jira/browse/SUBMARINE-437)

### How should this be tested?
[passed CI](https://travis-ci.org/github/lowc1012/submarine/builds/663932263)

### Screenshots (if appropriate)
![build success](https://user-images.githubusercontent.com/52355146/76972778-089a4800-696a-11ea-86ab-cd494dab3bdf.png)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
