### PR TITLE
SUBMARINE-448. Make Spark Security's RangerSparkPlugin static

### DIFF
--- a/submarine-security/spark-security/src/main/scala/org/apache/spark/sql/catalyst/optimizer/SubmarineDataMaskingExtension.scala
+++ b/submarine-security/spark-security/src/main/scala/org/apache/spark/sql/catalyst/optimizer/SubmarineDataMaskingExtension.scala
@@ -55,7 +55,6 @@ case class SubmarineDataMaskingExtension(spark: SparkSession) extends Rule[Logic
     .map(x => CatalogFunction(FunctionIdentifier(x._1), x._2, Seq.empty))
     .foreach(spark.sessionState.catalog.registerFunction(_, overrideIfExists = true))
 
-  private lazy val sparkPlugin = RangerSparkPlugin.build().getOrCreate()
   private lazy val sqlParser = spark.sessionState.sqlParser
   private lazy val analyzer = spark.sessionState.analyzer
   private lazy val auditHandler = RangerSparkAuditHandler()
@@ -72,8 +71,8 @@ case class SubmarineDataMaskingExtension(spark: SparkSession) extends Rule[Logic
       currentUser.getGroupNames.toSet,
       COLUMN.toString,
       SparkAccessType.SELECT,
-      sparkPlugin.getClusterName)
-    sparkPlugin.evalDataMaskPolicies(req, auditHandler)
+      RangerSparkPlugin.getClusterName)
+    RangerSparkPlugin.evalDataMaskPolicies(req, auditHandler)
   }
 
   /**

--- a/submarine-security/spark-security/src/main/scala/org/apache/spark/sql/catalyst/optimizer/SubmarineRowFilterExtension.scala
+++ b/submarine-security/spark-security/src/main/scala/org/apache/spark/sql/catalyst/optimizer/SubmarineRowFilterExtension.scala
@@ -38,7 +38,6 @@ import org.apache.submarine.spark.security._
  * An Apache Spark's [[Optimizer]] extension for row level filtering.
  */
 case class SubmarineRowFilterExtension(spark: SparkSession) extends Rule[LogicalPlan] {
-  private lazy val sparkPlugin = RangerSparkPlugin.build().getOrCreate()
   private lazy val rangerSparkOptimizer = new SubmarineSparkOptimizer(spark)
 
   /**
@@ -56,8 +55,8 @@ case class SubmarineRowFilterExtension(spark: SparkSession) extends Rule[Logical
       val ugi = UserGroupInformation.getCurrentUser
       val request = new RangerSparkAccessRequest(resource, ugi.getShortUserName,
         ugi.getGroupNames.toSet, SparkObjectType.TABLE.toString, SparkAccessType.SELECT,
-        sparkPlugin.getClusterName)
-      val result = sparkPlugin.evalRowFilterPolicies(request, auditHandler)
+        RangerSparkPlugin.getClusterName)
+      val result = RangerSparkPlugin.evalRowFilterPolicies(request, auditHandler)
       if (isRowFilterEnabled(result)) {
         val condition = spark.sessionState.sqlParser.parseExpression(result.getFilterExpr)
         val analyzed = spark.sessionState.analyzer.execute(Filter(condition, plan))

--- a/submarine-security/spark-security/src/main/scala/org/apache/submarine/spark/security/RangerSparkPlugin.scala
+++ b/submarine-security/spark-security/src/main/scala/org/apache/submarine/spark/security/RangerSparkPlugin.scala
@@ -25,10 +25,13 @@ import org.apache.commons.logging.LogFactory
 import org.apache.ranger.authorization.hadoop.config.RangerConfiguration
 import org.apache.ranger.plugin.service.RangerBasePlugin
 
-class RangerSparkPlugin private extends RangerBasePlugin("spark", "sparkSql") {
-  import RangerSparkPlugin._
+object RangerSparkPlugin extends RangerBasePlugin("spark", "sparkSql") {
 
-  private val LOG = LogFactory.getLog(classOf[RangerSparkPlugin])
+  private val LOG = LogFactory.getLog(RangerSparkPlugin.getClass)
+
+  private val rangerConf: RangerConfiguration = RangerConfiguration.getInstance
+  val showColumnsOption: String = rangerConf.get(
+    "xasecure.spark.describetable.showcolumns.authorization.option", "NONE")
 
   lazy val fsScheme: Array[String] = RangerConfiguration.getInstance()
     .get("ranger.plugin.spark.urlauth.filesystem.schemes", "hdfs:,file:")
@@ -50,29 +53,7 @@ class RangerSparkPlugin private extends RangerBasePlugin("spark", "sparkSql") {
     }
     LOG.info("Policy cache directory successfully set to " + cacheDir.getAbsolutePath)
   }
+
+  init()
 }
 
-object RangerSparkPlugin {
-
-  private val rangerConf: RangerConfiguration = RangerConfiguration.getInstance
-
-  val showColumnsOption: String = rangerConf.get(
-    "xasecure.spark.describetable.showcolumns.authorization.option", "NONE")
-
-  def build(): Builder = new Builder
-
-  class Builder {
-
-    @volatile private var sparkPlugin: RangerSparkPlugin = _
-
-    def getOrCreate(): RangerSparkPlugin = RangerSparkPlugin.synchronized {
-      if (sparkPlugin == null) {
-        sparkPlugin = new RangerSparkPlugin
-        sparkPlugin.init()
-        sparkPlugin
-      } else {
-        sparkPlugin
-      }
-    }
-  }
-}

--- a/submarine-security/spark-security/src/test/resources/log4j.properties
+++ b/submarine-security/spark-security/src/test/resources/log4j.properties
@@ -21,3 +21,5 @@ log4j.appender.console=org.apache.log4j.ConsoleAppender
 log4j.appender.console.target=System.err
 log4j.appender.console.layout=org.apache.log4j.PatternLayout
 log4j.appender.console.layout.ConversionPattern=%d{yy/MM/dd HH:mm:ss} %p %c{1}: %m%n
+
+log4j.logger.org.apache.hadoop.security.ShellBasedUnixGroupsMapping=OFF

--- a/submarine-security/spark-security/src/test/scala/org/apache/submarine/spark/security/RangerAdminClientImpl.scala
+++ b/submarine-security/spark-security/src/test/scala/org/apache/submarine/spark/security/RangerAdminClientImpl.scala
@@ -32,17 +32,22 @@ class RangerAdminClientImpl extends RangerAdminRESTClient {
   private val cacheFilename = "sparkSql_hive_jenkins.json"
   private val gson =
     new GsonBuilder().setDateFormat("yyyyMMdd-HH:mm:ss.SSS-Z").setPrettyPrinting().create
+  private var policies: ServicePolicies = _
 
-  override def init(serviceName: String, appId: String, configPropertyPrefix: String): Unit = {}
+  override def init(serviceName: String, appId: String, configPropertyPrefix: String): Unit = {
+    if (policies == null) {
+      val basedir = this.getClass.getProtectionDomain.getCodeSource.getLocation.getPath
+      val cachePath = FileSystems.getDefault.getPath(basedir, cacheFilename)
+      LOG.info("Reading policies from " + cachePath)
+      val bytes = Files.readAllBytes(cachePath)
+      policies = gson.fromJson(new String(bytes), classOf[ServicePolicies])
+    }
+  }
 
   override def getServicePoliciesIfUpdated(
       lastKnownVersion: Long,
       lastActivationTimeInMillis: Long): ServicePolicies = {
-    val basedir = this.getClass.getProtectionDomain.getCodeSource.getLocation.getPath
-    val cachePath = FileSystems.getDefault.getPath(basedir, cacheFilename)
-    LOG.info("Reading policies from " + cachePath)
-    val bytes = Files.readAllBytes(cachePath)
-    gson.fromJson(new String(bytes), classOf[ServicePolicies])
+    policies
   }
 
   override def grantAccess(request: GrantRevokeRequest): Unit = {}


### PR DESCRIPTION
### What is this PR for?

Now the RangerSparkPlugin is non-static and will be created and init times and times again, this should be an object, not a class in scala, to avoid high load policies decoding.

### What type of PR is it?
Refactoring
### Todos

### What is the Jira issue?

https://issues.apache.org/jira/browse/SUBMARINE-448

### How should this be tested?

existing tests

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
