### PR TITLE
SUBMARINE-453. Mini-submarine build_mini-submarine.sh get error

### DIFF
--- a/dev-support/mini-submarine/Dockerfile
+++ b/dev-support/mini-submarine/Dockerfile
@@ -16,8 +16,7 @@
 FROM ubuntu:18.04
 #INSTALL JAVA
 RUN apt-get -q update \
-    && apt-get install -y wget \
-    && apt-get install -y software-properties-common \
+    && apt-get install -y wget software-properties-common \
     && add-apt-repository -y ppa:webupd8team/java \
     && apt-get update \
     && wget http://archive.ubuntu.com/ubuntu/pool/main/m/mesa/libgl1-mesa-dri_19.2.8-0ubuntu0~18.04.2_amd64.deb \

--- a/dev-support/mini-submarine/Dockerfile
+++ b/dev-support/mini-submarine/Dockerfile
@@ -16,6 +16,14 @@
 FROM ubuntu:18.04
 #INSTALL JAVA
 RUN apt-get -q update \
+    && apt-get install -y wget \
+    && apt-get install -y software-properties-common \
+    && add-apt-repository -y ppa:webupd8team/java \
+    && apt-get update \
+    && wget http://archive.ubuntu.com/ubuntu/pool/main/m/mesa/libgl1-mesa-dri_19.2.8-0ubuntu0~18.04.2_amd64.deb \
+    && wget http://security.ubuntu.com/ubuntu/pool/main/i/icu/libicu60_60.2-3ubuntu3.1_amd64.deb \
+    && apt-get install -y ./libgl1-mesa-dri_19.2.8-0ubuntu0~18.04.2_amd64.deb \
+    && apt-get install -y ./libicu60_60.2-3ubuntu3.1_amd64.deb \
     && apt-get -q install -y --no-install-recommends openjdk-8-jdk libbcprov-java \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*

--- a/dev-support/mini-submarine/build_mini-submarine.sh
+++ b/dev-support/mini-submarine/build_mini-submarine.sh
@@ -15,7 +15,7 @@
 # limitations under the License.
 set -e
 hadoop_v=2.9.2
-spark_v=2.4.4
+spark_v=2.3.4
 
 submarine_v=${submarine_version:-"0.4.0-SNAPSHOT"}
 echo "Using submarine version: $submarine_v"


### PR DESCRIPTION
### What is this PR for?
Change spark 2.4.4 to 2.3.4 , because the link only support spark 2.3.4 .
Manual install some packages which will connect fail when it auto install . 

### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/projects/SUBMARINE/issues/SUBMARINE-453

### How should this be tested?
* First time? Setup Travis CI as described on https://submarine.apache.org/contribution/contributions.html#continuous-integration
* Strongly recommended: add automated unit tests for any new or changed behavior
* Outline any manual steps to test the PR here.

### Screenshots (if appropriate)
![success](https://user-images.githubusercontent.com/61864060/77605726-9240ab80-6f50-11ea-8937-070e6870d7aa.PNG)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
