### PR TITLE
SUBMARINE-458. ResetCommand should not wipe out all configs

### DIFF
--- a/submarine-security/spark-security/src/main/scala/org/apache/spark/sql/catalyst/optimizer/SubmarineSparkRangerAuthorizationExtension.scala
+++ b/submarine-security/spark-security/src/main/scala/org/apache/spark/sql/catalyst/optimizer/SubmarineSparkRangerAuthorizationExtension.scala
@@ -56,6 +56,7 @@ case class SubmarineSparkRangerAuthorizationExtension(spark: SparkSession)
       case s: SubmarineShowDatabasesCommand => s
       case s: ShowTablesCommand => SubmarineShowTablesCommand(s)
       case s: SubmarineShowTablesCommand => s
+      case ResetCommand => SubmarineResetCommand
       case _ =>
         val operationType: SparkOperationType = toOperationType(plan)
         val (in, out) = PrivilegesBuilder.build(plan)

--- a/submarine-security/spark-security/src/main/scala/org/apache/spark/sql/execution/command/SubmarineResetCommand.scala
+++ b/submarine-security/spark-security/src/main/scala/org/apache/spark/sql/execution/command/SubmarineResetCommand.scala
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.execution.command
+
+import org.apache.spark.sql.{Row, SparkSession}
+
+/**
+ * Runtime replacement for spark's original [[ResetCommand]], since the operation will
+ * wipe out all configuration including our security-specific ones
+ * see: https://issues.apache.org/jira/browse/SPARK-31234
+ */
+case object SubmarineResetCommand extends RunnableCommand {
+  override def run(sparkSession: SparkSession): Seq[Row] = {
+    val conf = sparkSession.sessionState.conf
+    conf.clear()
+    sparkSession.sparkContext.getConf.getAll.foreach { case (k, v) =>
+      conf.setConfString(k, v)
+    }
+    Seq.empty[Row]
+  }
+}


### PR DESCRIPTION
### What is this PR for?

add a runtime replacement for `ResetCommand` to keep the static configs of spark


### What type of PR is it?
Improvement

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-458

### How should this be tested?

add uts

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
