### PR TITLE
SUBMARINE-300. Add UT for SubmitterManager

### DIFF
--- a/submarine-commons/commons-utils/src/main/java/org/apache/submarine/commons/utils/SubmarineConfiguration.java
+++ b/submarine-commons/commons-utils/src/main/java/org/apache/submarine/commons/utils/SubmarineConfiguration.java
@@ -338,7 +338,7 @@ public class SubmarineConfiguration extends XMLConfiguration {
    * @return class name
    */
   public String getSubmitterClass(String name) {
-    return getStringValue(String.format(SubmarineConfVars.ConfVars.SUBMARINE_SUBMITTERS_CLASS.getVarName(), 
+    return getStringValue(String.format(SubmarineConfVars.ConfVars.SUBMARINE_SUBMITTERS_CLASS.getVarName(),
         name), "");
   }
 
@@ -409,6 +409,10 @@ public class SubmarineConfiguration extends XMLConfiguration {
 
   public void setString(SubmarineConfVars.ConfVars c, String value) {
     properties.put(c.getVarName(), value);
+  }
+
+  public void setString(SubmarineConfVars.ConfVars c, String formatValue, String value) {
+    properties.put(String.format(c.getVarName(), formatValue), value);
   }
 
   public int getInt(SubmarineConfVars.ConfVars c) {

--- a/submarine-server/server-core/src/test/java/org/apache/submarine/server/submitter/SubmitterManagerTest.java
+++ b/submarine-server/server-core/src/test/java/org/apache/submarine/server/submitter/SubmitterManagerTest.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.submarine.server.submitter;
+
+import org.apache.submarine.commons.utils.SubmarineConfVars;
+import org.apache.submarine.commons.utils.SubmarineConfiguration;
+import org.apache.submarine.server.SubmitterManager;
+import org.apache.submarine.server.api.JobSubmitter;
+import org.apache.submarine.server.submitter.mock.MockSubmitter;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class SubmitterManagerTest {
+  @Test
+  public void testLoadSubmitter() {
+    SubmarineConfiguration conf = SubmarineConfiguration.getInstance();
+    conf.setString(SubmarineConfVars.ConfVars.SUBMARINE_SUBMITTERS, "mock");
+    conf.setString(SubmarineConfVars.ConfVars.SUBMARINE_SUBMITTERS_CLASS,
+        "mock", "org.apache.submarine.server.submitter.mock.MockSubmitter");
+    SubmitterManager manager = new SubmitterManager(conf);
+    JobSubmitter submitter = manager.getSubmitterByType("mock");
+    Assert.assertNotNull(submitter);
+    Assert.assertEquals(MockSubmitter.class, submitter.getClass());
+  }
+}

--- a/submarine-server/server-core/src/test/java/org/apache/submarine/server/submitter/mock/MockSubmitter.java
+++ b/submarine-server/server-core/src/test/java/org/apache/submarine/server/submitter/mock/MockSubmitter.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.submarine.server.submitter.mock;
+
+import org.apache.submarine.commons.utils.SubmarineConfiguration;
+import org.apache.submarine.server.api.JobSubmitter;
+import org.apache.submarine.server.api.exception.InvalidSpecException;
+import org.apache.submarine.server.api.exception.UnsupportedJobTypeException;
+import org.apache.submarine.server.api.job.Job;
+import org.apache.submarine.server.api.spec.JobSpec;
+
+public class MockSubmitter implements JobSubmitter {
+  @Override
+  public void initialize(SubmarineConfiguration conf) {
+    System.out.println("mock");
+  }
+
+  @Override
+  public String getSubmitterType() {
+    return "mock";
+  }
+
+  @Override
+  public Job submitJob(JobSpec jobSpec) throws UnsupportedJobTypeException, InvalidSpecException {
+    return null;
+  }
+}


### PR DESCRIPTION
### What is this PR for?
To ensure the SubmitterManager can load any custom JobSubmitter which is set in configuration file.

### What type of PR is it?
Improvement

### Todos

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-300

### How should this be tested?
https://travis-ci.com/github/jiwq/submarine/builds/156283502

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
