### PR TITLE
SUBMARINE-466. [WORKBENCH] Add lib path creation into bin/submarine-daemon.sh

### DIFF
--- a/bin/submarine-daemon.sh
+++ b/bin/submarine-daemon.sh
@@ -92,7 +92,7 @@ function wait_for_submarine_server_to_die() {
 
 function check_jdbc_jar() {
   if [[ ! -e "${1}" ]]; then
-    echo -e "\\033[31mError: Path '${1}' doesn't exist.\\033[0m"
+    echo -e "\\033[31mWarn: Path '${1}' doesn't exist.\\033[0m"
     echo -e "\\033[31mCreate path '${1}' automatically.\\033[0m"
     mkdir -p "${1}"
     if [[ ${GET_MYSQL_JAR} = true ]]; then

--- a/bin/submarine-daemon.sh
+++ b/bin/submarine-daemon.sh
@@ -91,7 +91,14 @@ function wait_for_submarine_server_to_die() {
 }
 
 function check_jdbc_jar() {
-  if [[ -d "${1}" ]]; then
+  if [[ ! -e "${1}" ]]; then
+    echo -e "\\033[31mError: Path '${1}' doesn't exist.\\033[0m"
+    echo -e "\\033[31mCreate path '${1}' automatically.\\033[0m"
+    mkdir -p "${1}"
+    if [[ ${GET_MYSQL_JAR} = true ]]; then
+        download_mysql_jdbc_jar
+    fi
+  elif [[ -d "${1}" ]]; then
     mysql_connector_exists=$(find -L "${1}" -name "mysql-connector*")
     if [[ -z "${mysql_connector_exists}" ]]; then
       if [[ ${GET_MYSQL_JAR} = true ]]; then


### PR DESCRIPTION
### What is this PR for?

The `bin/submarine-daemon.sh` script should create path `submarine/lib` if user type 

`./bin/submarine-daemon.sh start getMysqlJar`

without creating `submarine/lib` directory first.


### What type of PR is it?
[Improvement]


### What is the Jira issue?

https://issues.apache.org/jira/browse/SUBMARINE-466

### How should this be tested?

https://travis-ci.org/github/cchung100m/submarine/builds/673689069

### Screenshots (if appropriate)

<img width="921" alt="螢幕快照 2020-04-10 下午11 24 30" src="https://user-images.githubusercontent.com/6762509/79002610-6560db00-7b83-11ea-8ea3-ca10beca15c0.png">

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
