### PR TITLE
SUBMARINE-457. Run TF MNIST example using Docker Container failed in mini-submarine

### DIFF
--- a/docs/helper/InstallationGuide.md
+++ b/docs/helper/InstallationGuide.md
@@ -415,7 +415,8 @@ Run a distributed tensorflow job.
 The parameter -d is used to specify the url from which we can get the mnist data.
 
 ### Run a TensorFlow job in a Docker container
-Prepare your docker image, you could refer to this sample Docker image for building your own Docker image. An example is provided under `docker/tensorflow/mnist/Dockerfile.tony.tf.mnist.tf_1.13.1`
+Prepare your docker image, you could refer to this sample Docker image for building your own Docker image. An example is provided under `docker/tensorflow/mnist/Dockerfile.tony.tf.mnist.tf_1.13.1`.
+For details please refer to [Docker Image Requirements](https://hadoop.apache.org/docs/current/hadoop-yarn/hadoop-yarn-site/DockerContainers.html#user-management).
 
 Please make sure you have _HADOOP_HOME_, _HADOOP_YARN_HOME_, _HADOOP_HDFS_HOME_, _HADOOP_CONF_DIR_, _JAVA_HOME_ configured correctly. You could use this command to run a distributed TensorFLow job in Docker
 
@@ -534,7 +535,7 @@ Then restart all nodemanagers.
 ### Start yarn registery dns service
 
 Yarn registry nds server exposes existing service-discovery information via DNS
-and enables docker containers to IP mappings. By using it, the containers of a 
+and enables docker containers to IP mappings. By using it, the containers of a
 ML job knows how to communicate with each other.
 
 Please specify a server to start yarn registery dns service. For details please

--- a/docs/helper/docker/tensorflow/mnist/Dockerfile.tony.tf.mnist.tf_1.13.1
+++ b/docs/helper/docker/tensorflow/mnist/Dockerfile.tony.tf.mnist.tf_1.13.1
@@ -22,6 +22,7 @@ RUN apt-get -y install apt-transport-https \
      curl \
      gnupg2 \
      git \
+     zip \
      software-properties-common \
      openjdk-8-jdk vim \
      wget python3-distutils
@@ -63,7 +64,8 @@ ENV HADOOP_HDFS_HOME=/opt/hadoop-$HADOOP_VERSION/
 ENV HADOOP_CONF_DIR=/opt/hadoop-$HADOOP_VERSION/etc/hadoop
 ENV JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
 
-# Crate user, make sure the user groups are the same as your host
+# Create a user, make sure the user groups are the same as your host
+# and the user's UID same as your NodeManager host
 RUN groupadd -g 5000 hadoop
 RUN useradd -u 1000 -g hadoop pi
 RUN mkdir /home/pi


### PR DESCRIPTION
### What is this PR for?
The error "javax.security.auth.login.LoginException: java.lang.NullPointerException: invalid null input: name.." is due to user's UID of NodeManager host and container user are mismatch.
So I think we only need to improve some documents.

<img width="1028" alt="screenshot" src="https://user-images.githubusercontent.com/52355146/79230216-d3b0e080-7e96-11ea-84e0-6c354c04a169.png">

[link](https://hadoop.apache.org/docs/r2.9.2/hadoop-yarn/hadoop-yarn-site/DockerContainers.html
)

### What type of PR is it?
[Bug Fix]

### Todos

### What is the Jira issue?
[SUBMARINE-457](https://issues.apache.org/jira/projects/SUBMARINE/issues/SUBMARINE-457)

### How should this be tested?
[passed CI](https://travis-ci.org/github/lowc1012/submarine/builds/674784433)

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
