### PR TITLE
SUBMARINE-442. Support get job's log in submarine-server REST API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,9 @@ submarine-cloud/bin/*
 
 submarine-security/spark-security/dependency-reduced-pom.xml
 submarine-security/spark-security/derby.log
+
+# vscode file
+.project
+.classpath
+.settings
+.factorypath

--- a/submarine-server/server-api/src/main/java/org/apache/submarine/server/api/job/JobLog.java
+++ b/submarine-server/server-api/src/main/java/org/apache/submarine/server/api/job/JobLog.java
@@ -17,23 +17,41 @@
  * under the License.
  */
 
-package org.apache.submarine.server.rest;
+package org.apache.submarine.server.api.job;
 
-public class RestConstants {
-  public static final String V1 = "v1";
-  public static final String JOBS = "jobs";
-  public static final String JOB_ID = "id";
-  public static final String PING = "ping";
-  public static final String MEDIA_TYPE_YAML = "application/yaml";
-  public static final String CHARSET_UTF8 = "charset=utf-8";
+import java.util.ArrayList;
+import java.util.List;
 
-  public static final String METASTORE = "metastore";
+public class JobLog {
+  private String jobId;
+  private List<podLog> logContent;
 
-  public static final String CLUSTER = "cluster";
-  public static final String ADDRESS = "address";
+  class podLog {
+    String podName;
+    String podLog;
+    podLog(String podName, String podLog) {
+      this.podName = podName;
+      this.podLog = podLog;
+    }
+  }
 
-  public static final String NODES = "nodes";
-  public static final String NODE = "node";
+  public JobLog() {
+    logContent = new ArrayList<podLog>();
+  }
+  
+  public void setJobId(String jobId) {
+    this.jobId = jobId;
+  }
+  
+  public String getJobId() {
+    return jobId;
+  }
 
-  public static final String LOGS = "logs";
+  public void addPodLog(String name, String log) {
+    logContent.add(new podLog(name, log));
+  }
+
+  public void clearPodLog() {
+    logContent.clear();
+  }
 }

--- a/submarine-server/server-api/src/main/java/org/apache/submarine/server/api/job/JobSubmitter.java
+++ b/submarine-server/server-api/src/main/java/org/apache/submarine/server/api/job/JobSubmitter.java
@@ -70,4 +70,20 @@ public interface JobSubmitter {
    * @throws SubmarineRuntimeException running error
    */
   Job deleteJob(JobSpec jobSpec) throws SubmarineRuntimeException;
+
+  /**
+   * Get the pod log list in the job
+   * @param Job job
+   * @return object
+   * @throws SubmarineRuntimeException running error
+   */
+  JobLog getJobLog(JobSpec jobSpec, String jobId) throws SubmarineRuntimeException;
+
+  /**
+   * Get the pod name list in the job
+   * @param Job job
+   * @return object
+   * @throws SubmarineRuntimeException running error
+   */
+  JobLog getJobLogName(JobSpec jobSpec, String jobId) throws SubmarineRuntimeException;
 }

--- a/submarine-server/server-core/src/main/java/org/apache/submarine/server/rest/JobManagerRestApi.java
+++ b/submarine-server/server-core/src/main/java/org/apache/submarine/server/rest/JobManagerRestApi.java
@@ -35,6 +35,7 @@ import java.util.List;
 import org.apache.submarine.commons.utils.exception.SubmarineRuntimeException;
 import org.apache.submarine.server.job.JobManager;
 import org.apache.submarine.server.api.job.Job;
+import org.apache.submarine.server.api.job.JobLog;
 import org.apache.submarine.server.api.spec.JobSpec;
 import org.apache.submarine.server.response.JsonResponse;
 
@@ -128,6 +129,32 @@ public class JobManagerRestApi {
       Job job = jobManager.deleteJob(id);
       return new JsonResponse.Builder<Job>(Response.Status.OK)
           .result(job).build();
+    } catch (SubmarineRuntimeException e) {
+      return parseJobServiceException(e);
+    }
+  }
+  
+  @GET
+  @Path("/logs")
+  public Response listLog(@QueryParam("status") String status) {
+    try {
+      List<JobLog> jobLogList = jobManager.listJobLogsByStatus(status);
+      return new JsonResponse.Builder<List<JobLog>>(Response.Status.OK).
+          result(jobLogList).build();
+
+    } catch (SubmarineRuntimeException e) {
+      return parseJobServiceException(e);
+    }
+  }
+
+  @GET
+  @Path("/logs/{id}")
+  public Response getLog(@PathParam(RestConstants.JOB_ID) String id) {
+    try {
+      JobLog jobLog = jobManager.getJobLog(id);
+      return new JsonResponse.Builder<JobLog>(Response.Status.OK).
+          result(jobLog).build();
+
     } catch (SubmarineRuntimeException e) {
       return parseJobServiceException(e);
     }

--- a/submarine-test/test-k8s/src/test/java/org/apache/submarine/rest/JobManagerRestApiIT.java
+++ b/submarine-test/test-k8s/src/test/java/org/apache/submarine/rest/JobManagerRestApiIT.java
@@ -258,7 +258,7 @@ public class JobManagerRestApiIT extends AbstractSubmarineServerTest {
   }
 
   @Test
-  public void testListJob() throws Exception {
+  public void testListJobLog() throws Exception {
     GetMethod getMethod = httpGet(JOB_LOG_PATH);
     Assert.assertEquals(Response.Status.OK.getStatusCode(), getMethod.getStatusCode());
 

--- a/submarine-test/test-k8s/src/test/java/org/apache/submarine/rest/JobManagerRestApiIT.java
+++ b/submarine-test/test-k8s/src/test/java/org/apache/submarine/rest/JobManagerRestApiIT.java
@@ -24,18 +24,15 @@ import javax.ws.rs.core.Response;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
-import java.lang.reflect.Type;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.Date;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonObject;
-import com.google.gson.reflect.TypeToken;
 
 import io.kubernetes.client.ApiClient;
 import io.kubernetes.client.ApiException;
@@ -51,7 +48,6 @@ import org.apache.commons.io.FileUtils;
 import org.apache.submarine.server.AbstractSubmarineServerTest;
 import org.apache.submarine.server.api.job.Job;
 import org.apache.submarine.server.api.job.JobId;
-import org.apache.submarine.server.api.job.JobLog;
 import org.apache.submarine.server.json.JobIdDeserializer;
 import org.apache.submarine.server.json.JobIdSerializer;
 import org.apache.submarine.server.response.JsonResponse;
@@ -158,7 +154,7 @@ public class JobManagerRestApiIT extends AbstractSubmarineServerTest {
     verifyGetJobApiResult(createdJob, foundJob);
 
     // get log list
-    // TODO(JohnTing): jobLog test
+    // TODO(JohnTing): Test the job log after creating the job
 
     // patch
     // TODO(jiwq): the commons-httpclient not support patch method
@@ -191,10 +187,6 @@ public class JobManagerRestApiIT extends AbstractSubmarineServerTest {
     Assert.assertEquals(createdJob.getAcceptedTime(), foundJob.getAcceptedTime());
 
     assertK8sResultEquals(foundJob);
-  }
-
-  private void verifyGetJobLogApiResult(Job createdJob, JobLog foundJobLog) throws Exception {
-    Assert.assertEquals(createdJob.getJobId().toString(), foundJobLog.getJobId());
   }
 
   private void assertK8sResultEquals(Job job) throws Exception {
@@ -263,6 +255,16 @@ public class JobManagerRestApiIT extends AbstractSubmarineServerTest {
     String json = getMethod.getResponseBodyAsString();
     JsonResponse jsonResponse = gson.fromJson(json, JsonResponse.class);
     Assert.assertEquals(Response.Status.NOT_FOUND.getStatusCode(), jsonResponse.getCode());
+  }
+
+  @Test
+  public void testListJob() throws Exception {
+    GetMethod getMethod = httpGet(JOB_LOG_PATH);
+    Assert.assertEquals(Response.Status.OK.getStatusCode(), getMethod.getStatusCode());
+
+    String json = getMethod.getResponseBodyAsString();
+    JsonResponse jsonResponse = gson.fromJson(json, JsonResponse.class);
+    Assert.assertEquals(Response.Status.OK.getStatusCode(), jsonResponse.getCode());
   }
 
   String loadContent(String resourceName) throws Exception {

--- a/submarine-test/test-k8s/src/test/java/org/apache/submarine/rest/JobManagerRestApiIT.java
+++ b/submarine-test/test-k8s/src/test/java/org/apache/submarine/rest/JobManagerRestApiIT.java
@@ -24,15 +24,19 @@ import javax.ws.rs.core.Response;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
+import java.lang.reflect.Type;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonObject;
+import com.google.gson.reflect.TypeToken;
+
 import io.kubernetes.client.ApiClient;
 import io.kubernetes.client.ApiException;
 import io.kubernetes.client.Configuration;
@@ -47,6 +51,7 @@ import org.apache.commons.io.FileUtils;
 import org.apache.submarine.server.AbstractSubmarineServerTest;
 import org.apache.submarine.server.api.job.Job;
 import org.apache.submarine.server.api.job.JobId;
+import org.apache.submarine.server.api.job.JobLog;
 import org.apache.submarine.server.json.JobIdDeserializer;
 import org.apache.submarine.server.json.JobIdSerializer;
 import org.apache.submarine.server.response.JsonResponse;
@@ -66,6 +71,7 @@ public class JobManagerRestApiIT extends AbstractSubmarineServerTest {
   /** Key is the ml framework name, the value is the operator */
   private static Map<String, KfOperator> kfOperatorMap;
   private static String JOB_PATH = "/api/" + RestConstants.V1 + "/" + RestConstants.JOBS;
+  private static String JOB_LOG_PATH = JOB_PATH + "/" + RestConstants.LOGS;
 
   private Gson gson = new GsonBuilder()
       .registerTypeAdapter(JobId.class, new JobIdSerializer())
@@ -151,6 +157,9 @@ public class JobManagerRestApiIT extends AbstractSubmarineServerTest {
     Job foundJob = gson.fromJson(gson.toJson(jsonResponse.getResult()), Job.class);
     verifyGetJobApiResult(createdJob, foundJob);
 
+    // get log list
+    // TODO(JohnTing): jobLog test
+
     // patch
     // TODO(jiwq): the commons-httpclient not support patch method
     // https://tools.ietf.org/html/rfc5789
@@ -182,6 +191,10 @@ public class JobManagerRestApiIT extends AbstractSubmarineServerTest {
     Assert.assertEquals(createdJob.getAcceptedTime(), foundJob.getAcceptedTime());
 
     assertK8sResultEquals(foundJob);
+  }
+
+  private void verifyGetJobLogApiResult(Job createdJob, JobLog foundJobLog) throws Exception {
+    Assert.assertEquals(createdJob.getJobId().toString(), foundJobLog.getJobId());
   }
 
   private void assertK8sResultEquals(Job job) throws Exception {


### PR DESCRIPTION
### What is this PR for?

Now we have the "jobs" resource in REST which can do CRUD. We also need a "logs" API to get the job's log output. The URI could be "api/v1/logs"
It should accept parameters like "jobid". Initially, the logs could be aggregated logs of all containers.
Streaming is preferred so that the python client can enable a fancy way for the end-user to check logs

### What type of PR is it?
Feature

### Todos
* [x] - get logs so far

### What is the Jira issue?
https://issues.apache.org/jira/projects/SUBMARINE/issues/SUBMARINE-442

### How should this be tested?
Create a job 
Visit /api/v1/logs or /api/v1/logs/{jobid} with a browser

### Screenshots (if appropriate)
http://127.0.0.1:8080/api/v1/jobs/logs
![image](https://user-images.githubusercontent.com/19265751/79961593-8a294c80-84b9-11ea-85ef-9367e17fecc9.png)

http://127.0.0.1:8080/api/v1/jobs/logs/job_1587481945001_0001
![image](https://user-images.githubusercontent.com/19265751/79961674-a0370d00-84b9-11ea-908f-b6bdeceeb6eb.png)


### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No