### PR TITLE
SUBMARINE-478. Running jupyterlab container in KIND

### DIFF
--- a/docs/workbench/notebook/jupyter.yaml
+++ b/docs/workbench/notebook/jupyter.yaml
@@ -43,7 +43,7 @@ spec:
         - name: jupyter-storage
           # this path must be the same as extraMounts.containerPath in the kind config
           hostPath:
-            path: /home/jovyan/
+            path: /tmp/submarine/
             type: DirectoryOrCreate
 ---
 kind: Service

--- a/docs/workbench/notebook/jupyter.yaml
+++ b/docs/workbench/notebook/jupyter.yaml
@@ -1,0 +1,60 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+kind: Deployment
+apiVersion: extensions/v1beta1
+metadata:
+  name: jupyter-deployment
+  labels:
+    app: jupyter
+spec:
+  selector:
+    matchLabels:
+      app: jupyter
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        namespace: submarine
+        app: jupyter
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: k8s-submarine-control-plane
+      containers:
+        - name: jupyter
+          image: jupyter/minimal-notebook
+          # mount path in jupyter container
+          volumeMounts:
+            - mountPath: /home/jovyan
+              name: jupyter-storage
+      volumes:
+        - name: jupyter-storage
+          # this path must be the same as extraMounts.containerPath in the kind config
+          hostPath:
+            path: /home/jovyan/
+            type: DirectoryOrCreate
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: jupyter-service
+spec:
+  selector:
+    app: jupyter
+  type: NodePort
+  ports:
+    - port: 8888
+      targetPort: 8888
+      nodePort: 30070

--- a/docs/workbench/notebook/setup-jupyter.md
+++ b/docs/workbench/notebook/setup-jupyter.md
@@ -31,8 +31,8 @@ nodes:
 - role: control-plane
   extraMounts:
   # add a mount from /path/to/my/files on the host to /files on the node
-  - hostPath: /tmp/jovyan
-    containerPath: /home/jovyan
+  - hostPath: /tmp/submarine
+    containerPath: /tmp/submarine
   extraPortMappings:
   - containerPort: 80
     hostPort: 80

--- a/docs/workbench/notebook/setup-jupyter.md
+++ b/docs/workbench/notebook/setup-jupyter.md
@@ -1,0 +1,73 @@
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+   http://www.apache.org/licenses/LICENSE-2.0
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+# Deploy Jupyter Notebook on Kubernetes
+This guide covers the deployment Jupyter Notebook on kubernetes cluster.
+
+## Experiment environment
+### Setup Kubernetes
+We recommend using [kind](https://kind.sigs.k8s.io/) to setup a Kubernetes cluster on a local machine.
+
+You can use Extra mounts to mount your host path to kind node and use Extra port mappings to port
+forward to the kind nodes. Please refer to [kind configuration](https://kind.sigs.k8s.io/docs/user/configuration/#extra-mounts)
+for more details.
+
+You need to create a kind config file. The following is an example :
+```
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+  extraMounts:
+  # add a mount from /path/to/my/files on the host to /files on the node
+  - hostPath: /tmp/jovyan
+    containerPath: /home/jovyan
+  extraPortMappings:
+  - containerPort: 80
+    hostPort: 80
+    protocol: TCP
+  # exposing additional ports to be used for NodePort services
+  - containerPort: 30070
+    hostPort: 8888
+    protocol: TCP
+```
+
+Running the following command:
+
+```
+kind create cluster --image kindest/node:v1.15.6 --config <path-to-kind-config> --name k8s-submarine
+kubectl create namespace submarine
+```
+
+### Deploy Jupyter Notebook
+Once you have a running Kubernetes cluster, you can write a YAML file to deploy a jupyter notebook.
+In this [example yaml](./jupyter.yaml), we use [jupyter/minimal-notebook](https://hub.docker.com/r/jupyter/minimal-notebook/)
+to make a single notebook running on the kind node.
+
+```
+kubectl apply -f jupyter.yaml --namespace submarine
+```
+
+Once jupyter notebook is running, you can access the notebook server from the browser using http://localhost:8888 on local machine.
+
+You can enter and store a password for your notebook server with:
+```
+kubectl exec -it <jupyter-pod-name> -- jupyter notebook password
+```
+After restarting the notebook server,  you can login jupyter notebook with your new password.
+
+If you want to use JupyterLab :
+```
+http://localhost:8888/lab
+```


### PR DESCRIPTION
### What is this PR for?
Use jupyter's yaml file to run a jupyter container,
1. First support mounting local path into jupyter
2. Support setting jupyter password
3. Run by creating jupyter pod in KIND
4. Provide simple Python library support (if the submarine project has a relatively complete Python image, it can also be used)

### What type of PR is it?
[Feature]

### Todos
* [ ] - Task

### What is the Jira issue?
[SUBMARINE-478](https://issues.apache.org/jira/projects/SUBMARINE/issues/SUBMARINE-478)

### How should this be tested?
[passed CI](https://travis-ci.org/github/lowc1012/submarine/builds/682881085)

### Screenshots (if appropriate)
<img width="984" alt="screenshot" src="https://user-images.githubusercontent.com/52355146/80968374-6e735e00-8e4a-11ea-9743-857944aa9cbd.png">

<img width="1044" alt="screenshot1" src="https://user-images.githubusercontent.com/52355146/80968115-00c73200-8e4a-11ea-86f6-725c6fc14831.png">

<img width="337" alt="screenshot2" src="https://user-images.githubusercontent.com/52355146/80968165-12103e80-8e4a-11ea-9063-a6791cda851e.png">

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
