### PR TITLE
SUBMARINE-492. Delete unnecessary maven install instruction in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,12 +61,6 @@ env:
     - MOZ_HEADLESS=1
 
 before_install:
-  # maven 3.6.1 (3.6.2 build tony failed!!!)
-  - echo "Download Maven 3.6.1"
-  - wget https://archive.apache.org/dist/maven/maven-3/3.6.1/binaries/apache-maven-3.6.1-bin.tar.gz
-  - tar zxvf apache-maven-3.6.1-bin.tar.gz || travis_terminate 1
-  - export M2_HOME=$PWD/apache-maven-3.6.1
-  - export PATH=$M2_HOME/bin:$PATH
   # mysql
   - sudo service mysql restart
   - mysql -e "create database submarine_test;"

--- a/.travis.yml
+++ b/.travis.yml
@@ -306,7 +306,7 @@ matrix:
       jdk: openjdk8
       env:
         - MAVEN_OPTS="-Xmx2g -XX:ReservedCodeCacheSize=512m -Dorg.slf4j.simpleLogger.defaultLogLevel=WARN"
-        - BUILD_FLAG="--no-transfer-progress clean install -Dmaven.javadoc.skip=true"
+        - BUILD_FLAG="--batch-mode clean install -Dmaven.javadoc.skip=true"
         - TEST_FLAG=$BUILD_FLAG
         - PROFILE="-Pspark-2.3 -Pranger-1.0"
         - MODULES="-pl :submarine-spark-security"
@@ -316,7 +316,7 @@ matrix:
       jdk: openjdk8
       env:
         - MAVEN_OPTS="-Xmx2g -XX:ReservedCodeCacheSize=512m -Dorg.slf4j.simpleLogger.defaultLogLevel=WARN"
-        - BUILD_FLAG="--no-transfer-progress clean install -Dmaven.javadoc.skip=true"
+        - BUILD_FLAG="--batch-mode clean install -Dmaven.javadoc.skip=true"
         - TEST_FLAG=$BUILD_FLAG
         - PROFILE="-Pspark-2.3 -Pranger-1.1"
         - MODULES="-pl :submarine-spark-security"
@@ -326,7 +326,7 @@ matrix:
       jdk: openjdk8
       env:
         - MAVEN_OPTS="-Xmx2g -XX:ReservedCodeCacheSize=512m -Dorg.slf4j.simpleLogger.defaultLogLevel=WARN"
-        - BUILD_FLAG="--no-transfer-progress clean install -Dmaven.javadoc.skip=true"
+        - BUILD_FLAG="--batch-mode clean install -Dmaven.javadoc.skip=true"
         - TEST_FLAG=$BUILD_FLAG
         - PROFILE="-Pspark-2.3 -Pranger-1.2"
         - MODULES="-pl :submarine-spark-security"
@@ -336,7 +336,7 @@ matrix:
       jdk: openjdk8
       env:
         - MAVEN_OPTS="-Xmx2g -XX:ReservedCodeCacheSize=512m -Dorg.slf4j.simpleLogger.defaultLogLevel=WARN"
-        - BUILD_FLAG="--no-transfer-progress clean install -Dmaven.javadoc.skip=true"
+        - BUILD_FLAG="--batch-mode clean install -Dmaven.javadoc.skip=true"
         - TEST_FLAG=$BUILD_FLAG
         - PROFILE="-Pspark-2.3 -Pranger-2.0"
         - MODULES="-pl :submarine-spark-security"
@@ -346,7 +346,7 @@ matrix:
       jdk: openjdk8
       env:
         - MAVEN_OPTS="-Xmx2g -XX:ReservedCodeCacheSize=512m -Dorg.slf4j.simpleLogger.defaultLogLevel=WARN"
-        - BUILD_FLAG="--no-transfer-progress clean install -Dmaven.javadoc.skip=true"
+        - BUILD_FLAG="--batch-mode clean install -Dmaven.javadoc.skip=true"
         - TEST_FLAG=$BUILD_FLAG
         - PROFILE="-Pspark-2.4 -Pranger-1.0"
         - MODULES="-pl :submarine-spark-security"
@@ -356,7 +356,7 @@ matrix:
       jdk: openjdk8
       env:
         - MAVEN_OPTS="-Xmx2g -XX:ReservedCodeCacheSize=512m -Dorg.slf4j.simpleLogger.defaultLogLevel=WARN"
-        - BUILD_FLAG="--no-transfer-progress clean install -Dmaven.javadoc.skip=true"
+        - BUILD_FLAG="--batch-mode clean install -Dmaven.javadoc.skip=true"
         - TEST_FLAG=$BUILD_FLAG
         - PROFILE="-Pspark-2.4 -Pranger-1.1"
         - MODULES="-pl :submarine-spark-security"
@@ -366,7 +366,7 @@ matrix:
       jdk: openjdk8
       env:
         - MAVEN_OPTS="-Xmx2g -XX:ReservedCodeCacheSize=512m -Dorg.slf4j.simpleLogger.defaultLogLevel=WARN"
-        - BUILD_FLAG="--no-transfer-progress clean install -Dmaven.javadoc.skip=true"
+        - BUILD_FLAG="--batch-mode clean install -Dmaven.javadoc.skip=true"
         - TEST_FLAG=$BUILD_FLAG
         - PROFILE="-Pspark-2.4 -Pranger-1.2"
         - MODULES="-pl :submarine-spark-security"
@@ -376,7 +376,7 @@ matrix:
       jdk: openjdk8
       env:
         - MAVEN_OPTS="-Xmx2g -XX:ReservedCodeCacheSize=512m -Dorg.slf4j.simpleLogger.defaultLogLevel=WARN"
-        - BUILD_FLAG="--no-transfer-progress clean install -Dmaven.javadoc.skip=true"
+        - BUILD_FLAG="--batch-mode clean install -Dmaven.javadoc.skip=true"
         - TEST_FLAG=$BUILD_FLAG
         - PROFILE="-Pspark-2.4 -Pranger-2.0"
         - MODULES="-pl :submarine-spark-security"


### PR DESCRIPTION
### What is this PR for?
Due to TonY source code has been removed from submarine, we should remove the specific maven install instructions in travis system.

### What type of PR is it?
[Bug Fix]

### What is the Jira issue?

[SUBMARINE-492](https://issues.apache.org/jira/browse/SUBMARINE-492)

### How should this be tested?
* First time? Setup Travis CI as described on https://submarine.apache.org/contribution/contributions.html#continuous-integration
* Strongly recommended: add automated unit tests for any new or changed behavior
* Outline any manual steps to test the PR here.

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? Yes/No
* Is there breaking changes for older versions? Yes/No
* Does this needs documentation? Yes/No
