### PR TITLE
SUBMARINE-501. Delete submarine-submitter-k8s unit test on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -230,34 +230,6 @@ matrix:
         - TEST_MODULES="-pl ${EXCLUDE_SUBMITTER_K8S},${EXCLUDE_WORKBENCH},${EXCLUDE_INTERPRETER},${EXCLUDE_CLOUD},${EXCLUDE_COMMONS},${EXCLUDE_DIST},${EXCLUDE_TEST},${EXCLUDE_ALL},${EXCLUDE_SERVER},${EXCLUDE_SPARK_SECURTITY}"
         - TEST_PROJECTS=""
 
-    - name: Test submarine submitter on Kubernetes
-      dist: xenial
-      services: docker
-      language: java
-      jdk: openjdk8
-      env: BUILD_FLAG="clean package install -DskipTests -am" TEST_FLAG="test -am" MODULES="-pl org.apache.submarine:submarine-submitter-k8s" TEST_MODULES="-pl org.apache.submarine:submarine-submitter-k8s" TEST_PROJECTS=""
-      before_install:
-        # deploy Kubernetes cluster
-        - curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl
-        - chmod +x kubectl
-        - sudo mv kubectl /usr/bin
-        - docker run -d --name kube --privileged -p 8443:8443 -p 10080:10080 bsycorp/kind:latest-1.15
-        - until curl -s --fail http://127.0.0.1:10080/kubernetes-ready; do
-          sleep 1;
-          done
-        - echo "Kubernetes ready - run tests!"
-        - mkdir $HOME/.kube
-        - curl http://127.0.0.1:10080/config > $HOME/.kube/config
-        - export KUBECONFIG=$HOME/.kube/config
-        - echo $KUBECONFIG
-        - kubectl config set clusters.kubernetes.server https://127.0.0.1:8443
-        - kubectl get nodes
-        - kubectl create namespace submarine
-        - kubectl apply -f ./dev-support/travis/tf-operator/crd_v1.yaml
-        - kubectl apply -f ./dev-support/travis/tf-operator/tfevent-volume/.
-        # prepare pytroch job CRD
-        - kubectl apply -f ./dev-support/k8s/pytorchjob/crd.yaml
-
     # Template disable by SUBMARINE-381
     #- name: Test submarine interpreter
     #  language: java


### PR DESCRIPTION
### What is this PR for?
Delete submarine-submitter-k8s unit test script on travis CI since k8s behavior is already tested in submarine-test-k8s integration test and it takes a lot of time to create a cluster.

### What type of PR is it?
Bug Fix

### Todos

### What is the Jira issue?
[SUBMARINE-501](https://issues.apache.org/jira/browse/SUBMARINE-501)

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
