### PR TITLE
SUBMARINE-513. Remove "\n" in job logs

### DIFF
--- a/submarine-server/server-api/src/main/java/org/apache/submarine/server/api/job/JobLog.java
+++ b/submarine-server/server-api/src/main/java/org/apache/submarine/server/api/job/JobLog.java
@@ -20,23 +20,24 @@
 package org.apache.submarine.server.api.job;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 public class JobLog {
   private String jobId;
-  private List<podLog> logContent;
+  private List<PodLog> logContent;
 
-  class podLog {
+  class PodLog {
     String podName;
-    String podLog;
-    podLog(String podName, String podLog) {
-      this.podName = podName;
-      this.podLog = podLog;
+    List<String> podLog;
+    PodLog(String name, String log) {
+      this.podName = name;
+      this.podLog.addAll(Arrays.asList(log.split("\n")));
     }
   }
 
   public JobLog() {
-    logContent = new ArrayList<podLog>();
+    logContent = new ArrayList<PodLog>();
   }
   
   public void setJobId(String jobId) {
@@ -48,7 +49,12 @@ public class JobLog {
   }
 
   public void addPodLog(String name, String log) {
-    logContent.add(new podLog(name, log));
+    for (PodLog podlog : logContent) {
+      if(podlog.podName.equals(name))
+      {
+        podlog.podLog.addAll(Arrays.asList(log.split("\n")));
+      }
+    }
   }
 
   public void clearPodLog() {

--- a/submarine-server/server-api/src/main/java/org/apache/submarine/server/api/job/JobLog.java
+++ b/submarine-server/server-api/src/main/java/org/apache/submarine/server/api/job/JobLog.java
@@ -28,11 +28,18 @@ public class JobLog {
   private List<PodLog> logContent;
 
   class PodLog {
+    
     String podName;
-    List<String> podLog;
+    List<String> podLog = new ArrayList<String>();
+
     PodLog(String name, String log) {
       this.podName = name;
-      this.podLog.addAll(Arrays.asList(log.split("\n")));
+      this.podLog = new ArrayList<String>();
+      addLog(log);
+    }
+    void addLog(String log) {
+      if ( log != null)
+        this.podLog.addAll(Arrays.asList(log.split("\n")));
     }
   }
 
@@ -50,11 +57,13 @@ public class JobLog {
 
   public void addPodLog(String name, String log) {
     for (PodLog podlog : logContent) {
-      if(podlog.podName.equals(name))
+      if (podlog.podName.equals(name))
       {
-        podlog.podLog.addAll(Arrays.asList(log.split("\n")));
+        podlog.addLog(log);
+        return;
       }
     }
+    logContent.add(new PodLog(name, log));
   }
 
   public void clearPodLog() {


### PR DESCRIPTION
### What is this PR for?
When logging job output, the content contains "\n", didn't print correctly.

curl -X GET http://127.0.0.1:8080/api/v1/jobs/logs/job_1590165277436_0001


### What type of PR is it?
Improvement

### Todos
* [X ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/projects/SUBMARINE/issues/SUBMARINE-513

### How should this be tested?
* First time? Setup Travis CI as described on https://submarine.apache.org/contribution/contributions.html#continuous-integration
* Strongly recommended: add automated unit tests for any new or changed behavior
* Outline any manual steps to test the PR here.

### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/19265751/82760210-b0c60480-9e24-11ea-88e6-d7b33cee1fd4.png)


### Questions:
* Does the licenses files need update? Yes/No
* Is there breaking changes for older versions? Yes/No
* Does this needs documentation? Yes/No
