### PR TITLE
SUBMARINE-529. Change apiVersion

### DIFF
--- a/helm-charts/submarine/templates/submarine-database.yaml
+++ b/helm-charts/submarine/templates/submarine-database.yaml
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: "{{ .Values.submarine.database.name }}"


### PR DESCRIPTION
### What is this PR for?
k8s installed by kind 0.8.0 seems that it does not support apiVersion apps/v1beta1 anymore.

Change to apps/v1 to build successfully.

### What type of PR is it?
[Improvement]

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-529

### How should this be tested?
https://travis-ci.com/github/wang0630/submarine/builds/172083779

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
