### PR TITLE
SUBMARINE-534. Set env_vars to optional in ExperimentMeta

### DIFF
--- a/submarine-sdk/pysubmarine/submarine/experiment/api/experiment_client.py
+++ b/submarine-sdk/pysubmarine/submarine/experiment/api/experiment_client.py
@@ -92,7 +92,7 @@ class ExperimentClient:
         response = self.experiment_api.get_experiment(id=id)
         return response.result
 
-    def list_experiments(self, status):
+    def list_experiments(self, status=None):
         """
         List all experiment for the user
         :param status: Accepted, Created, Running, Succeeded, Deleted

--- a/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/parser/ExperimentSpecParser.java
+++ b/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/parser/ExperimentSpecParser.java
@@ -171,7 +171,7 @@ public class ExperimentSpecParser {
   }
 
   private static List<V1EnvVar> parseEnvVars(Map<String, String> envMap) {
-    if(envMap == null)
+    if (envMap == null)
       return null;
     List<V1EnvVar> envVars = new ArrayList<>();
     for (Map.Entry<String, String> entry : envMap.entrySet()) {

--- a/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/parser/ExperimentSpecParser.java
+++ b/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/parser/ExperimentSpecParser.java
@@ -171,6 +171,8 @@ public class ExperimentSpecParser {
   }
 
   private static List<V1EnvVar> parseEnvVars(Map<String, String> envMap) {
+    if(envMap == null)
+      return null;
     List<V1EnvVar> envVars = new ArrayList<>();
     for (Map.Entry<String, String> entry : envMap.entrySet()) {
       V1EnvVar env = new V1EnvVar();

--- a/submarine-server/server-submitter/submitter-k8s/src/test/java/org/apache/submarine/server/submitter/k8s/ExperimentSpecParserTest.java
+++ b/submarine-server/server-submitter/submitter-k8s/src/test/java/org/apache/submarine/server/submitter/k8s/ExperimentSpecParserTest.java
@@ -47,6 +47,12 @@ public class ExperimentSpecParserTest extends SpecBuilder {
     validateMetadata(experimentSpec.getMeta(), tfJob.getMetadata(),
         ExperimentMeta.SupportedMLFramework.TENSORFLOW.getName().toLowerCase()
     );
+    // Validate ExperimentMeta without envVars. Related to SUBMARINE-534.
+    experimentSpec.getMeta().setEnvVars(null);
+    validateMetadata(experimentSpec.getMeta(), tfJob.getMetadata(),
+            ExperimentMeta.SupportedMLFramework.TENSORFLOW.getName().toLowerCase()
+    );
+
     validateReplicaSpec(experimentSpec, tfJob, TFJobReplicaType.Ps);
     validateReplicaSpec(experimentSpec, tfJob, TFJobReplicaType.Worker);
   }
@@ -84,6 +90,12 @@ public class ExperimentSpecParserTest extends SpecBuilder {
     validateMetadata(experimentSpec.getMeta(), pyTorchJob.getMetadata(),
         ExperimentMeta.SupportedMLFramework.PYTORCH.getName().toLowerCase()
     );
+    // Validate ExperimentMeta without envVars. Related to SUBMARINE-534.
+    experimentSpec.getMeta().setEnvVars(null);
+    validateMetadata(experimentSpec.getMeta(), pyTorchJob.getMetadata(),
+            ExperimentMeta.SupportedMLFramework.PYTORCH.getName().toLowerCase()
+    );
+
     validateReplicaSpec(experimentSpec, pyTorchJob, PyTorchJobReplicaType.Master);
     validateReplicaSpec(experimentSpec, pyTorchJob, PyTorchJobReplicaType.Worker);
   }


### PR DESCRIPTION
### What is this PR for?
Fix create experiment fails when the users don't specify `env_vars` in ExperimentMeta


### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-534?

### How should this be tested?
https://travis-ci.org/github/pingsutw/hadoop-submarine/builds/700290775

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
