### PR TITLE
SUBMARINE-537. missing JacksonJsonProvider in uber jar

### DIFF
--- a/submarine-security/spark-security/pom.xml
+++ b/submarine-security/spark-security/pom.xml
@@ -57,6 +57,7 @@
     <jna.version>5.2.0</jna.version>
     <jna-platform.version>5.2.0</jna-platform.version>
     <jna.scope>test</jna.scope>
+    <codehaus.jackson.version>1.9.13</codehaus.jackson.version>
   </properties>
   <dependencies>
     <dependency>
@@ -288,6 +289,7 @@
     <dependency>
       <groupId>org.codehaus.jackson</groupId>
       <artifactId>jackson-jaxrs</artifactId>
+      <version>${codehaus.jackson.version}</version>
       <scope>compile</scope>
     </dependency>
 

--- a/submarine-security/spark-security/pom.xml
+++ b/submarine-security/spark-security/pom.xml
@@ -285,6 +285,12 @@
       <scope>${jna.scope}</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.codehaus.jackson</groupId>
+      <artifactId>jackson-jaxrs</artifactId>
+      <scope>compile</scope>
+    </dependency>
+
   </dependencies>
 
   <build>


### PR DESCRIPTION
### What is this PR for?
submarine-spark-security fails with java.lang.NoClassDefFoundError

uber jar is missing submarine_spark_ranger_project/org/codehaus/jackson/jaxrs/JacksonJsonProvider

### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-537

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? Yes/No
* Is there breaking changes for older versions? Yes/No
* Does this needs documentation? Yes/No
