### PR TITLE
SUBMARINE-542. [SDK] get_log error when experiment is not started

### DIFF
--- a/submarine-sdk/pysubmarine/submarine/experiment/api/experiment_client.py
+++ b/submarine-sdk/pysubmarine/submarine/experiment/api/experiment_client.py
@@ -125,7 +125,7 @@ class ExperimentClient:
         response = self.experiment_api.get_log(id)
         log_contents = response.result['logContent']
 
-        if master is True and len(log_contents) !=0:
+        if master is True and len(log_contents) != 0:
             log_contents = [log_contents[0]]
 
         for log_content in log_contents:

--- a/submarine-sdk/pysubmarine/submarine/experiment/api/experiment_client.py
+++ b/submarine-sdk/pysubmarine/submarine/experiment/api/experiment_client.py
@@ -114,17 +114,18 @@ class ExperimentClient:
         return response.result
 
     def get_log(self, id, onlyMaster=False):
-        """  
+        """
         Get training logs of all pod of the experiment.
         By default get all the logs of Pod
         :param id: experiment id
-        :param onlyMaster: By default include pod log of "master" which might be Tensorflow PS/Chief or PyTroch master
+        :param onlyMaster: By default include pod log of "master" which might be
+         Tensorflow PS/Chief or PyTorch master
         :return: str: pods logs
         """
         response = self.experiment_api.get_log(id)
         log_contents = response.result['logContent']
 
-        if master is True and len(log_contents) != 0:
+        if onlyMaster is True and len(log_contents) != 0:
             log_contents = [log_contents[0]]
 
         for log_content in log_contents:

--- a/submarine-sdk/pysubmarine/submarine/experiment/api/experiment_client.py
+++ b/submarine-sdk/pysubmarine/submarine/experiment/api/experiment_client.py
@@ -65,7 +65,10 @@ class ExperimentClient:
 
     def _log_pod(self, id, index):
         response = self.experiment_api.get_log(id)
-        log_content = response.result['logContent'][0]
+        log_contents = response.result['logContent']
+        if len(log_contents) == 0:
+            return index
+        log_content = log_contents[0]
         for i, log in enumerate(log_content['podLog']):
             if i < index:
                 continue
@@ -110,11 +113,11 @@ class ExperimentClient:
         response = self.experiment_api.delete_experiment(id)
         return response.result
 
-    def get_log(self, id, master=True):
+    def get_log(self, id, master=False):
         """
         Get training logs of the experiment.
         By default only get the logs of Pod that has labels 'job-role: master'.
-        :param master: By default get pod with label 'job-role: master' pod if True.
+        :param master: Get pod with label 'job-role: master' pod if True.
                     If need to get more Pod Logs, set False.
         :param id: Experiment ID
         :return: str: experiment logs
@@ -122,7 +125,7 @@ class ExperimentClient:
         response = self.experiment_api.get_log(id)
         log_contents = response.result['logContent']
 
-        if master is True:
+        if master is True and len(log_contents) !=0:
             log_contents = [log_contents[0]]
 
         for log_content in log_contents:

--- a/submarine-sdk/pysubmarine/submarine/experiment/api/experiment_client.py
+++ b/submarine-sdk/pysubmarine/submarine/experiment/api/experiment_client.py
@@ -113,14 +113,13 @@ class ExperimentClient:
         response = self.experiment_api.delete_experiment(id)
         return response.result
 
-    def get_log(self, id, master=False):
-        """
-        Get training logs of the experiment.
-        By default only get the logs of Pod that has labels 'job-role: master'.
-        :param master: Get pod with label 'job-role: master' pod if True.
-                    If need to get more Pod Logs, set False.
-        :param id: Experiment ID
-        :return: str: experiment logs
+    def get_log(self, id, onlyMaster=False):
+        """  
+        Get training logs of all pod of the experiment.
+        By default get all the logs of Pod
+        :param id: experiment id
+        :param onlyMaster: By default include pod log of "master" which might be Tensorflow PS/Chief or PyTroch master
+        :return: str: pods logs
         """
         response = self.experiment_api.get_log(id)
         log_contents = response.result['logContent']


### PR DESCRIPTION
### What is this PR for?
Fix get_log error when the experiment is not started
```bash
IndexError                                Traceback (most recent call last)
<ipython-input-13-8bf55eff97d1> in <module>
----> 1 submarine_client.get_log(id)~/opt/anaconda3/envs/python3-7/lib/python3.7/site-packages/submarine/experiment/api/experiment_client.py in get_log(self, id, master)
    124 
    125         if master is True:
--> 126             log_contents = [log_contents[0]]
    127 
    128         for log_content in log_contents:IndexError: list index out of range
```

### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-542

### How should this be tested?
https://travis-ci.org/github/pingsutw/hadoop-submarine/builds/701089803

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
