### PR TITLE
SUBMARINE-540. Link broken in pysubmarine

### DIFF
--- a/docs/submarine-sdk/pysubmarine/README.md
+++ b/docs/submarine-sdk/pysubmarine/README.md
@@ -48,8 +48,8 @@ pytest --cov=submarine -vs
 ```
 
 ## Easy-to-use model trainers
-- [FM](../../../submarine-sdk/pysubmarine/example/deepfm)
-- [DeepFM](../../../submarine-sdk/pysubmarine/example/fm)
+- [FM](../../../submarine-sdk/pysubmarine/example/tensorflow/fm)
+- [DeepFM](../../../submarine-sdk/pysubmarine/example/tensorflow/deepfm)
 
 ## Submarine experiment management
 Makes it easy to run distributed or non-distributed TensorFlow, PyTorch experiments on Kubernetes.


### PR DESCRIPTION
### What is this PR for?
Links are broken in docs/submarine-sdk/pysubmarine/README.md

### What type of PR is it?
[Bug Fix]

### Todos

### What is the Jira issue?
[SUBMARINE-540](https://issues.apache.org/jira/projects/SUBMARINE/issues/SUBMARINE-540)

### How should this be tested?
[passed CI](https://travis-ci.org/github/lowc1012/submarine/builds/701607741)

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
