### PR TITLE
SUBMARINE-547. Incorrect path in deepfm example doc

### DIFF
--- a/submarine-sdk/pysubmarine/example/tensorflow/deepfm/README.md
+++ b/submarine-sdk/pysubmarine/example/tensorflow/deepfm/README.md
@@ -16,12 +16,12 @@ To run the examples here, you need to:
 - Build a Python virtual environment with pysubmarine installed
 - Install Submarine 0.3.0+
 ### Running DeepFM on a local machine
-1. Create a JSON configuration file containing train,valid and test data, model parameters, 
+1. Create a JSON configuration file containing train,valid and test data, model parameters,
 metrics, save model path, resources. e.g. [deepfm.json](./deepfm.json)
 
 2. Install submarine python bindings by setup.py:
 ```
-python ./submarine/submarine-sdk/setup.py install
+python ./submarine/submarine-sdk/pysubmarine/setup.py install
 ```
 2. Train
 ```


### PR DESCRIPTION
### What is this PR for?
Fix the incorrect path in 
https://github.com/apache/submarine/tree/master/submarine-sdk/pysubmarine/example/tensorflow/deepfm

### What type of PR is it?
[Bug Fix]

### Todos

### What is the Jira issue?
[SUBMARINE-547](https://issues.apache.org/jira/projects/SUBMARINE/issues/SUBMARINE-547)

### How should this be tested?
[CI](https://travis-ci.org/github/lowc1012/submarine/builds/702017801)

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
