### PR TITLE
SUBMARINE-541. Running time is null sometimes

### DIFF
--- a/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/util/MLJobConverter.java
+++ b/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/util/MLJobConverter.java
@@ -59,9 +59,7 @@ public class MLJobConverter {
       if (conditions != null && conditions.size() > 1) {
         experiment.setStatus(Experiment.Status.STATUS_RUNNING.getValue());
         for (V1JobCondition condition : conditions) {
-          if (Boolean.parseBoolean(condition.getStatus())
-              && condition.getType().toLowerCase().equals(
-              "running")) {
+          if (condition.getType().toLowerCase().equals("running")) {
             dateTime = condition.getLastTransitionTime();
             experiment.setRunningTime(dateTime.toString());
             break;


### PR DESCRIPTION
### What is this PR for?
The root cause is we could only get the running time when the experiment is running.
So if we try to get an experiment spec when the experiment is Succeeded, the running time would be NULL
Remove the condition `Boolean.parseBoolean(condition.getStatus() == true`

### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-541

### How should this be tested?
https://travis-ci.org/github/pingsutw/hadoop-submarine/builds/704941671

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
