### PR TITLE
SUBMARINE-568. [WEB] Fix a display bug in experiment info page

### DIFF
--- a/submarine-workbench/workbench-web-ng/src/app/pages/workbench/experiment/experiment-info/outputs/outputs.component.scss
+++ b/submarine-workbench/workbench-web-ng/src/app/pages/workbench/experiment/experiment-info/outputs/outputs.component.scss
@@ -18,8 +18,8 @@
  */
 
 #showLogDiv{
-    background-color: gainsboro;
-    color: red;
+    background-color: whitesmoke;
+    color: black;
     padding: 10px;
     height:500px;
     overflow:auto;

--- a/submarine-workbench/workbench-web-ng/src/app/pages/workbench/experiment/experiment.component.ts
+++ b/submarine-workbench/workbench-web-ng/src/app/pages/workbench/experiment/experiment.component.ts
@@ -91,6 +91,8 @@ export class ExperimentComponent implements OnInit {
         }
       }
     });
+
+    this.reloadCheck();
   }
 
   // Getters of experiment request form
@@ -213,6 +215,17 @@ export class ExperimentComponent implements OnInit {
         this.nzMessageService.success(err.message);
       }
     );
+  }
+
+  reloadCheck() {
+    /* 
+      When reload in info page, ths experimentId will turn into undifined, it will cause breadcrumb miss experimentId. 
+      Location.pathname -> /workbench/experiment/info/{experimentID}
+      So slice out experimentId string from location.pathname to reassign experimentId.
+      */
+    if (location.pathname != '/workbench/experiment') {
+      this.experimentID = location.pathname.slice(27);
+    }
   }
 
   // TODO(jasoonn): Filter experiment list

--- a/submarine-workbench/workbench-web-ng/src/app/pages/workbench/experiment/experiment.component.ts
+++ b/submarine-workbench/workbench-web-ng/src/app/pages/workbench/experiment/experiment.component.ts
@@ -224,7 +224,8 @@ export class ExperimentComponent implements OnInit {
       So slice out experimentId string from location.pathname to reassign experimentId.
       */
     if (location.pathname != '/workbench/experiment') {
-      this.experimentID = location.pathname.slice(27);
+      var sliceString = new String('/workbench/experiment/info');
+      this.experimentID = location.pathname.slice(sliceString.length);
     }
   }
 


### PR DESCRIPTION
### What is this PR for?
* Fix problem that when reload experiment info page, the experimentID in breadcrumb will miss.
* Adjustment the presenting of experiment info output page to be more friendly for users.

### What type of PR is it?
[Feature]

### Todos


### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-568

### How should this be tested?
https://travis-ci.org/github/kobe860219/submarine/builds/711355007

### Screenshots (if appropriate)
![螢幕錄製 2020-07-24 下午1](https://user-images.githubusercontent.com/48027290/88363729-8d332200-cdb3-11ea-8c63-bd00e352d890.gif)



### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
