### PR TITLE
SUBMARINE-581. Change submarine-cloud/bin permission

### DIFF
--- a/submarine-cloud/build.sh
+++ b/submarine-cloud/build.sh
@@ -31,5 +31,5 @@ if [[ "${1}"x == "test"x ]]; then
 elif [ "${1}"x == "clean"x ]; then
   rm -rf ./bin
 else
-  docker run --rm -v "$CURRENT_PATH":/go/src/submarine-cloud -w /go/src/submarine-cloud -e GOOS="${GOOS:-darwin}" -e GOARCH="${GOARCH:-amd64}" apache/submarine:build make ${1}
+  docker run --rm -v "$CURRENT_PATH":/go/src/submarine-cloud -w /go/src/submarine-cloud -e GOOS="${GOOS:-darwin}" -e GOARCH="${GOARCH:-amd64}" apache/submarine:build /bin/sh -c "make ${1} && chown -R $(id -u):$(id -g) ./bin"
 fi;


### PR DESCRIPTION
### What is this PR for?
After building the submarine project, `submarine-cloud/bin` will have root privilege
Change the directory permission to the current user and group.

### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-581

### How should this be tested?
https://travis-ci.org/github/pingsutw/hadoop-submarine/builds/711959054

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
