### PR TITLE
SUBMARINE-588. [SDK] Fix checkstyle error in core.py

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -18,6 +18,7 @@ jobs:
       - uses: actions/checkout@v1
       - name: Verify MySQL connection from host
         run: |
+          sudo apt update
           sudo apt-get install -y mysql-client
           sudo service mysql restart
           # default mysql account and password in github actions

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -34,6 +34,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
+          pip install --upgrade pip
           pip install ./submarine-sdk/pysubmarine/.
           pip install -q tensorflow==${{ matrix.tf-version }}
           pip install -r ./submarine-sdk/pysubmarine/github-actions/test-requirements.txt

--- a/submarine-sdk/pysubmarine/setup.py
+++ b/submarine-sdk/pysubmarine/setup.py
@@ -39,7 +39,7 @@ setup(
         'certifi >= 14.05.14',
         'python-dateutil >= 2.5.3',
         'pyarrow==0.17.0',
-        'torch',
+        'torch>=1.4.0',
     ],
     classifiers=[
         'Intended Audience :: Developers',

--- a/submarine-sdk/pysubmarine/submarine/ml/pytorch/layers/core.py
+++ b/submarine-sdk/pysubmarine/submarine/ml/pytorch/layers/core.py
@@ -17,6 +17,7 @@ import torch
 from torch import nn
 
 
+# pylint: disable=W0223
 class FeatureLinear(nn.Module):
 
     def __init__(self, num_features, out_features):

--- a/submarine-sdk/pysubmarine/submarine/ml/pytorch/model/ctr/afm.py
+++ b/submarine-sdk/pysubmarine/submarine/ml/pytorch/model/ctr/afm.py
@@ -27,6 +27,7 @@ class AFM(BasePyTorchModel):
         return _AFM(**self.params['model']['kwargs'])
 
 
+# pylint: disable=W0223
 class _AFM(nn.Module):
 
     def __init__(self, num_features: int, embedding_dim: int,

--- a/submarine-sdk/pysubmarine/submarine/ml/pytorch/model/ctr/deepfm.py
+++ b/submarine-sdk/pysubmarine/submarine/ml/pytorch/model/ctr/deepfm.py
@@ -29,6 +29,7 @@ class DeepFM(BasePyTorchModel):
         return _DeepFM(**self.params['model']['kwargs'])
 
 
+# pylint: disable=W0223
 class _DeepFM(nn.Module):
 
     def __init__(self, num_fields, num_features, embedding_dim, out_features,


### PR DESCRIPTION
### What is this PR for?
Fix checkstyle error in submarine/ml/pytorch/model/ctr/
https://github.com/apache/submarine/runs/923503735
```bash
Run ./submarine-sdk/pysubmarine/github-actions/lint.sh
+++ dirname ./submarine-sdk/pysubmarine/github-actions/lint.sh
++ cd ./submarine-sdk/pysubmarine/github-actions
++ pwd
+ FWDIR=/home/runner/work/submarine/submarine/submarine-sdk/pysubmarine/github-actions
+ cd /home/runner/work/submarine/submarine/submarine-sdk/pysubmarine/github-actions
+ cd ..
+ pycodestyle --max-line-length=100 -- submarine tests
+ pylint --ignore experiment '--msg-template={path} ({line},{column}): [{msg_id} {symbol}] {msg}' --rcfile=pylintrc -- submarine tests
************* Module submarine.ml.pytorch.model.ctr.afm
submarine/ml/pytorch/model/ctr/afm.py (30,0): [W0223 abstract-method] Method '_forward_unimplemented' is abstract in class 'Module' but is not overridden
submarine/ml/pytorch/model/ctr/afm.py (57,0): [W0223 abstract-method] Method '_forward_unimplemented' is abstract in class 'Module' but is not overridden
submarine/ml/pytorch/model/ctr/afm.py (81,0): [W0223 abstract-method] Method '_forward_unimplemented' is abstract in class 'Module' but is not overridden
************* Module submarine.ml.pytorch.model.ctr.deepfm
submarine/ml/pytorch/model/ctr/deepfm.py (32,0): [W0223 abstract-method] Method '_forward_unimplemented' is abstract in class 'Module' but is not overridden
************* Module submarine.ml.pytorch.layers.core
submarine/ml/pytorch/layers/core.py (20,0): [W0223 abstract-method] Method '_forward_unimplemented' is abstract in class 'Module' but is not overridden
submarine/ml/pytorch/layers/core.py (42,0): [W0223 abstract-method] Method '_forward_unimplemented' is abstract in class 'Module' but is not overridden
submarine/ml/pytorch/layers/core.py (57,0): [W0223 abstract-method] Method '_forward_unimplemented' is abstract in class 'Module' but is not overridden
submarine/ml/pytorch/layers/core.py (72,0): [W0223 abstract-method] Method '_forward_unimplemented' is abstract in class 'Module' but is not overridden
```

### What type of PR is it?
[Hot Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-588

### How should this be tested?
https://travis-ci.org/github/pingsutw/hadoop-submarine/builds/712952549

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
