### PR TITLE
SUBMARINE-589. Update the version of virtualenv in CICD docker file

### DIFF
--- a/dev-support/cicd/Dockerfile
+++ b/dev-support/cicd/Dockerfile
@@ -19,9 +19,9 @@ RUN \
   apt-get install -y wget vim git python-pip zlib1g-dev libssl-dev && \
   wget https://www.python.org/ftp/python/2.7.13/Python-2.7.13.tgz && \
   tar xzf Python-2.7.13.tgz && cd Python-2.7.13 && ./configure --with-zlib && make install && make altinstall && \
-  cd /root && wget https://files.pythonhosted.org/packages/33/bc/fa0b5347139cd9564f0d44ebd2b147ac97c36b2403943dbee8a25fd74012/virtualenv-16.0.0.tar.gz && \
-  tar xf virtualenv-16.0.0.tar.gz && \
-  python virtualenv-16.0.0/virtualenv.py venv2.7 && \
+  cd /root && wget https://files.pythonhosted.org/packages/59/38/55dd25a965990bd93f77eb765b189e72cf581ce1c2de651cb7b1dea74ed1/virtualenv-16.2.0.tar.gz && \
+  tar xf virtualenv-16.2.0.tar.gz && \
+  python virtualenv-16.2.0/virtualenv.py venv2.7 && \
   . venv2.7/bin/activate && \
   pip install jira && \
   deactivate


### PR DESCRIPTION
### What is this PR for?
Run the `build_and_start_cicd_image.sh` got the error : `/root/venv2.7/bin/activate: line 57: PS1: unbound variable` and I found it was fixed in https://github.com/pypa/virtualenv/pull/922 ,  which was included in the 16.2 milestone.


### What type of PR is it?
[Bug Fix]

### Todos

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-589

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
