### PR TITLE
SUBMARINE-595. reduce duplicate definitionsreduce duplicate definitions

### DIFF
--- a/submarine-client/src/main/java/org/apache/submarine/client/cli/Cli.java
+++ b/submarine-client/src/main/java/org/apache/submarine/client/cli/Cli.java
@@ -54,8 +54,6 @@ public class Cli {
           SUBMARINE_SERVER_RPC_ENABLED)) {
       runtimeFactory = new RpcRuntimeFactory(clientContext);
     } else {
-      Configuration conf = new YarnConfiguration();
-      clientContext.setYarnConfig(conf);
       runtimeFactory = RuntimeFactory.getRuntimeFactory(clientContext,
           Thread.currentThread().getContextClassLoader());
     }


### PR DESCRIPTION
### What is this PR for?
reduce duplicate definitions of object in submarine-client, such as:

```java
public class ClientContext {
  private Configuration yarnConf = new YarnConfiguration();
```
yarnConf object has been definitions whe we Instantiate ClientContext .

```java
 if (clientContext.getSubmarineConfig().getBoolean(
        SubmarineConfVars.ConfVars.
          SUBMARINE_SERVER_RPC_ENABLED)) {
      runtimeFactory = new RpcRuntimeFactory(clientContext);
    } else {
      Configuration conf = new YarnConfiguration();
      clientContext.setYarnConfig(conf);
      runtimeFactory = RuntimeFactory.getRuntimeFactory(clientContext,
          Thread.currentThread().getContextClassLoader());
    }
```
it has duplicate definitions, i think it should be remove.

### What type of PR is it?
[Refactoring]

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-595

### How should this be tested?


### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? Yes/No
* Is there breaking changes for older versions? Yes/No
* Does this needs documentation? Yes/No
