### PR TITLE
SUBMARINE-615. Fix Submarine interpreter test failure

### DIFF
--- a/dev-support/travis/install_external_dependencies.sh
+++ b/dev-support/travis/install_external_dependencies.sh
@@ -17,12 +17,12 @@
 #
 
 # Script for installing R / Python dependencies for Travis CI
-set -evuo pipefail
+set -exvuo pipefail
 touch ~/.environ
 
 # Install Python dependencies for Python specific tests
 if [[ -n "${PYTHON:-}" ]] ; then
-  wget https://repo.continuum.io/miniconda/Miniconda${PYTHON}-4.2.12-Linux-x86_64.sh -O miniconda.sh
+  wget https://repo.continuum.io/miniconda/Miniconda${PYTHON}-4.5.4-Linux-x86_64.sh -O miniconda.sh
   bash miniconda.sh -b -p $HOME/miniconda
   echo "export PATH='$HOME/miniconda/bin:$PATH'" >> ~/.environ
   source ~/.environ
@@ -33,13 +33,13 @@ if [[ -n "${PYTHON:-}" ]] ; then
   conda info -a
   conda config --add channels conda-forge
 
-  conda install -q numpy=1.13.3 pandas=0.21.1 matplotlib=2.1.1 pandasql=0.7.3 ipython=5.4.1 jupyter_client=5.1.0 ipykernel=4.7.0 bokeh=0.12.10
-  pip install -q scipy==0.18.0 ggplot==0.11.5 grpcio==1.8.2 bkzep==0.4.0
+  conda install numpy=1.13.3 pandas=0.21.1 matplotlib=2.1.1 pandasql=0.7.3 ipython=5.4.1 jupyter_client=5.1.0 ipykernel=4.7.0 bokeh=0.12.10
+  pip install scipy==1.5.2 ggplot==0.11.5 grpcio==1.8.2 bkzep==0.4.0
 
   if [[ -n "${TENSORFLOW:-}" ]] ; then
     check_results=`conda search -c conda-forge tensorflow`
     echo "search tensorflow = $check_results"
 
-    pip install tensorflow==${TENSORFLOW}
+    pip install tensorflow=="${TENSORFLOW}"
   fi
 fi


### PR DESCRIPTION
### What is this PR for?
Fix Submarine interpreter test failure
- update miniconda to python3.6, https://stackoverflow.com/questions/54628161/which-version-of-miniconda-has-python-3-6-for-windows-64-bit
- update scipy 
- print the commands from `dev-support/travis/install_external_dependencies.sh`, so that we could know which line of command was failed. 


### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-615

### How should this be tested?
https://travis-ci.org/github/pingsutw/hadoop-submarine/builds/723373637

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
