### PR TITLE
SUBMARINE-597. Support for SSH based git sync mode

### DIFF
--- a/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/experiment/codelocalizer/GitCodeLocalizer.java
+++ b/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/experiment/codelocalizer/GitCodeLocalizer.java
@@ -86,7 +86,6 @@ public abstract class GitCodeLocalizer extends AbstractCodeLocalizer {
       throws InvalidSpecException {
 
     try {
-      
       URI uriParser = new URI(url);
       String scheme = uriParser.getScheme();
       if (scheme.equals(GitCodeLocalizerModes.HTTP.getMode())) {

--- a/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/experiment/codelocalizer/GitCodeLocalizer.java
+++ b/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/experiment/codelocalizer/GitCodeLocalizer.java
@@ -19,8 +19,8 @@
 
 package org.apache.submarine.server.submitter.k8s.experiment.codelocalizer;
 
-import java.net.MalformedURLException;
-import java.net.URL;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -86,16 +86,17 @@ public abstract class GitCodeLocalizer extends AbstractCodeLocalizer {
       throws InvalidSpecException {
 
     try {
-      URL urlParser = new URL(url);
-      String protocol = urlParser.getProtocol();
-      if (protocol.equals(GitCodeLocalizerModes.HTTP.getMode())) {
+      
+      URI uriParser = new URI(url);
+      String scheme = uriParser.getScheme();
+      if (scheme.equals(GitCodeLocalizerModes.HTTP.getMode())) {
         return new HTTPGitCodeLocalizer(url);
-      } else if (protocol.equals(GitCodeLocalizerModes.SSH.getMode())) {
+      } else if (scheme.equals(GitCodeLocalizerModes.SSH.getMode())) {
         return new SSHGitCodeLocalizer(url);
       } else {
         return new DummyCodeLocalizer(url);
       }
-    } catch (MalformedURLException e) {
+    } catch (URISyntaxException e) {
       throw new InvalidSpecException(
           "Invalid Code Spec: URL is malformed. " + url);
     }

--- a/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/experiment/codelocalizer/SSHGitCodeLocalizer.java
+++ b/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/experiment/codelocalizer/SSHGitCodeLocalizer.java
@@ -33,7 +33,9 @@ public class SSHGitCodeLocalizer extends GitCodeLocalizer {
   public static final int GIT_SECRET_MODE = 0400;
   public static final String GIT_SECRET_MOUNT_NAME = "git-secret";
   public static final String GIT_SECRET_PATH = "/etc/git-secret";
-  public static final Long GIT_SYNC_USER = new Long(65533);
+  public static final long GIT_SYNC_USER = 65533L;
+  public static final String GIT_SYNC_SSH_NAME = "GIT_SYNC_SSH";
+  public static final String GIT_SYNC_SSH_VALUE = "true";
   
   public SSHGitCodeLocalizer(String url) {
     super(url);
@@ -46,8 +48,8 @@ public class SSHGitCodeLocalizer extends GitCodeLocalizer {
       if (container.getName().equals(CODE_LOCALIZER_INIT_CONTAINER_NAME)) {
         List<V1EnvVar> gitSyncEnvVars = container.getEnv();
         V1EnvVar sshEnv = new V1EnvVar();
-        sshEnv.setName("GIT_SYNC_SSH");
-        sshEnv.setValue("true");
+        sshEnv.setName(GIT_SYNC_SSH_NAME);
+        sshEnv.setValue(GIT_SYNC_SSH_VALUE);
         gitSyncEnvVars.add(sshEnv);
         
         List<V1VolumeMount> mounts = container.getVolumeMounts();

--- a/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/experiment/codelocalizer/SSHGitCodeLocalizer.java
+++ b/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/experiment/codelocalizer/SSHGitCodeLocalizer.java
@@ -62,7 +62,7 @@ public class SSHGitCodeLocalizer extends GitCodeLocalizer {
         containerSecurityContext
             .setRunAsUser(SSHGitCodeLocalizer.GIT_SYNC_USER);
         container.setSecurityContext(containerSecurityContext);
-       }
+      }
     }
   }
 }

--- a/submarine-server/server-submitter/submitter-k8s/src/test/java/org/apache/submarine/server/submitter/k8s/ExperimentSpecParserTest.java
+++ b/submarine-server/server-submitter/submitter-k8s/src/test/java/org/apache/submarine/server/submitter/k8s/ExperimentSpecParserTest.java
@@ -46,6 +46,7 @@ import org.apache.submarine.server.submitter.k8s.model.tfjob.TFJobReplicaType;
 import org.apache.submarine.server.submitter.k8s.parser.ExperimentSpecParser;
 import org.apache.submarine.server.submitter.k8s.experiment.codelocalizer.AbstractCodeLocalizer;
 import org.apache.submarine.server.submitter.k8s.experiment.codelocalizer.GitCodeLocalizer;
+import org.apache.submarine.server.submitter.k8s.experiment.codelocalizer.SSHGitCodeLocalizer;
 import org.junit.Assert;
 import org.junit.Test;
 import io.kubernetes.client.models.V1Container;
@@ -335,8 +336,9 @@ public class ExperimentSpecParserTest extends SpecBuilder {
     Assert.assertEquals(AbstractCodeLocalizer.CODE_LOCALIZER_PATH,
         initContainer.getVolumeMounts().get(0).getMountPath());
     for (V1EnvVar env : initContainer.getEnv()) {
-      if (env.getName().equals("GIT_SYNC_SSH")) {
-        Assert.assertEquals("true", env.getValue());
+      if (env.getName().equals(SSHGitCodeLocalizer.GIT_SYNC_SSH_NAME)) {
+        Assert.assertEquals(SSHGitCodeLocalizer.GIT_SYNC_SSH_VALUE,
+            env.getValue());
       }
     }
 

--- a/submarine-server/server-submitter/submitter-k8s/src/test/java/org/apache/submarine/server/submitter/k8s/ExperimentSpecParserTest.java
+++ b/submarine-server/server-submitter/submitter-k8s/src/test/java/org/apache/submarine/server/submitter/k8s/ExperimentSpecParserTest.java
@@ -310,4 +310,54 @@ public class ExperimentSpecParserTest extends SpecBuilder {
     Assert.assertEquals(AbstractCodeLocalizer.CODE_LOCALIZER_MOUNT_NAME,
         V1Volume.getName());
   }
+  
+  @Test
+  public void testValidPyTorchJobSpecWithSSHGitCodeLocalizer()
+      throws IOException, URISyntaxException, InvalidSpecException {
+    ExperimentSpec jobSpec =
+        (ExperimentSpec) buildFromJsonFile(ExperimentSpec.class,
+            pytorchJobWithSSHGitCodeLocalizerFile);
+    PyTorchJob pyTorchJob = (PyTorchJob) ExperimentSpecParser.parseJob(jobSpec);
+
+    MLJobReplicaSpec mlJobReplicaSpec = pyTorchJob.getSpec().getReplicaSpecs()
+        .get(PyTorchJobReplicaType.Master);
+    Assert.assertEquals(1,
+        mlJobReplicaSpec.getTemplate().getSpec().getInitContainers().size());
+    V1Container initContainer =
+        mlJobReplicaSpec.getTemplate().getSpec().getInitContainers().get(0);
+    Assert.assertEquals(
+        AbstractCodeLocalizer.CODE_LOCALIZER_INIT_CONTAINER_NAME,
+        initContainer.getName());
+    Assert.assertEquals(GitCodeLocalizer.GIT_SYNC_IMAGE,
+        initContainer.getImage());
+    Assert.assertEquals(AbstractCodeLocalizer.CODE_LOCALIZER_MOUNT_NAME,
+        initContainer.getVolumeMounts().get(0).getName());
+    Assert.assertEquals(AbstractCodeLocalizer.CODE_LOCALIZER_PATH,
+        initContainer.getVolumeMounts().get(0).getMountPath());
+    for (V1EnvVar env : initContainer.getEnv()) {
+      if (env.getName().equals("GIT_SYNC_SSH")) {
+        Assert.assertEquals("true", env.getValue());
+      }
+    }
+
+    V1Container container =
+        mlJobReplicaSpec.getTemplate().getSpec().getInitContainers().get(0);
+    Assert.assertEquals(AbstractCodeLocalizer.CODE_LOCALIZER_MOUNT_NAME,
+        container.getVolumeMounts().get(0).getName());
+    Assert.assertEquals(AbstractCodeLocalizer.CODE_LOCALIZER_PATH,
+        container.getVolumeMounts().get(0).getMountPath());
+    for (V1EnvVar env : container.getEnv()) {
+      if (env.getName()
+          .equals(AbstractCodeLocalizer.CODE_LOCALIZER_PATH_ENV_VAR)) {
+        Assert.assertEquals(AbstractCodeLocalizer.CODE_LOCALIZER_PATH,
+            env.getValue());
+      }
+    }
+
+    V1Volume V1Volume =
+        mlJobReplicaSpec.getTemplate().getSpec().getVolumes().get(0);
+    Assert.assertEquals(new V1EmptyDirVolumeSource(), V1Volume.getEmptyDir());
+    Assert.assertEquals(AbstractCodeLocalizer.CODE_LOCALIZER_MOUNT_NAME,
+        V1Volume.getName());
+  }
 }

--- a/submarine-server/server-submitter/submitter-k8s/src/test/java/org/apache/submarine/server/submitter/k8s/SpecBuilder.java
+++ b/submarine-server/server-submitter/submitter-k8s/src/test/java/org/apache/submarine/server/submitter/k8s/SpecBuilder.java
@@ -42,6 +42,8 @@ public abstract class SpecBuilder {
   protected final String notebookReqFile = "/notebook_req.json";
   protected final String pytorchJobWithHTTPGitCodeLocalizerFile =
       "/pytorch_job_req_http_git_code_localizer.json";
+  protected final String pytorchJobWithSSHGitCodeLocalizerFile =
+      "/pytorch_job_req_ssh_git_code_localizer.json";
 
   protected Object buildFromJsonFile(Object obj, String filePath) throws IOException,
       URISyntaxException {

--- a/submarine-server/server-submitter/submitter-k8s/src/test/resources/pytorch_job_req_ssh_git_code_localizer.json
+++ b/submarine-server/server-submitter/submitter-k8s/src/test/resources/pytorch_job_req_ssh_git_code_localizer.json
@@ -1,0 +1,30 @@
+{
+  "meta": {
+    "name": "pytorch-dist-mnist",
+    "namespace": "submarine",
+    "framework": "PyTorch",
+    "cmd": "python /var/mnist.py --backend gloo",
+    "envVars": {
+      "ENV_1": "ENV1"
+    }
+  },
+  "environment": {
+    "image": "apache/submarine:pytorch-dist-mnist-1.0"
+  },
+  "spec": {
+    "Master": {
+      "name": "master",
+      "replicas": 1,
+      "resources": "cpu=2,memory=2048M"
+    },
+    "Worker": {
+      "name": "worker",
+      "replicas": 2,
+      "resources": "cpu=1,memory=1024M"
+    }
+  },
+  "code": {
+    "syncMode": "git",
+    "url" : "ssh://git@github.com/apache/submarine.git"
+  }
+}

--- a/submarine-test/test-k8s/src/test/java/org/apache/submarine/rest/ExperimentRestApiIT.java
+++ b/submarine-test/test-k8s/src/test/java/org/apache/submarine/rest/ExperimentRestApiIT.java
@@ -180,6 +180,13 @@ public class ExperimentRestApiIT extends AbstractSubmarineServerTest {
     run(body, patchBody, "application/json");
   }
 
+  @Test
+  public void testTensorFlowUsingSSHCodeWithJsonSpec() throws Exception {
+    String body = loadContent("tensorflow/tf-mnist-with-ssh-git-code-localizer-req.json");
+    String patchBody = loadContent("tensorflow/tf-mnist-with-ssh-git-code-localizer-req.json");
+    run(body, patchBody, "application/json");
+  }
+  
   private void run(String body, String patchBody, String contentType) throws Exception {
     // create
     LOG.info("Create training job by Job REST API");

--- a/submarine-test/test-k8s/src/test/resources/tensorflow/tf-mnist-with-ssh-git-code-localizer-req.json
+++ b/submarine-test/test-k8s/src/test/resources/tensorflow/tf-mnist-with-ssh-git-code-localizer-req.json
@@ -1,0 +1,28 @@
+{
+  "meta": {
+    "name": "tf-mnist-json",
+    "namespace": "default",
+    "framework": "TensorFlow",
+    "cmd": "python /var/tf_mnist/mnist_with_summaries.py --log_dir=/train/log --learning_rate=0.01 --batch_size=150",
+    "envVars": {
+      "ENV_1": "ENV1"
+    }
+  },
+  "environment": {
+  	"image": "gcr.io/kubeflow-ci/tf-mnist-with-summaries:1.0"
+  },
+  "spec": {
+    "Ps": {
+      "replicas": 1,
+      "resources": "cpu=1,memory=512M"
+    },
+    "Worker": {
+      "replicas": 1,
+      "resources": "cpu=1,memory=512M"
+    }
+  },
+  "code": {
+    "syncMode": "git",
+    "url" : "ssh://git@github.com/apache/submarine.git"
+  }
+}


### PR DESCRIPTION
### What is this PR for?
Clone the source code from git repository using SSH based access. /code dir is the location to store the source code. SSH based access requires SSH host private key and known hosts to be passed through /etc/secret to K8 git sync init container process.

### What type of PR is it?
Improvement 

### Todos
* [ ] - Task


### How should this be tested?
* First time? Setup Travis CI as described on https://submarine.apache.org/contribution/contributions.html#continuous-integration
* Strongly recommended: add automated unit tests for any new or changed behavior
* Outline any manual steps to test the PR here.

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? Yes/No
* Is there breaking changes for older versions? Yes/No
* Does this needs documentation? Yes/No
