### PR TITLE
SUBMARINE-612. Environment variable not found in jupyter pod

### DIFF
--- a/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/parser/NotebookSpecParser.java
+++ b/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/parser/NotebookSpecParser.java
@@ -78,7 +78,7 @@ public class NotebookSpecParser {
     container.setName(notebookSpec.getMeta().getName());
 
     // Environment variables
-    if (notebookPodSpec.getEnvVars() == null) {
+    if (notebookPodSpec.getEnvVars() != null) {
       container.setEnv(parseEnvVars(notebookPodSpec));
     }
 


### PR DESCRIPTION
### What is this PR for?
submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/parser/NotebookSpecParser.java#L81

it should be " if (notebookPodSpec.getEnvVars() != null)"

### What type of PR is it?
[Bug Fix]

### Todos

### What is the Jira issue?
[SUBMARINE-612](https://issues.apache.org/jira/projects/SUBMARINE/issues/SUBMARINE-612)

### How should this be tested?
[travis ci](https://travis-ci.org/github/lowc1012/submarine/builds/723505973)

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
