### PR TITLE
SUBMARINE-618. Create/Delete IngressRoute with Notebook CR

### DIFF
--- a/helm-charts/submarine/templates/rbac.yaml
+++ b/helm-charts/submarine/templates/rbac.yaml
@@ -38,6 +38,19 @@ rules:
   - deletecollection
   - patch
   - update
+- apiGroups:
+  - traefik.containo.us
+  resources:
+  - ingressroutes
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
 
 ---
 kind: ClusterRoleBinding

--- a/submarine-cloud/manifests/submarine-cluster/rbac.yaml
+++ b/submarine-cloud/manifests/submarine-cluster/rbac.yaml
@@ -35,6 +35,10 @@ items:
           - pytorchjobs
           - notebooks
         verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+      - apiGroups: ["traefik.containo.us"]
+        resources:
+          - ingressroutes
+        verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
   - apiVersion: rbac.authorization.k8s.io/v1beta1
     kind: ClusterRoleBinding
     metadata:

--- a/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/model/ingressroute/IngressRoute.java
+++ b/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/model/ingressroute/IngressRoute.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.submarine.server.submitter.k8s.model.ingressroute;
+
+import com.google.gson.annotations.SerializedName;
+import io.kubernetes.client.models.V1ObjectMeta;
+
+public class IngressRoute {
+  public static final String CRD_INGRESSROUTE_GROUP_V1 = "traefik.containo.us";
+  public static final String CRD_INGRESSROUTE_VERSION_V1 = "v1alpha1";
+  public static final String CRD_APIVERSION_V1 = CRD_INGRESSROUTE_GROUP_V1 +
+          "/" + CRD_INGRESSROUTE_VERSION_V1;
+  public static final String CRD_INGRESSROUTE_KIND_V1 = "IngressRoute";
+  public static final String CRD_INGRESSROUTE_PLURAL_V1 = "ingressroutes";
+
+  @SerializedName("apiVersion")
+  private String apiVersion;
+
+  @SerializedName("kind")
+  private String kind;
+
+  @SerializedName("metadata")
+  private V1ObjectMeta metadata;
+
+  private transient String group;
+
+  private transient String version;
+
+  private transient String plural;
+
+  @SerializedName("spec")
+  private IngressRouteSpec spec;
+
+  public IngressRoute() {
+    setApiVersion(CRD_APIVERSION_V1);
+    setKind(CRD_INGRESSROUTE_KIND_V1);
+    setPlural(CRD_INGRESSROUTE_PLURAL_V1);
+    setGroup(CRD_INGRESSROUTE_GROUP_V1);
+    setVersion(CRD_INGRESSROUTE_VERSION_V1);
+  }
+
+  public String getApiVersion() {
+    return apiVersion;
+  }
+
+  public void setApiVersion(String apiVersion) {
+    this.apiVersion = apiVersion;
+  }
+
+  public String getKind() {
+    return kind;
+  }
+
+  public void setKind(String kind) {
+    this.kind = kind;
+  }
+
+  public V1ObjectMeta getMetadata() {
+    return metadata;
+  }
+
+  public void setMetadata(V1ObjectMeta metadata) {
+    this.metadata = metadata;
+  }
+
+  public String getPlural() {
+    return plural;
+  }
+
+  public void setPlural(String plural) {
+    this.plural = plural;
+  }
+
+  public String getGroup() {
+    return group;
+  }
+
+  public void setGroup(String group) {
+    this.group = group;
+  }
+
+  public String getVersion() {
+    return version;
+  }
+
+  public void setVersion(String version) {
+    this.version = version;
+  }
+
+  public IngressRouteSpec getSpec() {
+    return spec;
+  }
+
+  public void setSpec(IngressRouteSpec spec) {
+    this.spec = spec;
+  }
+}

--- a/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/model/ingressroute/IngressRouteSpec.java
+++ b/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/model/ingressroute/IngressRouteSpec.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.submarine.server.submitter.k8s.model.ingressroute;
+
+import com.google.gson.annotations.SerializedName;
+
+import java.util.Set;
+
+public class IngressRouteSpec {
+
+  public IngressRouteSpec() {
+
+  }
+
+  @SerializedName("entryPoints")
+  private Set<String> entryPoints;
+
+  @SerializedName("routes")
+  private Set<SpecRoute> routes;
+
+  public Set<String> getEntryPoints() {
+    return entryPoints;
+  }
+
+  public void setEntryPoints(Set<String> entryPoints) {
+    this.entryPoints = entryPoints;
+  }
+
+  public Set<SpecRoute> getRoutes() {
+    return routes;
+  }
+
+  public void setRoutes(Set<SpecRoute> routes) {
+    this.routes = routes;
+  }
+
+}

--- a/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/model/ingressroute/SpecRoute.java
+++ b/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/model/ingressroute/SpecRoute.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.submarine.server.submitter.k8s.model.ingressroute;
+
+import com.google.gson.annotations.SerializedName;
+
+import java.util.Map;
+import java.util.Set;
+
+public class SpecRoute {
+
+  public SpecRoute() {
+
+  }
+
+  @SerializedName("match")
+  private String match;
+
+  @SerializedName("kind")
+  private String kind;
+
+  @SerializedName("services")
+  private Set<Map<String, Object>> services;
+
+  public String getMatch() {
+    return match;
+  }
+
+  public void setMatch(String match) {
+    this.match = match;
+  }
+
+  public String getKind() {
+    return kind;
+  }
+
+  public void setKind(String kind) {
+    this.kind = kind;
+  }
+
+  public Set<Map<String, Object>> getServices() {
+    return services;
+  }
+
+  public void setServices(Set<Map<String, Object>> services) {
+    this.services = services;
+  }
+}

--- a/submarine-workbench/workbench-web-ng/src/app/pages/workbench/notebook/notebook.component.html
+++ b/submarine-workbench/workbench-web-ng/src/app/pages/workbench/notebook/notebook.component.html
@@ -78,7 +78,7 @@
         <tbody>
           <tr *ngFor="let data of basicTable.data; let i = index">
             <td>
-              <a>{{ data.name }}</a>
+              <a href="{{ data.url }}" target="_blank">{{ data.name }}</a>
             </td>
             <td>{{ data.spec.environment.name }}</td>
             <td>{{ data.spec.environment.dockerImage }}</td>


### PR DESCRIPTION
### What is this PR for?
Traefik uses CRD (IngressRoute) to retrieve its routing configuration. 
In order to route the traffic to jupyter notebooks, we should add routing rules by creating a IngressRoute witch pair with notebook's service. 

### What type of PR is it?
[Improvement]

### Todos
* [ ] - Task

### What is the Jira issue?
[SUBMARINE-618](https://issues.apache.org/jira/projects/SUBMARINE/issues/SUBMARINE-618)

### How should this be tested?
[Travis CI](https://travis-ci.org/github/lowc1012/submarine/builds/727777761)

### Screenshots (if appropriate)
![img1](https://user-images.githubusercontent.com/52355146/93370999-382bfd80-f884-11ea-88c1-216012475cad.png)
<img width="613" alt="img2"https://user-images.githubusercontent.com/52355146/93371062-50038180-f884-11ea-99ff-e90f426e8941.png">
<img width="612" alt="img3" src="https://user-images.githubusercontent.com/52355146/93371068-53970880-f884-11ea-927d-7aeb86e4591b.png">


### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
