### PR TITLE
SUBMARINE-627. Can't find the new environment when it named "my-submarine-env"

### DIFF
--- a/docs/database/submarine-data.sql
+++ b/docs/database/submarine-data.sql
@@ -84,7 +84,7 @@ INSERT INTO `params` (`id`, `key`, `value`, `worker_index`) VALUES
 -- ----------------------------
 -- Records of environment
 -- ----------------------------
-INSERT INTO `environment` VALUES ('environment_1595134205164_0002', 'my-submarine-test-env','{"name":"my-submarine-env","dockerImage":"continuumio/anaconda3","kernelSpec":{"name":"team_default_python_3.7","channels":["defaults"],"dependencies":["_ipyw_jlab_nb_ext_conf=0.1.0=py37_0","alabaster=0.7.12=py37_0","anaconda=2020.02=py37_0","anaconda-client=1.7.2=py37_0","anaconda-navigator=1.9.12=py37_0"]}}','admin', '2020-05-06 14:00:05', 'Jack', '2020-05-06 14:00:14');
+INSERT INTO `environment` VALUES ('environment_1595134205164_0002', 'my-submarine-test-env','{"name":"my-submarine-test-env","dockerImage":"continuumio/anaconda3","kernelSpec":{"name":"team_default_python_3.7","channels":["defaults"],"dependencies":["_ipyw_jlab_nb_ext_conf=0.1.0=py37_0","alabaster=0.7.12=py37_0","anaconda=2020.02=py37_0","anaconda-client=1.7.2=py37_0","anaconda-navigator=1.9.12=py37_0"]}}','admin', '2020-05-06 14:00:05', 'Jack', '2020-05-06 14:00:14');
 
 -- ----------------------------
 -- Records of experiment_templates


### PR DESCRIPTION
### What is this PR for?
https://github.com/apache/submarine/blob/master/docs/database/submarine-data.sql
There is an environment with "my-submarine-test-env" environment name and "my-submarine-env" environmentSpec name inserted by submarine-data.sql, which result that the new environment named "my-submarine-env" will be created successfully but can not be found by API.

### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/projects/SUBMARINE/issues/SUBMARINE-627

### How should this be tested?
* First time? Setup Travis CI as described on https://submarine.apache.org/contribution/contributions.html#continuous-integration
* Strongly recommended: add automated unit tests for any new or changed behavior
* Outline any manual steps to test the PR here.

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
