### PR TITLE
SUBMARINE-642. Install latest python sdk in notebook

### DIFF
--- a/dev-support/docker-images/jupyter/Dockerfile
+++ b/dev-support/docker-images/jupyter/Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -yq --no-in
     build-essential \
     curl \
     wget \
-    vim \
+    git \
     bzip2 \
     ca-certificates \
     sudo \
@@ -91,8 +91,13 @@ RUN wget --quiet https://repo.continuum.io/miniconda/Miniconda3-py37_${MINICONDA
     conda clean --all -f -y && \
     rm -rf /home/$NB_USER/.cache/yarn
 
-# Install sumbarine python sdk and notebook
-RUN pip --quiet --no-cache-dir install notebook==6.1.3 apache-submarine
+# Install latest sumbarine python sdk and notebook
+RUN pip install notebook==6.1.3 && \
+    git clone https://github.com/apache/submarine && \
+    pip install submarine/submarine-sdk/pysubmarine && \
+    rm submarine -rf
+
+
 
 EXPOSE $NB_PORT
 ENTRYPOINT ["tini", "-g", "--"]


### PR DESCRIPTION
### What is this PR for?
https://github.com/apache/submarine/blob/b2d3eed82b678c3243079fc25e6b47d44c28c841/dev-support/docker-images/jupyter/Dockerfile#L95

Instead of install a stable version of pysubmarine, we should Install the latest pysubmarine in docker file, so that every time we manually build apache/submarine:jupyter-notebook-0.x.0-SNAPSHOT, we could use the latest version of pysubmarine 


### What type of PR is it?
[Improvement]

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/projects/SUBMARINE/issues/SUBMARINE-642

### How should this be tested?
https://travis-ci.org/github/pingsutw/hadoop-submarine/builds/731157706

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
