### PR TITLE
SUBMARINE-652. Autoformat staged files before committing

### DIFF
--- a/submarine-workbench/workbench-web-ng/README.md
+++ b/submarine-workbench/workbench-web-ng/README.md
@@ -32,6 +32,12 @@ Run `ng e2e` to execute the end-to-end tests via [Protractor](http://www.protrac
 
 If you want to add end-to-end test cases, please click [here](./e2e/README.md) for reference.
 
+## Formatting the code
+There are two ways to format the code.
+
+1. Install node/npm **globally** to enable husky. If you commit the code, it will trigger pre-commit hook and auto-format your code.
+2. If you do not install node/npm globally, it will not trigger pre-commit hook. However, you can run `npm autoformat` to format your code manually.
+
 ## Further help
 
 To get more help on the Angular CLI use `ng help` or go check out the [Angular CLI README](https://github.com/angular/angular-cli/blob/master/README.md).

--- a/submarine-workbench/workbench-web-ng/package.json
+++ b/submarine-workbench/workbench-web-ng/package.json
@@ -9,7 +9,7 @@
     "test": "ng test",
     "lint": "ng lint",
     "e2e": "ng e2e",
-    "autoformat": "prettier --write --trailing-comma none --single-quote 'src/**/*.{js,json,ts,html}'",
+    "autoformat": "prettier --config .prettierrc --write 'src/**/*.{js,json,ts,html}'",
     "webdriver": "webdriver-manager update --ignore_ssl = true"
   },
   "private": true,
@@ -24,7 +24,6 @@
     "@angular/router": "~8.2.9",
     "@swimlane/ngx-charts": "^13.0.1",
     "date-fns": "^2.6.0",
-    "lint-staged": "^10.2.2",
     "lodash": "^4.17.19",
     "md5": "^2.2.1",
     "nanoid": "^3.1.12",
@@ -35,8 +34,13 @@
   },
   "lint-staged": {
     "src/**/*.{js,json,ts,html}": [
-      "prettier --write --trailing-comma none --single-quote"
+      "prettier --config .prettierrc"
     ]
+  },
+  "husky": {
+    "hooks": {
+      "pre-commit": "lint-staged"
+    }
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "^0.803.21",
@@ -49,14 +53,16 @@
     "codelyzer": "^5.1.2",
     "dotenv": "^8.0.0",
     "https-proxy-agent": "^2.2.1",
+    "husky": "^4.3.0",
     "jasmine-core": "~3.4.0",
     "jasmine-spec-reporter": "~4.2.1",
     "karma": "~4.1.0",
     "karma-chrome-launcher": "~2.2.0",
-    "karma-firefox-launcher": "~1.3.0",
     "karma-coverage-istanbul-reporter": "~2.0.1",
+    "karma-firefox-launcher": "~1.3.0",
     "karma-jasmine": "~2.0.1",
     "karma-jasmine-html-reporter": "^1.4.0",
+    "lint-staged": "^10.4.0",
     "prettier": "^2.0.5",
     "protractor": "~5.4.0",
     "ts-node": "~7.0.0",


### PR DESCRIPTION
### What is this PR for?
Although we applied prettier in the workbench. However, even if the code format violates the rule, we can still commit the code.
In that way, prettier might become useless, so we should autoformat the file in precommit.

Therefore, I use husky + lint-staged to construct a mechanism which can automatically format only staged file in git, which is quite efficient and convenient.

### What type of PR is it?
[Improvement]

### Todos

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-652

### How should this be tested?
https://travis-ci.org/github/ByronHsu/submarine/builds/732470123

### Screenshots (if appropriate)
<img width="494" alt="Screen Shot 2020-10-03 at 4 01 01 PM" src="https://user-images.githubusercontent.com/24364830/94986774-07daa380-0594-11eb-9ef5-e39aad54f716.png">

### Questions:
* Does the licenses files need update? Yes/No
* Is there breaking changes for older versions? Yes/No
* Does this needs documentation? Yes/No
