### PR TITLE
SUBMARINE-662. Clarify duplicate experiment error

### DIFF
--- a/submarine-server/server-core/src/main/java/org/apache/submarine/server/rest/ExperimentRestApi.java
+++ b/submarine-server/server-core/src/main/java/org/apache/submarine/server/rest/ExperimentRestApi.java
@@ -80,14 +80,14 @@ public class ExperimentRestApi {
         .success(true).result("Pong").build();
   }
 
-  
+
   /**
    * Returns the contents of {@link Experiment} that submitted by user.
    *
    * @param spec spec
    * @return the contents of experiment
    */
-  
+
   @POST
   @Consumes({RestConstants.MEDIA_TYPE_YAML, MediaType.APPLICATION_JSON})
   @Operation(summary = "Create an experiment",
@@ -109,7 +109,7 @@ public class ExperimentRestApi {
    * Returns the contents of {@link Experiment} that submitted by user.
    *
    * @param id template id
-   * @param spec 
+   * @param spec
    * @return the contents of experiment
    */
   @POST
@@ -120,11 +120,11 @@ public class ExperimentRestApi {
       responses = {
           @ApiResponse(description = "successful operation", content = @Content(
               schema = @Schema(implementation = JsonResponse.class)))})
-  public Response SubmitExperimentTemplate(@PathParam("name") String name, 
+  public Response SubmitExperimentTemplate(@PathParam("name") String name,
         ExperimentTemplateSubmit spec) {
     try {
       spec.setName(name);
-      
+
       Experiment experiment = ExperimentTemplateManager.getInstance().submitExperimentTemplate(spec);
       return new JsonResponse.Builder<Experiment>(Response.Status.OK)
           .success(true).result(experiment).build();
@@ -259,6 +259,7 @@ public class ExperimentRestApi {
   }
 
   private Response parseExperimentServiceException(SubmarineRuntimeException e) {
-    return new JsonResponse.Builder<String>(e.getCode()).message(e.getMessage()).build();
+    return new JsonResponse.Builder<String>(e.getCode())
+      .message(e.getMessage().equals("Conflict") ? "Duplicated Experiment" : e.getMessage()).build();
   }
 }

--- a/submarine-server/server-core/src/main/java/org/apache/submarine/server/rest/ExperimentRestApi.java
+++ b/submarine-server/server-core/src/main/java/org/apache/submarine/server/rest/ExperimentRestApi.java
@@ -260,6 +260,6 @@ public class ExperimentRestApi {
 
   private Response parseExperimentServiceException(SubmarineRuntimeException e) {
     return new JsonResponse.Builder<String>(e.getCode())
-      .message(e.getMessage().equals("Conflict") ? "Duplicated Experiment" : e.getMessage()).build();
+      .message(e.getMessage().equals("Conflict") ? "Duplicated experiment name" : e.getMessage()).build();
   }
 }


### PR DESCRIPTION
### What is this PR for?
When we send an experiment POST request that has the same name as the previous ones, it will raise an error. However, the error message does not explain the error clearly, it only says that there is a Conflict. (as the following)
```
{
  "status": "CONFLICT",
  "code": 409,
  "success": null,
  "message": "Conflict",
  "result": null,
  "attributes": {}
}
```
To let users understand the cause of the error better, I change the message from "Conflict" to "Duplicated experiment".

```
{ 
  "status": "CONFLICT",
  "code": 409,
  "success": null,
  "message": "Duplicated Experiment",
  "result": null,
  "attributes": {} 
}
 
```

### What type of PR is it?
[Improvement]

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-662

### How should this be tested?
https://travis-ci.org/github/ByronHsu/submarine/builds/736283354

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? Yes/No
* Is there breaking changes for older versions? Yes/No
* Does this needs documentation? Yes/No
