### PR TITLE
SUBMARINE-663. Use md5sum command in publish_release.sh

### DIFF
--- a/dev-support/cicd/publish_release.sh
+++ b/dev-support/cicd/publish_release.sh
@@ -134,7 +134,13 @@ function publish_to_maven() {
   for file in $(find . -type f); do
     echo "${GPG_PASSPHRASE}" | gpg --passphrase-fd 0 --output "${file}.asc" \
       --detach-sig --armor "${file}"
-    md5 -q "${file}" > "${file}.md5"
+    if [ $(command -v md5) ]; then
+      # Available on OS X; -q to keep only hash
+      md5 -q $file > $file.md5
+    else
+      # Available on Linux; cut to keep only hash
+      md5sum $file | cut -f1 -d' ' > $file.md5
+    fi
     ${SHASUM} -a 1 "${file}" | cut -f1 -d' ' > "${file}.sha1"
   done
 


### PR DESCRIPTION
### What is this PR for?
md5 could only run on macOS machines.

Add md5sum, so that we could also run on Linux machines

ref: https://github.com/apache/spark/blame/688d016c7acc4b9d96d75b40123be9f40b7b2693/dev/create-release/release-build.sh#L444-L452

### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-663

### How should this be tested?
https://travis-ci.org/github/pingsutw/hadoop-submarine/builds/737266426

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
