### PR TITLE
SUBMARINE-611. Fix a bug in add new project page

### DIFF
--- a/submarine-test/test-e2e/src/test/java/org/apache/submarine/integration/workspaceIT.java
+++ b/submarine-test/test-e2e/src/test/java/org/apache/submarine/integration/workspaceIT.java
@@ -84,13 +84,34 @@ public class workspaceIT extends AbstractSubmarineIT {
     Assert.assertEquals(pollingWait(By.xpath("//div[@id='addProjectbtn']"), MAX_BROWSER_TIMEOUT_SEC).isDisplayed(), true);
     pollingWait(By.xpath("//div[@id='addProjectbtn']/button"), MAX_BROWSER_TIMEOUT_SEC).click();
     //step1
+    By nextStepButton = By.xpath("//div[@class='centerDiv']/button");
     Assert.assertEquals(pollingWait(By.xpath("//form"), MAX_BROWSER_TIMEOUT_SEC).isDisplayed(), true);
     pollingWait(By.xpath("//input[@id='username']"), MAX_BROWSER_TIMEOUT_SEC).sendKeys("e2e test Project");
     pollingWait(By.xpath("//textarea[@name='projectDescription']"), MAX_BROWSER_TIMEOUT_SEC).sendKeys("e2e test Project description");
-    pollingWait(By.xpath("//div[@class='centerDiv']/button"), MAX_BROWSER_TIMEOUT_SEC).click();
+    Assert.assertEquals(pollingWait(nextStepButton, MAX_BROWSER_TIMEOUT_SEC).getAttribute("disabled"), "true"); // nextStepButton disabled (no set visibility)
+    
+    pollingWait(By.xpath("//nz-radio-group[@name='visibility']/label[1]/span/input"), MAX_BROWSER_TIMEOUT_SEC).click(); // select Private
+    Assert.assertEquals(pollingWait(nextStepButton, MAX_BROWSER_TIMEOUT_SEC).getAttribute("disabled"), null); // nextStepButton enabled
+    
+    pollingWait(By.xpath("//nz-radio-group[@name='visibility']/label[last()]/span/input"), MAX_BROWSER_TIMEOUT_SEC).click(); // select Public
+    Assert.assertEquals(pollingWait(nextStepButton, MAX_BROWSER_TIMEOUT_SEC).getAttribute("disabled"), "true"); // nextStepButton disabled (no set permission)
+    
+    pollingWait(By.xpath("//nz-radio-group[@name='permission']/label[last()]/span/input"), MAX_BROWSER_TIMEOUT_SEC).click(); // select Can View
+    Assert.assertEquals(pollingWait(nextStepButton, MAX_BROWSER_TIMEOUT_SEC).getAttribute("disabled"), null); // nextStepButton enabled
+
+    pollingWait(By.xpath("//nz-radio-group[@name='visibility']/label[2]/span/input"), MAX_BROWSER_TIMEOUT_SEC).click(); // select Team
+    Assert.assertEquals(pollingWait(nextStepButton, MAX_BROWSER_TIMEOUT_SEC).getAttribute("disabled"), "true"); // nextStepButton disabled (no set Team)
+
+    pollingWait(By.xpath("//nz-select[@name='team']"), MAX_BROWSER_TIMEOUT_SEC).click(); // expand team options
+    pollingWait(By.xpath("//li[@nz-option-li][last()]"), MAX_BROWSER_TIMEOUT_SEC).click(); // select a team
+    Assert.assertEquals(pollingWait(nextStepButton, MAX_BROWSER_TIMEOUT_SEC).getAttribute("disabled"), null); // nextStepButton enabled
+    
+    pollingWait(nextStepButton, MAX_BROWSER_TIMEOUT_SEC).click();
+    
     //step2
     Assert.assertEquals(pollingWait(By.xpath("//nz-tabset"), MAX_BROWSER_TIMEOUT_SEC).isDisplayed(), true);
     pollingWait(By.xpath("//div[@class='centerDiv']/button[last()]"), MAX_BROWSER_TIMEOUT_SEC).click();
+    
     //step3
     Assert.assertEquals(pollingWait(By.xpath("//thead"), MAX_BROWSER_TIMEOUT_SEC).isDisplayed(), true);
     pollingWait(By.xpath("//div[@class='centerDiv']/button[last()-1]"), MAX_BROWSER_TIMEOUT_SEC).click();

--- a/submarine-workbench/workbench-web/src/app/pages/workbench/workspace/project/new-project-page/new-project-page.component.html
+++ b/submarine-workbench/workbench-web/src/app/pages/workbench/workspace/project/new-project-page/new-project-page.component.html
@@ -118,7 +118,7 @@
         style="margin-bottom: 10px;"
         nz-button
         nzType="primary"
-        [disabled]="!f.valid"
+        [disabled]="!f.valid || !isVisibilityFilled()"
         (click)="current = current + 1"
       >
         Next Step

--- a/submarine-workbench/workbench-web/src/app/pages/workbench/workspace/project/new-project-page/new-project-page.component.ts
+++ b/submarine-workbench/workbench-web/src/app/pages/workbench/workspace/project/new-project-page/new-project-page.component.ts
@@ -56,9 +56,9 @@ export class NewProjectPageComponent implements OnInit {
   newProjectContent = {
     projectName: '',
     description: '',
-    visibility: 'Private',
+    visibility: '',
     team: '',
-    permission: 'View',
+    permission: '',
     files: []
   };
   Templates = [
@@ -110,6 +110,27 @@ export class NewProjectPageComponent implements OnInit {
     } else {
       this.templateType = '';
     }
+  }
+
+  isVisibilityFilled(): boolean {
+    // check whether visibility is filled
+    if (this.newProjectContent.visibility === '') {
+      return false;
+    }
+
+    // check whether chosen visibility requires additional information (e.g. permission)
+    if (this.newProjectContent.visibility === 'PROJECT_VISIBILITY_TEAM') {
+      if (this.newProjectContent.team === '' || this.newProjectContent.permission === '') {
+        return false;
+      }
+    }
+
+    if (this.newProjectContent.visibility === 'PROJECT_VISIBILITY_PUBLIC') {
+        if (this.newProjectContent.permission === '') {
+          return false;
+        }
+    }
+    return true;
   }
 
   done(): void {


### PR DESCRIPTION
### What is this PR for?
"Create new project page" UI makes the "Next Step button" become clickable before all required fields are filled.
Now the button would stay unclickable until users filled all required fields.

### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-611

### How should this be tested?
https://travis-ci.org/github/brayce1996/submarine/builds/736928222

### Screenshots (if appropriate)
1. Visibility is not filled, so Next Step button is disabled.
![image](https://user-images.githubusercontent.com/18074733/96534746-ef23fa80-12c2-11eb-916a-61617604a0b5.png)
2. Visibility is filled, but public visibility requires Permission to be filled. Next Step button is disabled.
![image](https://user-images.githubusercontent.com/18074733/96534788-02cf6100-12c3-11eb-9f8e-d9a90d02624f.png)
3. All required fields are filled, so Next Step button is enabled.
![image](https://user-images.githubusercontent.com/18074733/96534981-72455080-12c3-11eb-8e24-8892eef02269.png)


### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
