### PR TITLE
SUBMARINE-673. Fixed Cannot read property 'environment' of null

### DIFF
--- a/submarine-workbench/workbench-web/src/app/pages/workbench/environment/environment.component.html
+++ b/submarine-workbench/workbench-web/src/app/pages/workbench/environment/environment.component.html
@@ -95,7 +95,7 @@
         <tbody>
           <tr *ngFor="let data of basicTable.data; let i = index">
             <td>
-              <label nz-checkbox [(ngModel)]="checkedList[i]"></label>
+              <label *ngIf="data.environmentSpec.name != 'notebook-env'" nz-checkbox [(ngModel)]="checkedList[i]"></label>
             </td>
             <td>{{ data.environmentSpec.name }}</td>
             <td>{{ data.environmentSpec.dockerImage }}</td>

--- a/submarine-workbench/workbench-web/src/app/pages/workbench/environment/environment.component.ts
+++ b/submarine-workbench/workbench-web/src/app/pages/workbench/environment/environment.component.ts
@@ -175,7 +175,7 @@ export class EnvironmentComponent implements OnInit {
   deleteEnvironments() {
     for (let i = this.checkedList.length - 1; i >= 0; i--) {
       console.log(this.environmentList[i].environmentSpec.name);
-      if (this.checkedList[i] === true) {
+      if (this.checkedList[i] === true && this.environmentList[i].environmentSpec.name != 'notebook-env') {
         this.onDeleteEnvironment(this.environmentList[i].environmentSpec.name, false);
       }
     }

--- a/submarine-workbench/workbench-web/src/app/pages/workbench/notebook/notebook.component.ts
+++ b/submarine-workbench/workbench-web/src/app/pages/workbench/notebook/notebook.component.ts
@@ -34,6 +34,7 @@ export class NotebookComponent implements OnInit {
   // Environment
   envList;
   envNameList = [];
+  indexOfDeaultEnv;
 
   // Namesapces
   allNamespaceList = [];
@@ -85,6 +86,7 @@ export class NotebookComponent implements OnInit {
           this.envNameList.push(env.environmentSpec.name);
         }
       });
+      this.indexOfDeaultEnv = this.envNameList.indexOf('notebook-env');
     });
   }
 
@@ -180,7 +182,7 @@ export class NotebookComponent implements OnInit {
   initNotebookStatus() {
     this.isVisible = true;
     this.notebookName.reset();
-    this.envName.reset(this.envNameList[0]);
+    this.envName.reset(this.envNameList[this.indexOfDeaultEnv]);
     this.envVars.clear();
     this.cpus.reset(1);
     this.gpus.reset(0);


### PR DESCRIPTION
### What is this PR for?
If there is no environment in submarine server, clicking the button "+ New notebook" will output error message "ERROR TypeError: Cannot read property 'environment' of null" to the web console and the modal do not open.

1. Set notebook-env can't be deleted in environment page of UI.
2. Set notebook-env as default environment when create new notebook in notebook page of UI.


### What type of PR is it?
[Bug Fix]

### Todos

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-673

### How should this be tested?
https://travis-ci.org/github/kobe860219/submarine/builds/742502456

### Screenshots (if appropriate)
![螢幕錄製 2020-11-10 上午12](https://user-images.githubusercontent.com/48027290/98574254-a9bb8180-22f2-11eb-9b9d-421263afe564.gif)


### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
