### PR TITLE
SUBMARINE-674. Delete the unused environment "my-submarine-env" in DB

### DIFF
--- a/docs/database/submarine-data.sql
+++ b/docs/database/submarine-data.sql
@@ -85,8 +85,7 @@ INSERT INTO `params` (`id`, `key`, `value`, `worker_index`) VALUES
 -- Records of environment
 -- ----------------------------
 INSERT INTO `environment` VALUES
-('environment_1600862964725_0001', 'notebook-env', '{"name":"notebook-env","dockerImage":"apache/submarine:jupyter-notebook-0.5.0","kernelSpec":{"name":"submarine_jupyter_py3","channels":["defaults"],"dependencies":[]}}', 'admin', '2020-09-21 14:00:05', 'admin', '2020-09-21 14:00:14'),
-('environment_1595134205164_0002', 'my-submarine-test-env','{"name":"my-submarine-env","dockerImage":"continuumio/anaconda3","kernelSpec":{"name":"team_default_python_3.7","channels":["defaults"],"dependencies":["_ipyw_jlab_nb_ext_conf=0.1.0=py37_0","alabaster=0.7.12=py37_0","anaconda=2020.02=py37_0","anaconda-client=1.7.2=py37_0","anaconda-navigator=1.9.12=py37_0"]}}','admin', '2020-05-06 14:00:05', 'Jack', '2020-05-06 14:00:14');
+('environment_1600862964725_0001', 'notebook-env', '{"name":"notebook-env","dockerImage":"apache/submarine:jupyter-notebook-0.5.0","kernelSpec":{"name":"submarine_jupyter_py3","channels":["defaults"],"dependencies":[]}}', 'admin', '2020-09-21 14:00:05', 'admin', '2020-09-21 14:00:14');
 
 -- ----------------------------
 -- Records of experiment_templates


### PR DESCRIPTION
### What is this PR for?
Delete the environment "my-submarine-env" of notebook in database.

### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
[SUBMARINE-674](https://issues.apache.org/jira/projects/SUBMARINE/issues/SUBMARINE-674?filter=allopenissues)

### How should this be tested?
[Travis-CI](https://travis-ci.com/github/charlie0220/submarine/builds/201707917)
### Screenshots (if appropriate)
![submarine-674](https://user-images.githubusercontent.com/50860453/99234100-1244ba00-282f-11eb-97ee-085dfafc3320.png)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
