### PR TITLE
SUBMARINE-676. Add NG-ZORRO UI component library to notebook page

### DIFF
--- a/submarine-workbench/workbench-web/src/app/pages/workbench/notebook/notebook.component.html
+++ b/submarine-workbench/workbench-web/src/app/pages/workbench/notebook/notebook.component.html
@@ -105,26 +105,26 @@
   (nzOnCancel)="isVisible = false"
   [nzWidth]="700"
 >
-  <form [formGroup]="notebookForm">
+  <form nz-form [formGroup]="notebookForm" nzLayout="horizontal">
     <div *nzModalFooter>
       <button nz-button nzType="default" (click)="isVisible = false">Cancel</button>
       <button id="create-btn" nz-button nzType="primary" [disabled]="checkStatus()" (click)="handleOk()">
         Create
       </button>
     </div>
-    <div style="margin-top: 30px;">
-      <div class="newNotebookForm">
-        <label for="notebookName">
-          <span class="red-star">*</span>
+    <nz-form-item>
+        <nz-form-label [nzSm]="6" [nzXs]="24" nzRequired nzFor="notebookName">
           Notebook Name
-        </label>
-        <input nz-input required type="text" name="notebookName" id="notebookName" formControlName="notebookName" />
-      </div>
-      <div class="newNotebookForm">
-        <label for="environment">
-          <span class="red-star">*</span>
-          Environment
-        </label>
+        </nz-form-label>
+        <nz-form-control [nzSm]="14" [nzXs]="24">
+          <input nz-input required type="text" name="notebookName" id="notebookName" formControlName="notebookName" />
+        </nz-form-control>
+    </nz-form-item>
+    <nz-form-item>
+      <nz-form-label [nzSm]="6" [nzXs]="24" nzRequired nzFor="environment">
+        Environment
+      </nz-form-label>
+      <nz-form-control [nzSm]="14" [nzXs]="24">
         <nz-select required name="select-envName" formControlName="envName">
           <nz-option
             *ngFor="let env of envNameList; let i; of: index"
@@ -133,67 +133,77 @@
             [nzLabel]="env"
           ></nz-option>
         </nz-select>
-      </div>
-      <div class="newNotebookForm">
-        <label for="cpus">
-          <span class="red-star">*</span>
-          CPU
-        </label>
-        <input nz-input required type="number" name="cpus" id="cpus" formControlName="cpus" />
-      </div>
-      <div class="newNotebookForm">
-        <label for="gpus">
-          GPU
-        </label>
-        <input nz-input type="number" name="gpus" id="gpus" formControlName="gpus" />
-      </div>
-      <div class="newNotebookForm">
-        <label for="memoryNum">
-          <span class="red-star">*</span>
-          Memory
-        </label>
-        <div class="memory-input-group">
-          <input nz-input required name="memoryNum" placeholder="EX:1024" formControlName="memoryNum" />
+      </nz-form-control>
+    </nz-form-item>
+    <nz-form-item>
+      <nz-form-label [nzSm]="6" [nzXs]="24" nzRequired nzFor="cpus">
+        CPU
+      </nz-form-label>
+      <nz-form-control [nzSm]="14" [nzXs]="24">
+        <input nz-input min="0" required type="number" name="cpus" id="cpus" formControlName="cpus" />
+      </nz-form-control>
+    </nz-form-item>
+    <nz-form-item>
+      <nz-form-label [nzSm]="6" [nzXs]="24" nzRequired nzFor="gpus">
+        GPU
+      </nz-form-label>
+      <nz-form-control [nzSm]="14" [nzXs]="24">
+        <input nz-input min="0" type="number" name="gpus" id="gpus" formControlName="gpus" />
+      </nz-form-control>
+    </nz-form-item>
+    <nz-form-item>
+      <nz-form-label [nzSm]="6" [nzXs]="24" nzRequired nzFor="memoryNum">
+        Memory
+      </nz-form-label>
+      <nz-form-control [nzSm]="14" [nzXs]="24">
+        <div nz-col nzSpan="6">
+        <input nz-input required name="memoryNum" placeholder="EX:1024" formControlName="memoryNum" />
+        </div>
+        <div nz-col nzSpan="6" style="margin-left: 5px;">
           <nz-select formControlName="unit">
             <nz-option *ngFor="let unit of MEMORY_UNITS" [nzValue]="unit" [nzLabel]="unit"></nz-option>
           </nz-select>
         </div>
-      </div>
-      <div formArrayName="envVars">
-        <ng-container *ngFor="let envVar of envVars.controls; index as i">
-          <div [formGroupName]="i" class="newNotebookForm">
-            <label for="envVar{{ i }}">EnvVar {{ i + 1 }}</label>
-            <div>
-              <input
-                style="width: 30%;"
-                nz-input
-                id="key{{ i }}"
-                name="key{{ i }}"
-                placeholder="Key"
-                formControlName="key"
-              />
-              <input
-                style="width: 50%; margin-left: 10px;"
-                nz-input
-                id="value{{ i }}"
-                name="value{{ i }}"
-                placeholder="Value"
-                formControlName="value"
-              />
-              <i
-                nz-icon
-                style="margin-left: 5px;"
-                nzType="close-circle"
-                nzTheme="fill"
-                (click)="deleteItem(envVars, i)"
-              ></i>
-            </div>
+      </nz-form-control>
+    </nz-form-item>
+    <div formArrayName="envVars">
+      <ng-container *ngFor="let envVar of envVars.controls; index as i">
+        <nz-form-item>
+        <nz-form-label nzRequired [nzSm]="6" [nzXs]="24">EnvVar{{ i+1 }}</nz-form-label>
+        <div [formGroupName]="i">
+          <div nz-col nzSpan="12">
+            <input
+              style="width: 30%;"
+              nz-input
+              required
+              id="key{{ i }}"
+              name="key{{ i }}"
+              placeholder="Key"
+              formControlName="key"
+            />
+            <input
+              style="width: 60%; margin-left: 10px;"
+              nz-input
+              required
+              id="value{{ i }}"
+              name="value{{ i }}"
+              placeholder="Value"
+              formControlName="value"
+            />
+            <i
+              nz-icon
+              style="margin-left: 5px;"
+              nzType="close-circle"
+              nzTheme="fill"
+              (click)="deleteItem(envVars, i)"
+            ></i>
           </div>
-        </ng-container>
-      </div>
+        </div>
+      </nz-form-item>
+      </ng-container>
     </div>
     <button nz-button style="display: block; margin: auto;" id="envVar-btn" type="default" (click)="onCreateEnvVar()">
-      Add New EnvVar
+      New EnvVar
     </button>
   </form>
 </nz-modal>


### PR DESCRIPTION
### What is this PR for?
We use NG-ZORRO as the UI Component library in Workbench Web. But the form in notebook page of WEB has not been used yet. We should make the WEB interface all use uniformly.


### What type of PR is it?
[Refactoring]

### Todos

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-676

### How should this be tested?
https://travis-ci.org/github/kobe860219/submarine/builds/744476551

### Screenshots (if appropriate)
![x3ie8-uk0nv](https://user-images.githubusercontent.com/48027290/99566311-b2edd200-2a07-11eb-96ea-c387bfef4ebe.gif)


### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
