### PR TITLE
SUBMARINE-675. Sync the status of notebook

### DIFF
--- a/docs/userdocs/k8s/api/notebook.md
+++ b/docs/userdocs/k8s/api/notebook.md
@@ -58,8 +58,8 @@ curl -X POST -H "Content-Type: application/json" -d '
     "name":"test-nb",
     "uid":"5a94c01d-6a92-4222-bc66-c610c277546d",
     "url":"/notebook/default/test-nb/",
-    "status": null,
-    "reason": null,
+    "status":"creating",
+    "reason":"The notebook instance is creating",
     "createdTime":"2020-08-20T21:58:27.000+08:00",
     "deletedTime":null,
     "spec":{
@@ -116,8 +116,8 @@ curl -X GET http://127.0.0.1:32080/api/v1/notebook?id={user_id}
       "name":"test-nb",
       "uid":"5a94c01d-6a92-4222-bc66-c610c277546d",
       "url":"/notebook/default/test-nb/",
-      "status": "ready",
-      "reason": "Notebook instance is running",
+      "status": "running",
+      "reason": "The notebook instance is running",
       "createdTime":"2020-08-20T21:58:27.000+08:00",
       "deletedTime":null,
       "spec":{
@@ -174,7 +174,8 @@ curl -X GET http://127.0.0.1:32080/api/v1/notebook/{id}
     "name":"test-nb",
     "uid":"5a94c01d-6a92-4222-bc66-c610c277546d",
     "url":"/notebook/default/test-nb/",
-    "status":"Created",
+    "status":"running",
+    "reason":"The notebook instance is running",
     "createdTime":"2020-08-20T21:58:27.000+08:00",
     "deletedTime":null,
     "spec":{
@@ -215,7 +216,7 @@ curl -X GET http://127.0.0.1:32080/api/v1/notebook/{id}
 
 **Example Request:**
 ```sh
-curl -X DELETE http://127.0.0.1:8080/api/v1/notebook/{id}
+curl -X DELETE http://127.0.0.1:32080/api/v1/notebook/{id}
 ```
 
 **Example Response:**
@@ -230,7 +231,8 @@ curl -X DELETE http://127.0.0.1:8080/api/v1/notebook/{id}
     "name": "test-nb",
     "uid": "5a94c01d-6a92-4222-bc66-c610c277546d",
     "url": "/notebook/default/test-nb/",
-    "status": "Deleted",
+    "status": "terminating",
+    "reason": "The notebook instance is terminating",
     "createdTime": "2020-08-22T14:03:19.000+08:00",
     "deletedTime": "2020-08-22T14:46:28+0800",
     "spec": {

--- a/docs/userdocs/k8s/api/notebook.md
+++ b/docs/userdocs/k8s/api/notebook.md
@@ -43,7 +43,7 @@ curl -X POST -H "Content-Type: application/json" -d '
     "resources": "cpu=1,memory=1.0Gi"
   }
 }
-' http://127.0.0.1:8080/api/v1/notebook
+' http://127.0.0.1:32080/api/v1/notebook
 ```
 
 **Example Response:**
@@ -58,7 +58,8 @@ curl -X POST -H "Content-Type: application/json" -d '
     "name":"test-nb",
     "uid":"5a94c01d-6a92-4222-bc66-c610c277546d",
     "url":"/notebook/default/test-nb/",
-    "status":"Created",
+    "status": null,
+    "reason": null,
     "createdTime":"2020-08-20T21:58:27.000+08:00",
     "deletedTime":null,
     "spec":{
@@ -99,7 +100,7 @@ curl -X POST -H "Content-Type: application/json" -d '
 
 **Example Request:**
 ```sh
-curl -X GET http://127.0.0.1:8080/api/v1/notebook?id={user_id}
+curl -X GET http://127.0.0.1:32080/api/v1/notebook?id={user_id}
 ```
 
 **Example Response:**
@@ -115,7 +116,8 @@ curl -X GET http://127.0.0.1:8080/api/v1/notebook?id={user_id}
       "name":"test-nb",
       "uid":"5a94c01d-6a92-4222-bc66-c610c277546d",
       "url":"/notebook/default/test-nb/",
-      "status":"Created",
+      "status": "ready",
+      "reason": "Notebook instance is running",
       "createdTime":"2020-08-20T21:58:27.000+08:00",
       "deletedTime":null,
       "spec":{
@@ -157,7 +159,7 @@ curl -X GET http://127.0.0.1:8080/api/v1/notebook?id={user_id}
 
 **Example Request:**
 ```sh
-curl -X GET http://127.0.0.1:8080/api/v1/notebook/{id}
+curl -X GET http://127.0.0.1:32080/api/v1/notebook/{id}
 ```
 
 **Example Response:**

--- a/submarine-server/server-api/src/main/java/org/apache/submarine/server/api/notebook/Notebook.java
+++ b/submarine-server/server-api/src/main/java/org/apache/submarine/server/api/notebook/Notebook.java
@@ -30,6 +30,7 @@ public class Notebook {
   private String uid;
   private String url;
   private String status;
+  private String reason;
   private String createdTime;
   private String deletedTime;
   private NotebookSpec spec;
@@ -74,6 +75,14 @@ public class Notebook {
     this.status = status;
   }
 
+  public String getReason() {
+    return reason;
+  }
+
+  public void setReason(String message) {
+    this.reason = message;
+  }
+
   public String getCreatedTime() {
     return createdTime;
   }
@@ -99,10 +108,12 @@ public class Notebook {
   }
 
   public enum Status {
-    STATUS_CREATED("Created"),
-    STATUS_DELETED("Deleted");
+    STATUS_SCHEDULING("scheduling"),
+    STATUS_RUNNING("running"),
+    STATUS_WAITING("waiting"),
+    STATUS_TERMINATING("terminating");
 
-    private String value;
+    private final String value;
     Status(String value) {
       this.value = value;
     }
@@ -133,6 +144,9 @@ public class Notebook {
       }
       if (notebook.getStatus() != null) {
         this.setStatus(notebook.getStatus());
+      }
+      if (notebook.getReason() != null) {
+        this.setReason(notebook.getReason());
       }
       if (notebook.getCreatedTime() != null) {
         this.setCreatedTime(notebook.getCreatedTime());

--- a/submarine-server/server-api/src/main/java/org/apache/submarine/server/api/notebook/Notebook.java
+++ b/submarine-server/server-api/src/main/java/org/apache/submarine/server/api/notebook/Notebook.java
@@ -79,8 +79,8 @@ public class Notebook {
     return reason;
   }
 
-  public void setReason(String message) {
-    this.reason = message;
+  public void setReason(String reason) {
+    this.reason = reason;
   }
 
   public String getCreatedTime() {
@@ -108,12 +108,12 @@ public class Notebook {
   }
 
   public enum Status {
-    STATUS_SCHEDULING("scheduling"),
+    STATUS_CREATING("creating"),
     STATUS_RUNNING("running"),
     STATUS_WAITING("waiting"),
     STATUS_TERMINATING("terminating");
 
-    private final String value;
+    private String value;
     Status(String value) {
       this.value = value;
     }

--- a/submarine-server/server-core/src/main/java/org/apache/submarine/server/notebook/NotebookManager.java
+++ b/submarine-server/server-core/src/main/java/org/apache/submarine/server/notebook/NotebookManager.java
@@ -84,6 +84,8 @@ public class NotebookManager {
     Notebook notebook = submitter.createNotebook(spec);
     notebook.setNotebookId(generateNotebookId());
     notebook.setSpec(spec);
+
+    // environment information
     NotebookSpec notebookSpec = notebook.getSpec();
     EnvironmentManager environmentManager = EnvironmentManager.getInstance();
     Environment environment = environmentManager.getEnvironment(spec.getEnvironment().getName());

--- a/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/K8sSubmitter.java
+++ b/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/K8sSubmitter.java
@@ -21,14 +21,11 @@ package org.apache.submarine.server.submitter.k8s;
 
 import java.io.FileReader;
 import java.io.IOException;
-import java.text.SimpleDateFormat;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.List;
-import java.util.ArrayList;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonSyntaxException;
@@ -57,14 +54,13 @@ import org.apache.submarine.server.api.spec.ExperimentSpec;
 import org.apache.submarine.server.api.spec.NotebookSpec;
 import org.apache.submarine.server.submitter.k8s.model.MLJob;
 import org.apache.submarine.server.submitter.k8s.model.NotebookCR;
-import org.apache.submarine.server.submitter.k8s.model.NotebookCRList;
 import org.apache.submarine.server.submitter.k8s.model.ingressroute.IngressRoute;
 import org.apache.submarine.server.submitter.k8s.model.ingressroute.IngressRouteSpec;
 import org.apache.submarine.server.submitter.k8s.model.ingressroute.SpecRoute;
 import org.apache.submarine.server.submitter.k8s.parser.ExperimentSpecParser;
 import org.apache.submarine.server.submitter.k8s.parser.NotebookSpecParser;
 import org.apache.submarine.server.submitter.k8s.util.MLJobConverter;
-import org.joda.time.DateTime;
+import org.apache.submarine.server.submitter.k8s.util.NotebookUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -252,6 +248,7 @@ public class K8sSubmitter implements Submitter {
   @Override
   public Notebook createNotebook(NotebookSpec spec) throws SubmarineRuntimeException {
     Notebook notebook;
+    NotebookUtils utils = new NotebookUtils();
     try {
       // create notebook custom resource
       NotebookCR notebookCR = NotebookSpecParser.parseNotebook(spec);
@@ -260,7 +257,7 @@ public class K8sSubmitter implements Submitter {
       notebookCR.getMetadata().setLabels(labels);
       Object object = api.createNamespacedCustomObject(notebookCR.getGroup(), notebookCR.getVersion(),
               notebookCR.getMetadata().getNamespace(), notebookCR.getPlural(), notebookCR, "true");
-      notebook = parseNotebookResponseObject(object);
+      notebook = utils.parseObject(object, NotebookUtils.ParseOpt.PARSE_OPT_CREATE);
 
       // create Traefik custom resource
       createIngressRoute(notebookCR.getMetadata().getNamespace(), notebookCR.getMetadata().getName());
@@ -279,12 +276,13 @@ public class K8sSubmitter implements Submitter {
   @Override
   public Notebook findNotebook(NotebookSpec spec) throws SubmarineRuntimeException {
     Notebook notebook;
+    NotebookUtils utils = new NotebookUtils();
     try {
       NotebookCR notebookCR = NotebookSpecParser.parseNotebook(spec);
       Object object = api.getNamespacedCustomObject(notebookCR.getGroup(), notebookCR.getVersion(),
               notebookCR.getMetadata().getNamespace(),
               notebookCR.getPlural(), notebookCR.getMetadata().getName());
-      notebook = parseNotebookResponseObject(object);
+      notebook = utils.parseObject(object, NotebookUtils.ParseOpt.PARSE_OPT_GET);
     } catch (ApiException e) {
       throw new SubmarineRuntimeException(e.getCode(), e.getMessage());
     }
@@ -294,6 +292,7 @@ public class K8sSubmitter implements Submitter {
   @Override
   public Notebook deleteNotebook(NotebookSpec spec) throws SubmarineRuntimeException {
     Notebook notebook;
+    NotebookUtils utils = new NotebookUtils();
     try {
       NotebookCR notebookCR = NotebookSpecParser.parseNotebook(spec);
       Object object = api.deleteNamespacedCustomObject(notebookCR.getGroup(), notebookCR.getVersion(),
@@ -301,7 +300,7 @@ public class K8sSubmitter implements Submitter {
               notebookCR.getMetadata().getName(),
               new V1DeleteOptionsBuilder().withApiVersion(notebookCR.getApiVersion()).build(),
               null, null, null);
-      notebook = parseNotebookResponseObject(object);
+      notebook = utils.parseObject(object, NotebookUtils.ParseOpt.PARSE_OPT_DELETE);
       deleteIngressRoute(notebookCR.getMetadata().getNamespace(), notebookCR.getMetadata().getName());
     } catch (ApiException e) {
       throw new SubmarineRuntimeException(e.getCode(), e.getMessage());
@@ -312,76 +311,17 @@ public class K8sSubmitter implements Submitter {
   @Override
   public List<Notebook> listNotebook(String id) throws SubmarineRuntimeException {
     List<Notebook> notebookList;
+    NotebookUtils utils = new NotebookUtils();
     try {
       Object object = api.listClusterCustomObject(NotebookCR.CRD_NOTEBOOK_GROUP_V1,
               NotebookCR.CRD_NOTEBOOK_VERSION_V1, NotebookCR.CRD_NOTEBOOK_PLURAL_V1,
               "true", null, NotebookCR.NOTEBOOK_OWNER_SELECTOR_KET + "=" + id,
               null, null, null);
-      notebookList = parseNotebookListResponseObject(object);
+      notebookList = utils.parseObjectForList(object);
     } catch (ApiException e) {
       throw new SubmarineRuntimeException(e.getCode(), e.getMessage());
     }
     return notebookList;
-  }
-
-  private Notebook parseNotebookResponseObject(Object obj) throws SubmarineRuntimeException {
-    Gson gson = new JSON().getGson();
-    String jsonString = gson.toJson(obj);
-    LOG.info("Upstream response JSON: {}", jsonString);
-    Notebook notebook;
-    try {
-      NotebookCR notebookCR = gson.fromJson(jsonString, NotebookCR.class);
-      if (notebookCR.getMetadata().getName() != null) {
-        notebook = buildNotebookResponse(notebookCR);
-        // notebook is deleted
-      } else {
-        notebook = new Notebook();
-        SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ");
-        Date current = new Date();
-        notebook.setDeletedTime(dateFormat.format(current));
-        notebook.setStatus(Notebook.Status.STATUS_DELETED.toString());
-      }
-
-    } catch (JsonSyntaxException e) {
-      LOG.error("K8s submitter: parse response object failed by " + e.getMessage(), e);
-      throw new SubmarineRuntimeException(500, "K8s Submitter parse upstream response failed.");
-    }
-    return notebook;
-  }
-
-  private List<Notebook> parseNotebookListResponseObject(Object object) {
-    Gson gson = new JSON().getGson();
-    String jsonString = gson.toJson(object);
-    LOG.info("Upstream response JSON: {}", jsonString);
-
-    Notebook notebook;
-    List<Notebook> notebookList = new ArrayList<>();
-    try {
-      NotebookCRList notebookCRList = gson.fromJson(jsonString, NotebookCRList.class);
-      for (NotebookCR notebookCR : notebookCRList.getItems()) {
-        notebook = buildNotebookResponse(notebookCR);
-        notebookList.add(notebook);
-      }
-    } catch (JsonSyntaxException e) {
-      LOG.error("K8s submitter: parse response object failed by " + e.getMessage(), e);
-      throw new SubmarineRuntimeException(500, "K8s Submitter parse upstream response failed.");
-    }
-    return notebookList;
-  }
-
-  private Notebook buildNotebookResponse(NotebookCR notebookCR) {
-    Notebook notebook = new Notebook();
-    notebook.setUid(notebookCR.getMetadata().getUid());
-    notebook.setName(notebookCR.getMetadata().getName());
-    // notebook url
-    notebook.setUrl("/notebook/" + notebookCR.getMetadata().getNamespace() + "/" +
-            notebookCR.getMetadata().getName() + "/");
-    DateTime createdTime = notebookCR.getMetadata().getCreationTimestamp();
-    if (createdTime != null) {
-      notebook.setCreatedTime(createdTime.toString());
-      notebook.setStatus(Notebook.Status.STATUS_CREATED.getValue());
-    }
-    return notebook;
   }
 
   private String getJobLabelSelector(ExperimentSpec experimentSpec) {

--- a/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/K8sSubmitter.java
+++ b/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/K8sSubmitter.java
@@ -248,7 +248,6 @@ public class K8sSubmitter implements Submitter {
   @Override
   public Notebook createNotebook(NotebookSpec spec) throws SubmarineRuntimeException {
     Notebook notebook;
-    NotebookUtils utils = new NotebookUtils();
     try {
       // create notebook custom resource
       NotebookCR notebookCR = NotebookSpecParser.parseNotebook(spec);
@@ -257,7 +256,7 @@ public class K8sSubmitter implements Submitter {
       notebookCR.getMetadata().setLabels(labels);
       Object object = api.createNamespacedCustomObject(notebookCR.getGroup(), notebookCR.getVersion(),
               notebookCR.getMetadata().getNamespace(), notebookCR.getPlural(), notebookCR, "true");
-      notebook = utils.parseObject(object, NotebookUtils.ParseOpt.PARSE_OPT_CREATE);
+      notebook = NotebookUtils.parseObject(object, NotebookUtils.ParseOpt.PARSE_OPT_CREATE);
 
       // create Traefik custom resource
       createIngressRoute(notebookCR.getMetadata().getNamespace(), notebookCR.getMetadata().getName());
@@ -276,13 +275,12 @@ public class K8sSubmitter implements Submitter {
   @Override
   public Notebook findNotebook(NotebookSpec spec) throws SubmarineRuntimeException {
     Notebook notebook;
-    NotebookUtils utils = new NotebookUtils();
     try {
       NotebookCR notebookCR = NotebookSpecParser.parseNotebook(spec);
       Object object = api.getNamespacedCustomObject(notebookCR.getGroup(), notebookCR.getVersion(),
               notebookCR.getMetadata().getNamespace(),
               notebookCR.getPlural(), notebookCR.getMetadata().getName());
-      notebook = utils.parseObject(object, NotebookUtils.ParseOpt.PARSE_OPT_GET);
+      notebook = NotebookUtils.parseObject(object, NotebookUtils.ParseOpt.PARSE_OPT_GET);
     } catch (ApiException e) {
       throw new SubmarineRuntimeException(e.getCode(), e.getMessage());
     }
@@ -292,7 +290,6 @@ public class K8sSubmitter implements Submitter {
   @Override
   public Notebook deleteNotebook(NotebookSpec spec) throws SubmarineRuntimeException {
     Notebook notebook;
-    NotebookUtils utils = new NotebookUtils();
     try {
       NotebookCR notebookCR = NotebookSpecParser.parseNotebook(spec);
       Object object = api.deleteNamespacedCustomObject(notebookCR.getGroup(), notebookCR.getVersion(),
@@ -300,7 +297,7 @@ public class K8sSubmitter implements Submitter {
               notebookCR.getMetadata().getName(),
               new V1DeleteOptionsBuilder().withApiVersion(notebookCR.getApiVersion()).build(),
               null, null, null);
-      notebook = utils.parseObject(object, NotebookUtils.ParseOpt.PARSE_OPT_DELETE);
+      notebook = NotebookUtils.parseObject(object, NotebookUtils.ParseOpt.PARSE_OPT_DELETE);
       deleteIngressRoute(notebookCR.getMetadata().getNamespace(), notebookCR.getMetadata().getName());
     } catch (ApiException e) {
       throw new SubmarineRuntimeException(e.getCode(), e.getMessage());
@@ -311,13 +308,12 @@ public class K8sSubmitter implements Submitter {
   @Override
   public List<Notebook> listNotebook(String id) throws SubmarineRuntimeException {
     List<Notebook> notebookList;
-    NotebookUtils utils = new NotebookUtils();
     try {
       Object object = api.listClusterCustomObject(NotebookCR.CRD_NOTEBOOK_GROUP_V1,
               NotebookCR.CRD_NOTEBOOK_VERSION_V1, NotebookCR.CRD_NOTEBOOK_PLURAL_V1,
               "true", null, NotebookCR.NOTEBOOK_OWNER_SELECTOR_KET + "=" + id,
               null, null, null);
-      notebookList = utils.parseObjectForList(object);
+      notebookList = NotebookUtils.parseObjectForList(object);
     } catch (ApiException e) {
       throw new SubmarineRuntimeException(e.getCode(), e.getMessage());
     }

--- a/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/model/NotebookCR.java
+++ b/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/model/NotebookCR.java
@@ -49,6 +49,9 @@ public class NotebookCR {
   @SerializedName("spec")
   private NotebookCRSpec spec;
 
+  @SerializedName("status")
+  private NotebookStatus status;
+
   public NotebookCR() {
     setApiVersion(CRD_APIVERSION_V1);
     setKind(CRD_NOTEBOOK_KIND_V1);
@@ -113,4 +116,11 @@ public class NotebookCR {
     this.spec = spec;
   }
 
+  public NotebookStatus getStatus() {
+    return status;
+  }
+
+  public void setStatus(NotebookStatus status) {
+    this.status = status;
+  }
 }

--- a/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/model/NotebookCondition.java
+++ b/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/model/NotebookCondition.java
@@ -16,19 +16,27 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 package org.apache.submarine.server.submitter.k8s.model;
 
 import com.google.gson.annotations.SerializedName;
+import org.joda.time.DateTime;
 
-import java.util.List;
+public class NotebookCondition {
 
-public class NotebookCRList {
+  public NotebookCondition() {
 
-  @SerializedName("items")
-  private List<NotebookCR> items;
-
-  public List<NotebookCR> getItems() {
-    return items;
   }
+
+  @SerializedName("type")
+  private String type;
+
+  @SerializedName("lastProbeTime")
+  private DateTime lastProbeTime;
+
+  @SerializedName("reason")
+  private String reason;
+
+  @SerializedName("message")
+  private String message;
+
 }

--- a/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/model/NotebookStatus.java
+++ b/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/model/NotebookStatus.java
@@ -16,19 +16,36 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 package org.apache.submarine.server.submitter.k8s.model;
 
 import com.google.gson.annotations.SerializedName;
+import io.kubernetes.client.models.V1ContainerState;
 
 import java.util.List;
 
-public class NotebookCRList {
+public class NotebookStatus {
 
-  @SerializedName("items")
-  private List<NotebookCR> items;
+  @SerializedName("conditions")
+  private List<NotebookCondition> conditions;
 
-  public List<NotebookCR> getItems() {
-    return items;
+  @SerializedName("readyReplicas")
+  private int readyReplicas;
+
+  @SerializedName("containerState")
+  private V1ContainerState containerState;
+
+  NotebookStatus() {
+  }
+
+  public int getReadyReplicas() {
+    return readyReplicas;
+  }
+
+  public V1ContainerState getContainerState() {
+    return containerState;
+  }
+
+  public List<NotebookCondition> getConditions() {
+    return conditions;
   }
 }

--- a/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/util/NotebookUtils.java
+++ b/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/util/NotebookUtils.java
@@ -50,7 +50,7 @@ public class NotebookUtils {
     PARSE_OPT_DELETE;
   }
 
-  public Notebook parseObject(Object obj, ParseOpt opt) throws SubmarineRuntimeException {
+  public static Notebook parseObject(Object obj, ParseOpt opt) throws SubmarineRuntimeException {
     Gson gson = new JSON().getGson();
     String jsonString = gson.toJson(obj);
     LOG.info("Upstream response JSON: {}", jsonString);
@@ -68,7 +68,7 @@ public class NotebookUtils {
     throw new SubmarineRuntimeException(500, "K8s Submitter parse upstream response failed.");
   }
 
-  public List<Notebook> parseObjectForList(Object object) throws SubmarineRuntimeException {
+  public static List<Notebook> parseObjectForList(Object object) throws SubmarineRuntimeException {
     Gson gson = new JSON().getGson();
     String jsonString = gson.toJson(object);
     LOG.info("Upstream response JSON: {}", jsonString);
@@ -87,7 +87,7 @@ public class NotebookUtils {
     throw new SubmarineRuntimeException(500, "K8s Submitter parse upstream response failed.");
   }
 
-  private Notebook buildNotebookResponse(NotebookCR notebookCR) {
+  private static Notebook buildNotebookResponse(NotebookCR notebookCR) {
     Notebook notebook = new Notebook();
     notebook.setUid(notebookCR.getMetadata().getUid());
     notebook.setName(notebookCR.getMetadata().getName());
@@ -107,7 +107,7 @@ public class NotebookUtils {
     return notebook;
   }
 
-  private Map<String, String> processStatus(NotebookCR notebookCR) {
+  private static Map<String, String> processStatus(NotebookCR notebookCR) {
     Map<String, String> statusMap = new HashMap<>();
     // if the notebook instance is deleted
     if (notebookCR.getMetadata().getDeletionTimestamp() != null) {
@@ -138,14 +138,14 @@ public class NotebookUtils {
     return statusMap;
   }
 
-  public Map<String, String> createStatusMap(String status, String reason) {
+  private static Map<String, String> createStatusMap(String status, String reason) {
     Map<String, String> statusMap = new HashMap<>();
     statusMap.put("status", status);
     statusMap.put("reason", reason);
     return statusMap;
   }
 
-  private Notebook buildNotebookResponseFromStatus(V1Status status) {
+  private static Notebook buildNotebookResponseFromStatus(V1Status status) {
     Notebook notebook = new Notebook();
     if (status.getStatus().toLowerCase().equals("success")) {
       notebook.setStatus(Notebook.Status.STATUS_TERMINATING.toString());

--- a/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/util/NotebookUtils.java
+++ b/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/util/NotebookUtils.java
@@ -112,19 +112,19 @@ public class NotebookUtils {
     // if the notebook instance is deleted
     if (notebookCR.getMetadata().getDeletionTimestamp() != null) {
       statusMap = createStatusMap(Notebook.Status.STATUS_TERMINATING.toString(),
-              "Notebook instance is terminating");
+              "The notebook instance is terminating");
     }
 
-    // Notebook is submitted but its pod is scheduling
     if (notebookCR.getStatus() == null) {
-      statusMap = createStatusMap(Notebook.Status.STATUS_SCHEDULING.toString(),
-              "Pod is scheduling");
+      // if the notebook pod has not been created
+      statusMap = createStatusMap(Notebook.Status.STATUS_CREATING.toString(),
+              "The notebook instance is creating");
     } else {
       // if the notebook instance is ready(Running)
       int replicas = notebookCR.getStatus().getReadyReplicas();
       if (replicas == 1) {
         statusMap = createStatusMap(Notebook.Status.STATUS_RUNNING.toString(),
-                "Notebook instance is running");
+                "The notebook instance is running");
       }
 
       // if the notebook instance is waiting
@@ -149,6 +149,7 @@ public class NotebookUtils {
     Notebook notebook = new Notebook();
     if (status.getStatus().toLowerCase().equals("success")) {
       notebook.setStatus(Notebook.Status.STATUS_TERMINATING.toString());
+      notebook.setReason("The notebook instance is terminating");
     }
 
     if (status.getDetails() != null) {

--- a/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/util/NotebookUtils.java
+++ b/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/util/NotebookUtils.java
@@ -1,0 +1,160 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.submarine.server.submitter.k8s.util;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonSyntaxException;
+import io.kubernetes.client.JSON;
+import io.kubernetes.client.models.V1ContainerState;
+import io.kubernetes.client.models.V1Status;
+import org.apache.submarine.commons.utils.exception.SubmarineRuntimeException;
+import org.apache.submarine.server.api.notebook.Notebook;
+import org.apache.submarine.server.submitter.k8s.model.NotebookCR;
+import org.apache.submarine.server.submitter.k8s.model.NotebookCRList;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Utils for building response of k8s (notebook) submitter
+ */
+public class NotebookUtils {
+
+  private static final Logger LOG = LoggerFactory.getLogger(NotebookUtils.class);
+
+  public enum ParseOpt {
+    PARSE_OPT_CREATE,
+    PARSE_OPT_GET,
+    PARSE_OPT_DELETE;
+  }
+
+  public Notebook parseObject(Object obj, ParseOpt opt) throws SubmarineRuntimeException {
+    Gson gson = new JSON().getGson();
+    String jsonString = gson.toJson(obj);
+    LOG.info("Upstream response JSON: {}", jsonString);
+    try {
+      if (opt == ParseOpt.PARSE_OPT_DELETE) {
+        V1Status status = gson.fromJson(jsonString, V1Status.class);
+        return buildNotebookResponseFromStatus(status);
+      } else {
+        NotebookCR notebookCR = gson.fromJson(jsonString, NotebookCR.class);
+        return buildNotebookResponse(notebookCR);
+      }
+    } catch (JsonSyntaxException e) {
+      LOG.error("K8s submitter: parse response object failed by " + e.getMessage(), e);
+    }
+    throw new SubmarineRuntimeException(500, "K8s Submitter parse upstream response failed.");
+  }
+
+  public List<Notebook> parseObjectForList(Object object) throws SubmarineRuntimeException {
+    Gson gson = new JSON().getGson();
+    String jsonString = gson.toJson(object);
+    LOG.info("Upstream response JSON: {}", jsonString);
+
+    try {
+      List<Notebook> notebookList = new ArrayList<>();
+      NotebookCRList notebookCRList = gson.fromJson(jsonString, NotebookCRList.class);
+      for (NotebookCR notebookCR : notebookCRList.getItems()) {
+        Notebook notebook = buildNotebookResponse(notebookCR);
+        notebookList.add(notebook);
+      }
+      return notebookList;
+    } catch (JsonSyntaxException e) {
+      LOG.error("K8s submitter: parse response object failed by " + e.getMessage(), e);
+    }
+    throw new SubmarineRuntimeException(500, "K8s Submitter parse upstream response failed.");
+  }
+
+  private Notebook buildNotebookResponse(NotebookCR notebookCR) {
+    Notebook notebook = new Notebook();
+    notebook.setUid(notebookCR.getMetadata().getUid());
+    notebook.setName(notebookCR.getMetadata().getName());
+    notebook.setCreatedTime(notebookCR.getMetadata().getCreationTimestamp().toString());
+    // notebook url
+    notebook.setUrl("/notebook/" + notebookCR.getMetadata().getNamespace() + "/" +
+            notebookCR.getMetadata().getName() + "/");
+
+    // process status
+    Map<String, String> statusMap = processStatus(notebookCR);
+    notebook.setStatus(statusMap.get("status"));
+    notebook.setReason(statusMap.get("reason"));
+
+    if (notebookCR.getMetadata().getDeletionTimestamp() != null) {
+      notebook.setDeletedTime(notebookCR.getMetadata().getDeletionTimestamp().toString());
+    }
+    return notebook;
+  }
+
+  private Map<String, String> processStatus(NotebookCR notebookCR) {
+    Map<String, String> statusMap = new HashMap<>();
+    // if the notebook instance is deleted
+    if (notebookCR.getMetadata().getDeletionTimestamp() != null) {
+      statusMap = createStatusMap(Notebook.Status.STATUS_TERMINATING.toString(),
+              "Notebook instance is terminating");
+    }
+
+    // Notebook is submitted but its pod is scheduling
+    if (notebookCR.getStatus() == null) {
+      statusMap = createStatusMap(Notebook.Status.STATUS_SCHEDULING.toString(),
+              "Pod is scheduling");
+    } else {
+      // if the notebook instance is ready(Running)
+      int replicas = notebookCR.getStatus().getReadyReplicas();
+      if (replicas == 1) {
+        statusMap = createStatusMap(Notebook.Status.STATUS_RUNNING.toString(),
+                "Notebook instance is running");
+      }
+
+      // if the notebook instance is waiting
+      V1ContainerState containerState = notebookCR.getStatus().getContainerState();
+      if (containerState.getWaiting() != null) {
+        statusMap = createStatusMap(Notebook.Status.STATUS_WAITING.toString(),
+                containerState.getWaiting().getReason());
+      }
+    }
+
+    return statusMap;
+  }
+
+  public Map<String, String> createStatusMap(String status, String reason) {
+    Map<String, String> statusMap = new HashMap<>();
+    statusMap.put("status", status);
+    statusMap.put("reason", reason);
+    return statusMap;
+  }
+
+  private Notebook buildNotebookResponseFromStatus(V1Status status) {
+    Notebook notebook = new Notebook();
+    if (status.getStatus().toLowerCase().equals("success")) {
+      notebook.setStatus(Notebook.Status.STATUS_TERMINATING.toString());
+    }
+
+    if (status.getDetails() != null) {
+      notebook.setUid(status.getDetails().getUid());
+      notebook.setName(status.getDetails().getName());
+    }
+    return notebook;
+  }
+}

--- a/submarine-test/test-k8s/src/test/java/org/apache/submarine/rest/NotebookRestApiIT.java
+++ b/submarine-test/test-k8s/src/test/java/org/apache/submarine/rest/NotebookRestApiIT.java
@@ -37,7 +37,6 @@ import org.apache.commons.httpclient.methods.PostMethod;
 import org.apache.submarine.server.AbstractSubmarineServerTest;
 import org.apache.submarine.server.api.environment.Environment;
 import org.apache.submarine.server.api.environment.EnvironmentId;
-import org.apache.submarine.server.api.experiment.Experiment;
 import org.apache.submarine.server.api.notebook.Notebook;
 import org.apache.submarine.server.api.notebook.NotebookId;
 import org.apache.submarine.server.gson.EnvironmentIdDeserializer;
@@ -263,7 +262,7 @@ public class NotebookRestApiIT extends AbstractSubmarineServerTest {
   private void verifyCreateNotebookApiResult(Notebook createdNotebook) {
     Assert.assertNotNull(createdNotebook.getUid());
     Assert.assertNotNull(createdNotebook.getCreatedTime());
-    Assert.assertEquals(Experiment.Status.STATUS_CREATED.getValue(), createdNotebook.getStatus());
+    Assert.assertEquals(Notebook.Status.STATUS_CREATING.toString(), createdNotebook.getStatus());
   }
 
   private void verifyGetNotebookApiResult(Notebook createdNotebook,

--- a/submarine-test/test-k8s/src/test/java/org/apache/submarine/rest/NotebookRestApiIT.java
+++ b/submarine-test/test-k8s/src/test/java/org/apache/submarine/rest/NotebookRestApiIT.java
@@ -278,7 +278,7 @@ public class NotebookRestApiIT extends AbstractSubmarineServerTest {
   private void verifyDeleteNotebookApiResult(Notebook createdNotebook,
                                              Notebook deletedNotebook) {
     Assert.assertEquals(createdNotebook.getName(), deletedNotebook.getName());
-    Assert.assertEquals(Notebook.Status.STATUS_DELETED.getValue(), deletedNotebook.getStatus());
+    Assert.assertEquals(Notebook.Status.STATUS_TERMINATING.getValue(), deletedNotebook.getStatus());
     assertDeleteK8sResult(deletedNotebook);
   }
 


### PR DESCRIPTION
### What is this PR for?
1. The notebook REST api will return four states of notebook (creating/waiting/running/terminating) and its reason.

- creating : Users submitted the request to create notebook and its pod haven't been created.
- waiting :  Still running the operations it requires in order to complete start up: for example, pulling the container image.
- running : The container is executing without issues and readyReplicas equals to 1
- terminating : Users submitted the request to delete notebook

2. Refactoring K8sSubmitter
3. Update userdocs/k8s/api/notebook.md

### What type of PR is it?
[Improvement | Documentation | Refactoring]

### Todos
* [@kobe860219  ] - Front-end : Using RxJS to do polling the status of notebook instance and adding spinner when notebook status is creating/waiting.

### What is the Jira issue?
[SUBMARINE-675](https://issues.apache.org/jira/projects/SUBMARINE/issues/SUBMARINE-675)

### How should this be tested?
[Travis CI](https://travis-ci.org/github/lowc1012/submarine/builds/747154671)

### Screenshots (if appropriate)
<img width="1189" alt="image" src="https://user-images.githubusercontent.com/52355146/100850958-8209a480-34bf-11eb-83b3-cef183a893cd.png">

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
