### PR TITLE
SUBMARINE-685. Retain the data in notebook pod even if notebook server is destroyed

### DIFF
--- a/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/parser/NotebookSpecParser.java
+++ b/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/parser/NotebookSpecParser.java
@@ -26,6 +26,8 @@ import io.kubernetes.client.models.V1ObjectMeta;
 import io.kubernetes.client.models.V1PodTemplateSpec;
 import io.kubernetes.client.models.V1PodSpec;
 import io.kubernetes.client.models.V1ResourceRequirements;
+import io.kubernetes.client.models.V1Volume;
+import io.kubernetes.client.models.V1VolumeMount;
 
 import org.apache.submarine.commons.utils.SubmarineConfVars;
 import org.apache.submarine.commons.utils.SubmarineConfiguration;
@@ -132,8 +134,31 @@ public class NotebookSpecParser {
       container.setResources(resources);
     }
 
+    // Volume Mount
+    List<V1VolumeMount> mounts = new ArrayList<>();
+    V1VolumeMount mount = new V1VolumeMount();
+    mount.setMountPath("/home/jovyan/workspace");
+    mount.setName("notebook-pv-" + notebookSpec.getMeta().getName());
+    mounts.add(mount);
+    container.setVolumeMounts(mounts);
+
     containers.add(container);
     podSpec.setContainers(containers);
+
+    // Set Volumes
+    if (podSpec.getVolumes() != null) {
+      V1Volume volume = new V1Volume();
+      String volumeName = "notebook-pv-" + notebookSpec.getMeta().getName();
+      volume.setName(volumeName);
+      podSpec.getVolumes().add(volume);
+    } else {
+      List<V1Volume> volumes = new ArrayList<>();
+      V1Volume volume = new V1Volume();
+      String volumeName = "notebook-pv-" + notebookSpec.getMeta().getName();
+      volume.setName(volumeName);
+      volumes.add(volume);
+      podSpec.setVolumes(volumes);
+    }
 
     podTemplateSpec.setSpec(podSpec);
     return podTemplateSpec;

--- a/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/parser/NotebookSpecParser.java
+++ b/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/parser/NotebookSpecParser.java
@@ -134,31 +134,26 @@ public class NotebookSpecParser {
       container.setResources(resources);
     }
 
-    // Volume Mount
-    List<V1VolumeMount> mounts = new ArrayList<>();
-    V1VolumeMount mount = new V1VolumeMount();
-    mount.setMountPath("/home/jovyan/workspace");
-    mount.setName("notebook-pv-" + notebookSpec.getMeta().getName());
-    mounts.add(mount);
-    container.setVolumeMounts(mounts);
+    // Volume spec
+    final String DEFAULT_MOUNT_PATH = "/home/jovyan/workspace";
+
+    List<V1VolumeMount> volumeMountList = new ArrayList<>();
+    V1VolumeMount  volumeMount = new V1VolumeMount();
+    volumeMount.setMountPath(DEFAULT_MOUNT_PATH);
+    volumeMount.setName("notebook-pv-" + notebookSpec.getMeta().getName());
+    volumeMountList.add(volumeMount);
+    container.setVolumeMounts(volumeMountList);
 
     containers.add(container);
     podSpec.setContainers(containers);
 
-    // Set Volumes
-    if (podSpec.getVolumes() != null) {
-      V1Volume volume = new V1Volume();
-      String volumeName = "notebook-pv-" + notebookSpec.getMeta().getName();
-      volume.setName(volumeName);
-      podSpec.getVolumes().add(volume);
-    } else {
-      List<V1Volume> volumes = new ArrayList<>();
-      V1Volume volume = new V1Volume();
-      String volumeName = "notebook-pv-" + notebookSpec.getMeta().getName();
-      volume.setName(volumeName);
-      volumes.add(volume);
-      podSpec.setVolumes(volumes);
-    }
+    // create volume object for persistent volume
+    List<V1Volume> volumeList = new ArrayList<>();
+    V1Volume volume = new V1Volume();
+    String volumeName = "notebook-pv-" + notebookSpec.getMeta().getName();
+    volume.setName(volumeName);
+    volumeList.add(volume);
+    podSpec.setVolumes(volumeList);
 
     podTemplateSpec.setSpec(podSpec);
     return podTemplateSpec;

--- a/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/util/NotebookUtils.java
+++ b/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/util/NotebookUtils.java
@@ -43,6 +43,10 @@ import org.slf4j.LoggerFactory;
 public class NotebookUtils {
 
   private static final Logger LOG = LoggerFactory.getLogger(NotebookUtils.class);
+  public static final String STORAGE = "10Gi";
+  public static final String PV_PREFIX = "notebook-pv-";
+  public static final String PVC_PREFIX = "notebook-pvc-";
+  public static final String HOST_PATH = "/mnt";
 
   public enum ParseOpt {
     PARSE_OPT_CREATE,

--- a/submarine-test/test-k8s/src/test/java/org/apache/submarine/rest/NotebookRestApiIT.java
+++ b/submarine-test/test-k8s/src/test/java/org/apache/submarine/rest/NotebookRestApiIT.java
@@ -56,6 +56,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.io.FileReader;
 import java.io.IOException;
+import java.lang.Thread;
 import java.util.Date;
 
 @SuppressWarnings("rawtypes")
@@ -188,6 +189,7 @@ public class NotebookRestApiIT extends AbstractSubmarineServerTest {
     Assert.assertEquals(ENV_NAME, getEnvironment.getEnvironmentSpec().getName());
 
     // create notebook instances
+    Thread.sleep(15000);
     LOG.info("Create notebook servers by Notebook REST API");
     String body = loadContent("notebook/notebook-req.json");
     PostMethod postMethod = httpPost(BASE_API_PATH, body,"application/json");
@@ -224,6 +226,7 @@ public class NotebookRestApiIT extends AbstractSubmarineServerTest {
 
   private void runTest(String body, String contentType) throws Exception {
     // create
+    Thread.sleep(15000);
     LOG.info("Create a notebook server by Notebook REST API");
     PostMethod postMethod = httpPost(BASE_API_PATH, body, contentType);
     Assert.assertEquals(Response.Status.OK.getStatusCode(), postMethod.getStatusCode());

--- a/submarine-test/test-k8s/src/test/java/org/apache/submarine/rest/NotebookRestApiIT.java
+++ b/submarine-test/test-k8s/src/test/java/org/apache/submarine/rest/NotebookRestApiIT.java
@@ -188,8 +188,9 @@ public class NotebookRestApiIT extends AbstractSubmarineServerTest {
             gson.fromJson(gson.toJson(jsonResponse.getResult()), Environment.class);
     Assert.assertEquals(ENV_NAME, getEnvironment.getEnvironmentSpec().getName());
 
-    // create notebook instances
+    // waiting for deleting previous persistent volume
     Thread.sleep(15000);
+    // create notebook instances
     LOG.info("Create notebook servers by Notebook REST API");
     String body = loadContent("notebook/notebook-req.json");
     PostMethod postMethod = httpPost(BASE_API_PATH, body,"application/json");
@@ -225,8 +226,9 @@ public class NotebookRestApiIT extends AbstractSubmarineServerTest {
   }
 
   private void runTest(String body, String contentType) throws Exception {
-    // create
+    // waiting for deleting previous persistent volume
     Thread.sleep(15000);
+    // create
     LOG.info("Create a notebook server by Notebook REST API");
     PostMethod postMethod = httpPost(BASE_API_PATH, body, contentType);
     Assert.assertEquals(Response.Status.OK.getStatusCode(), postMethod.getStatusCode());


### PR DESCRIPTION
### What is this PR for?
Add 10GB persistent volume for each notebook which mounting path is /home/jovyan/workspace.
 I use local persistent volume which mounting path of node is /mnt since Submarine do not use any storage class yet.

### What type of PR is it?
[Improvement]

### Todos
* [ ] - Task

### What is the Jira issue?
[SUBMARINE-685](https://issues.apache.org/jira/projects/SUBMARINE/issues/SUBMARINE-685?filter=allopenissues)
### How should this be tested?
[Travis-CI](https://travis-ci.com/github/charlie0220/submarine/builds/210378125)

### Screenshots (if appropriate)
![pv-test](https://user-images.githubusercontent.com/50860453/103065990-e4535200-45f2-11eb-950e-e1290427dc25.gif)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
