### PR TITLE
SUBMARINE-702. Run new server docker image in helm upgrade

### DIFF
--- a/helm-charts/submarine/templates/submarine-server.yaml
+++ b/helm-charts/submarine/templates/submarine-server.yaml
@@ -48,7 +48,8 @@ spec:
     metadata:
       labels:
         run: "{{ .Values.submarine.server.name }}"
-        date: "1234567567"
+      annotations:
+        timestamp: {{ now | quote }}
     spec:
       serviceAccountName: "{{ .Values.submarine.server.name }}"
       containers:

--- a/helm-charts/submarine/templates/submarine-server.yaml
+++ b/helm-charts/submarine/templates/submarine-server.yaml
@@ -48,6 +48,7 @@ spec:
     metadata:
       labels:
         run: "{{ .Values.submarine.server.name }}"
+        date: "1234567567"
     spec:
       serviceAccountName: "{{ .Values.submarine.server.name }}"
       containers:


### PR DESCRIPTION
### What is this PR for?

In backend development, after building a new server image, we need to re-install the whole helm chart. However, installing the chart again is very inefficient. In fact, we only need to apply new docker image in server pod, and we can achieve so by calling helm upgrade.

However, we use the same image name (apache/submarine:server-0.5.0) in each round of docker image building, and `helm upgrade` will not detect the change in image.

Therefore, I add an unique identifier (timestamp) in `submarine-server.yaml` file. Every time we call `helm upgrade`, `submarine-server.yaml` will be different, so it will run the new server image.
```yaml
# submarine-server.yaml
...
template:
    metadata:
      labels:
        run: "{{ .Values.submarine.server.name }}"
      annotations:
        timestamp: {{ now | quote }} # this line
...

# after parsing, it looks like:
metadata:
  annotations:
    timestamp: 2020-12-29 20:54:20.74787 +0800 CST m=+0.907604406
```

By doing so, we can make the backend development faster. We only need to call `helm upgrade submarine` after producing a new server image rather than re-installing the whole chart.

### What type of PR is it?
[Improvement]

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-702

### How should this be tested?


### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? Yes
