### PR TITLE
SUBMARINE-707. Fail to create kind cluster in github action

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -62,7 +62,7 @@ jobs:
               hostPort: 443
               protocol: TCP
           EOF
-      - uses: helm/kind-action@v1.1.0
+      - uses: container-tools/kind-action@v1
         with:
           version: "v0.9.0"
           node_image: kindest/node:v1.15.6

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -62,10 +62,10 @@ jobs:
               hostPort: 443
               protocol: TCP
           EOF
-      - uses: engineerd/setup-kind@v0.5.0
+      - uses: helm/kind-action@v1.1.0
         with:
-          version: "v0.7.0"
-          image: kindest/node:v1.15.6
+          version: "v0.9.0"
+          node_image: kindest/node:v1.15.6
           config: ./kind-config-kind.yaml
       - name: Show K8s cluster information
         run: |


### PR DESCRIPTION
### What is this PR for?
Error message: https://github.com/apache/submarine/actions/runs/477244144
Change to another action that is verified in the GitHub Marketplace.
https://github.com/marketplace/actions/kubernetes-kind-cluster

### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-707

### How should this be tested?
https://travis-ci.org/github/pingsutw/hadoop-submarine/builds/754061414

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
