### PR TITLE
SUBMARINE-714. Store experiment metadata into mysql database

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -27,3 +27,4 @@ indent_size = 4
 [*.java]
 indent_style = space
 max_line_length = 110
+indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -27,4 +27,3 @@ indent_size = 4
 [*.java]
 indent_style = space
 max_line_length = 110
-indent_size = 2

--- a/docs/database/submarine.sql
+++ b/docs/database/submarine.sql
@@ -237,6 +237,20 @@ CREATE TABLE `environment` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 -- ----------------------------
+-- Table structure for experiment
+-- ----------------------------
+DROP TABLE IF EXISTS `experiment`;
+CREATE TABLE `experiment` (
+  `id` varchar(64) NOT NULL COMMENT 'Id of the Experiment',
+  `experiment_spec` text NOT NULL COMMENT 'Spec of the experiment',
+  `create_by` varchar(32) DEFAULT NULL COMMENT 'create user',
+  `create_time` datetime DEFAULT NULL COMMENT 'create time',
+  `update_by` varchar(32) DEFAULT NULL COMMENT 'last update user',
+  `update_time` datetime DEFAULT NULL COMMENT 'last update time',
+   PRIMARY KEY `id` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+-- ----------------------------
 -- Table structure for metric
 -- ----------------------------
 DROP TABLE IF EXISTS `metrics`;

--- a/helm-charts/submarine/templates/submarine-database.yaml
+++ b/helm-charts/submarine/templates/submarine-database.yaml
@@ -28,6 +28,10 @@ spec:
     metadata:
       labels:
         app: "{{ .Values.submarine.database.name }}"
+      {{ if .Values.submarine.database.dev }}
+      annotations:
+        timestamp: {{ now | quote }}
+      {{ end }}
     spec:
       containers:
         - name: "{{ .Values.submarine.database.name }}"

--- a/helm-charts/submarine/templates/submarine-server.yaml
+++ b/helm-charts/submarine/templates/submarine-server.yaml
@@ -48,8 +48,10 @@ spec:
     metadata:
       labels:
         run: "{{ .Values.submarine.server.name }}"
+      {{ if .Values.submarine.server.dev }}
       annotations:
         timestamp: {{ now | quote }}
+      {{ end }}
     spec:
       serviceAccountName: "{{ .Values.submarine.server.name }}"
       containers:

--- a/helm-charts/submarine/values.yaml
+++ b/helm-charts/submarine/values.yaml
@@ -22,6 +22,7 @@ submarine:
     name: submarine-server
     image: apache/submarine:server-0.6.0-SNAPSHOT
     servicePort: 8080
+    dev: false # if true, restart server pod every time at helm upgrade
   database:
     imagePullPolicy: IfNotPresent
     replicas: 1
@@ -29,5 +30,6 @@ submarine:
     image: apache/submarine:database-0.6.0-SNAPSHOT
     servicePort: 3306
     mysqlRootPassword: password
+    dev: true # if true, restart database pod every time at helm upgrade
   traefik:
     enabled: true

--- a/helm-charts/submarine/values.yaml
+++ b/helm-charts/submarine/values.yaml
@@ -30,6 +30,6 @@ submarine:
     image: apache/submarine:database-0.6.0-SNAPSHOT
     servicePort: 3306
     mysqlRootPassword: password
-    dev: true # if true, restart database pod every time at helm upgrade
+    dev: false # if true, restart database pod every time at helm upgrade
   traefik:
     enabled: true

--- a/submarine-server/server-core/src/main/java/org/apache/submarine/server/experiment/ExperimentManager.java
+++ b/submarine-server/server-core/src/main/java/org/apache/submarine/server/experiment/ExperimentManager.java
@@ -105,6 +105,8 @@ public class ExperimentManager {
     spec.getMeta().getEnvVars().remove(RestConstants.JOB_ID);
     spec.getMeta().getEnvVars().remove(RestConstants.SUBMARINE_TRACKING_URI);
     experiment.setSpec(spec);
+
+    // service createExperiment(experimentEntity)
     cachedExperimentMap.putIfAbsent(experiment.getExperimentId().toString(), experiment);
     return experiment;
   }
@@ -131,8 +133,12 @@ public class ExperimentManager {
    * @throws SubmarineRuntimeException the service error
    */
   public Experiment getExperiment(String id) throws SubmarineRuntimeException {
+    // check if experiment is in cache
+    // if not, service getExperiment(id)
     checkExperimentId(id);
     Experiment experiment = cachedExperimentMap.get(id);
+
+
     ExperimentSpec spec = experiment.getSpec();
     Experiment patchExperiment = submitter.findExperiment(spec);
     experiment.rebuild(patchExperiment);

--- a/submarine-server/server-core/src/main/java/org/apache/submarine/server/experiment/database/ExperimentEntity.java
+++ b/submarine-server/server-core/src/main/java/org/apache/submarine/server/experiment/database/ExperimentEntity.java
@@ -29,11 +29,6 @@ public class ExperimentEntity extends BaseEntity {
 
   public ExperimentEntity() {}
 
-  public ExperimentEntity(String id, String experimentSpec) {
-    this.id = id;
-    this.experimentSpec = experimentSpec;
-  }
-
   public String getExperimentSpec() {
     return experimentSpec;
   }

--- a/submarine-server/server-core/src/main/java/org/apache/submarine/server/experiment/database/ExperimentEntity.java
+++ b/submarine-server/server-core/src/main/java/org/apache/submarine/server/experiment/database/ExperimentEntity.java
@@ -1,0 +1,18 @@
+package org.apache.submarine.server.experiment.database;
+
+import org.apache.submarine.server.database.entity.BaseEntity;
+
+public class ExperimentEntity extends BaseEntity {
+  /*
+    Take id (inherited from BaseEntity) as the primary key for experiment table
+  */
+  private String experimentSpec;
+
+  public String getExperimentSpec() {
+    return experimentSpec;
+  }
+
+  public void setExperimentSpec(String experimentSpec) {
+    this.experimentSpec = experimentSpec;
+  }
+}

--- a/submarine-server/server-core/src/main/java/org/apache/submarine/server/experiment/database/ExperimentEntity.java
+++ b/submarine-server/server-core/src/main/java/org/apache/submarine/server/experiment/database/ExperimentEntity.java
@@ -8,6 +8,13 @@ public class ExperimentEntity extends BaseEntity {
   */
   private String experimentSpec;
 
+  public ExperimentEntity() {}
+
+  public ExperimentEntity(String id, String experimentSpec) {
+    this.id = id;
+    this.experimentSpec = experimentSpec;
+  }
+
   public String getExperimentSpec() {
     return experimentSpec;
   }

--- a/submarine-server/server-core/src/main/java/org/apache/submarine/server/experiment/database/ExperimentEntity.java
+++ b/submarine-server/server-core/src/main/java/org/apache/submarine/server/experiment/database/ExperimentEntity.java
@@ -36,4 +36,16 @@ public class ExperimentEntity extends BaseEntity {
   public void setExperimentSpec(String experimentSpec) {
     this.experimentSpec = experimentSpec;
   }
+
+  @Override
+  public String toString() {
+    return "ExperimentEntity{" +
+      "experimentSpec='" + experimentSpec + '\'' +
+      ", id='" + id + '\'' +
+      ", createBy='" + createBy + '\'' +
+      ", createTime=" + createTime +
+      ", updateBy='" + updateBy + '\'' +
+      ", updateTime=" + updateTime +
+      '}';
+  }
 }

--- a/submarine-server/server-core/src/main/java/org/apache/submarine/server/experiment/database/ExperimentEntity.java
+++ b/submarine-server/server-core/src/main/java/org/apache/submarine/server/experiment/database/ExperimentEntity.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.apache.submarine.server.experiment.database;
 
 import org.apache.submarine.server.database.entity.BaseEntity;

--- a/submarine-server/server-core/src/main/java/org/apache/submarine/server/experiment/database/ExperimentMapper.java
+++ b/submarine-server/server-core/src/main/java/org/apache/submarine/server/experiment/database/ExperimentMapper.java
@@ -1,0 +1,12 @@
+package org.apache.submarine.server.experiment.database;
+
+import java.util.List;
+
+public interface ExperimentMapper {
+  List<ExperimentEntity> selectAll();
+  ExperimentEntity select(String id);
+
+  int insert(ExperimentEntity experiment);
+  int update(ExperimentEntity experiment);
+  int delete(String id);
+}

--- a/submarine-server/server-core/src/main/java/org/apache/submarine/server/experiment/database/ExperimentMapper.java
+++ b/submarine-server/server-core/src/main/java/org/apache/submarine/server/experiment/database/ExperimentMapper.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.apache.submarine.server.experiment.database;
 
 import java.util.List;

--- a/submarine-server/server-core/src/main/java/org/apache/submarine/server/experiment/database/ExperimentService.java
+++ b/submarine-server/server-core/src/main/java/org/apache/submarine/server/experiment/database/ExperimentService.java
@@ -46,7 +46,7 @@ public class ExperimentService {
   }
 
   public ExperimentEntity select(String id) throws SubmarineRuntimeException {
-    LOG.info("Experiment select");
+    LOG.info("Experiment select " + id);
     ExperimentEntity entity;
     try (SqlSession sqlSession = MyBatisUtil.getSqlSession()) {
       ExperimentMapper mapper = sqlSession.getMapper(ExperimentMapper.class);
@@ -61,6 +61,8 @@ public class ExperimentService {
 
   public boolean insert(ExperimentEntity experiment) throws SubmarineRuntimeException {
     LOG.info("Experiment insert");
+    LOG.debug(experiment.toString());
+
     try (SqlSession sqlSession = MyBatisUtil.getSqlSession()) {
       ExperimentMapper mapper = sqlSession.getMapper(ExperimentMapper.class);
       mapper.insert(experiment);
@@ -86,7 +88,8 @@ public class ExperimentService {
   }
 
   public boolean delete(String id) throws SubmarineRuntimeException {
-    LOG.info("Experiment delete");
+    LOG.info("Experiment delete " + id);
+
     try (SqlSession sqlSession = MyBatisUtil.getSqlSession()) {
       ExperimentMapper mapper = sqlSession.getMapper(ExperimentMapper.class);
       mapper.delete(id);

--- a/submarine-server/server-core/src/main/java/org/apache/submarine/server/experiment/database/ExperimentService.java
+++ b/submarine-server/server-core/src/main/java/org/apache/submarine/server/experiment/database/ExperimentService.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.apache.submarine.server.experiment.database;
 
 import org.apache.ibatis.session.SqlSession;

--- a/submarine-server/server-core/src/main/java/org/apache/submarine/server/experiment/database/ExperimentService.java
+++ b/submarine-server/server-core/src/main/java/org/apache/submarine/server/experiment/database/ExperimentService.java
@@ -1,0 +1,81 @@
+package org.apache.submarine.server.experiment.database;
+
+import org.apache.ibatis.session.SqlSession;
+import org.apache.submarine.commons.utils.exception.SubmarineRuntimeException;
+import org.apache.submarine.server.database.utils.MyBatisUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+public class ExperimentService {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ExperimentService.class);
+
+  public List<ExperimentEntity> selectAll() throws SubmarineRuntimeException {
+    LOG.info("Experiment selectAll");
+    List<ExperimentEntity> entities;
+    try (SqlSession sqlSession = MyBatisUtil.getSqlSession()) {
+      ExperimentMapper mapper = sqlSession.getMapper(ExperimentMapper.class);
+      entities = mapper.selectAll();
+      sqlSession.commit();
+    } catch (Exception e) {
+      LOG.error(e.getMessage(), e);
+      throw new SubmarineRuntimeException("Unable to get experiment entities from database");
+    }
+    return entities;
+  }
+
+  public ExperimentEntity select(String id) throws SubmarineRuntimeException {
+    LOG.info("Experiment select");
+    ExperimentEntity entity;
+    try (SqlSession sqlSession = MyBatisUtil.getSqlSession()) {
+      ExperimentMapper mapper = sqlSession.getMapper(ExperimentMapper.class);
+      entity = mapper.select(id);
+      sqlSession.commit();
+    } catch (Exception e) {
+      LOG.error(e.getMessage(), e);
+      throw new SubmarineRuntimeException("Unable to get experiment entity from database");
+    }
+    return entity;
+  }
+
+  public boolean insert(ExperimentEntity experiment) throws SubmarineRuntimeException {
+    LOG.info("Experiment insert");
+    try (SqlSession sqlSession = MyBatisUtil.getSqlSession()) {
+      ExperimentMapper mapper = sqlSession.getMapper(ExperimentMapper.class);
+      mapper.insert(experiment);
+      sqlSession.commit();
+    } catch (Exception e) {
+      LOG.error(e.getMessage(), e);
+      throw new SubmarineRuntimeException("Unable to insert experiment entity to database");
+    }
+    return true;
+  }
+
+  public boolean update(ExperimentEntity experiment) throws SubmarineRuntimeException {
+    LOG.info("Experiment update");
+    try (SqlSession sqlSession = MyBatisUtil.getSqlSession()) {
+      ExperimentMapper mapper = sqlSession.getMapper(ExperimentMapper.class);
+      mapper.update(experiment);
+      sqlSession.commit();
+    } catch (Exception e) {
+      LOG.error(e.getMessage(), e);
+      throw new SubmarineRuntimeException("Unable to update experiment entity in database");
+    }
+    return true;
+  }
+
+  public boolean delete(String id) throws SubmarineRuntimeException {
+    LOG.info("Experiment delete");
+    try (SqlSession sqlSession = MyBatisUtil.getSqlSession()) {
+      ExperimentMapper mapper = sqlSession.getMapper(ExperimentMapper.class);
+      mapper.delete(id);
+      sqlSession.commit();
+    } catch (Exception e) {
+      LOG.error(e.getMessage(), e);
+      throw new SubmarineRuntimeException("Unable to delete experiment entity from database");
+    }
+    return true;
+  }
+}

--- a/submarine-server/server-core/src/main/resources/mybatis-config.xml
+++ b/submarine-server/server-core/src/main/resources/mybatis-config.xml
@@ -68,5 +68,6 @@
     <mapper resource='org/apache/submarine/database/mappers/ParamMapper.xml'/>
     <mapper resource='org/apache/submarine/database/mappers/EnvironmentMapper.xml'/>
     <mapper resource='org/apache/submarine/database/mappers/ExperimentTemplateMapper.xml'/>
+    <mapper resource='org/apache/submarine/database/mappers/ExperimentMapper.xml'/>
   </mappers>
 </configuration>

--- a/submarine-server/server-core/src/main/resources/org/apache/submarine/database/mappers/ExperimentMapper.xml
+++ b/submarine-server/server-core/src/main/resources/org/apache/submarine/database/mappers/ExperimentMapper.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="org.apache.submarine.server.experiment.database.ExperimentMapper">
+  <resultMap id="BaseEntityResultMap" type="org.apache.submarine.server.database.entity.BaseEntity">
+    <id property="id" column="id"/>
+    <result column="create_by" property="createBy"/>
+    <result column="create_time" property="createTime"/>
+    <result column="update_by" property="updateBy"/>
+    <result column="update_time" property="updateTime"/>
+  </resultMap>
+
+  <resultMap id="ExperimentEntityResultMap" type="org.apache.submarine.server.experiment.database.ExperimentEntity" extends="BaseEntityResultMap">
+    <result column="experiment_spec" jdbcType="VARCHAR" property="experimentSpec" />
+  </resultMap>
+
+  <sql id="Base_Column_List">
+    id, experiment_spec, create_by, create_time, update_by, update_time
+  </sql>
+
+  <select id="selectAll" parameterType="java.lang.String" resultMap="ExperimentEntityResultMap">
+    select
+    <include refid="Base_Column_List" />
+    from experiment
+  </select>
+
+  <select id="select" parameterType="java.lang.String" resultMap="ExperimentEntityResultMap">
+    select
+    <include refid="Base_Column_List" />
+    from experiment
+    where id = #{id,jdbcType=VARCHAR}
+  </select>
+
+  <delete id="delete" parameterType="java.lang.String">
+    delete from experiment
+    where id = #{id,jdbcType=VARCHAR}
+  </delete>
+
+  <insert id="insert" parameterType="org.apache.submarine.server.experiment.database.ExperimentEntity">
+    insert into experiment (id, experiment_spec, create_by, create_time, update_by, update_time)
+    values (#{id,jdbcType=VARCHAR}, #{experimentSpec,jdbcType=VARCHAR},
+            #{createBy,jdbcType=VARCHAR}, now(), #{updateBy,jdbcType=VARCHAR}, now())
+  </insert>
+
+  <update id="update" parameterType="org.apache.submarine.server.experiment.database.ExperimentEntity">
+    update experiment
+    <set>
+      <if test="experimentSpec != null">
+        experiment_spec = #{experimentSpec,jdbcType=VARCHAR},
+      </if>
+      update_time = now()
+    </set>
+    where id = #{id,jdbcType=VARCHAR}
+  </update>
+
+</mapper>

--- a/submarine-server/server-core/src/test/java/org/apache/submarine/server/experiment/ExperimentManagerTest.java
+++ b/submarine-server/server-core/src/test/java/org/apache/submarine/server/experiment/ExperimentManagerTest.java
@@ -1,0 +1,244 @@
+package org.apache.submarine.server.experiment;
+
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import org.apache.submarine.commons.runtime.exception.SubmarineException;
+import org.apache.submarine.commons.utils.exception.SubmarineRuntimeException;
+import org.apache.submarine.server.api.Submitter;
+import org.apache.submarine.server.api.experiment.Experiment;
+import org.apache.submarine.server.api.experiment.ExperimentId;
+import org.apache.submarine.server.api.spec.ExperimentSpec;
+import org.apache.submarine.server.experiment.database.ExperimentEntity;
+import org.apache.submarine.server.experiment.database.ExperimentService;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.Reader;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+
+public class ExperimentManagerTest {
+  private final Logger LOG = LoggerFactory.getLogger(ExperimentManagerTest.class);
+  private ExperimentManager experimentManager;
+  private Submitter mockSubmitter;
+  private ExperimentService mockService;
+  private String specFile = "/experiment/spec.json";
+  private String newSpecFile = "/experiment/new_spec.json";
+  private String resultFile = "/experiment/result.json";
+  private String statusFile = "/experiment/status.json";
+
+  private ExperimentSpec spec;
+  private ExperimentSpec newSpec;
+  private Experiment result;
+  private Experiment status;
+
+
+  @Before
+  public void init() throws SubmarineException {
+    spec = (ExperimentSpec) buildFromJsonFile(ExperimentSpec.class, specFile);
+    newSpec = (ExperimentSpec) buildFromJsonFile(ExperimentSpec.class, newSpecFile);
+    result = (Experiment) buildFromJsonFile(Experiment.class, resultFile);
+    status = (Experiment) buildFromJsonFile(Experiment.class, statusFile);
+
+    mockSubmitter = mock(Submitter.class);
+    mockService = mock(ExperimentService.class);
+    experimentManager = new ExperimentManager(mockSubmitter, mockService);
+  }
+
+  @Test
+  public void testCreateExperiment() {
+
+    // Create a experimentID for this experiment
+    ExperimentId experimentId = new ExperimentId();
+    experimentId.setServerTimestamp(System.currentTimeMillis());
+    experimentId.setId(1);
+
+    // Construct expected result
+    Experiment expectedExperiment = new Experiment();
+    expectedExperiment.setSpec(spec);
+    expectedExperiment.setExperimentId(experimentId);
+    expectedExperiment.rebuild(result);
+
+    // Spy experimentManager in order to stub generateExperimentId()
+    ExperimentManager spyExperimentManager = spy(experimentManager);
+    doReturn(experimentId).when(spyExperimentManager).generateExperimentId();
+
+    // Stub mockSubmitter createExperiment
+    when(mockSubmitter.createExperiment(any(ExperimentSpec.class))).thenReturn(result);
+
+    // actual experiment should == expected experiment
+    Experiment actualExperiment = spyExperimentManager.createExperiment(spec);
+
+    verifyResult(expectedExperiment, actualExperiment);
+  }
+
+  @Test
+  public void testGetExperiment() {
+
+    // Create the experimentID for this experiment
+    ExperimentId experimentId = new ExperimentId();
+    experimentId.setServerTimestamp(System.currentTimeMillis());
+    experimentId.setId(1);
+
+    // Create the entity
+    ExperimentEntity entity = new ExperimentEntity();
+    entity.setExperimentSpec(toJson(spec));
+    entity.setId(experimentId.toString());
+
+    // Construct expected result
+    Experiment expectedExperiment = new Experiment();
+    expectedExperiment.setSpec(spec);
+    expectedExperiment.setExperimentId(experimentId);
+    expectedExperiment.rebuild(result);
+
+
+    // Stub service select
+    // Pretend there is a entity in db
+    when(mockService.select(any(String.class))).thenReturn(entity);
+
+    // Stub mockSubmitter findExperiment
+    when(mockSubmitter.findExperiment(any(ExperimentSpec.class))).thenReturn(result);
+
+    // get experiment
+    Experiment actualExperiment = experimentManager.getExperiment(experimentId.toString());
+
+    verifyResult(expectedExperiment, actualExperiment);
+  }
+
+  @Test
+  public void testPatchExperiment() {
+
+    // Create the experimentID for this experiment
+    ExperimentId experimentId = new ExperimentId();
+    experimentId.setServerTimestamp(System.currentTimeMillis());
+    experimentId.setId(1);
+
+    // Create the entity
+    ExperimentEntity entity = new ExperimentEntity();
+    entity.setExperimentSpec(toJson(spec));
+    entity.setId(experimentId.toString());
+
+    // Construct expected result
+    Experiment expectedExperiment = new Experiment();
+    expectedExperiment.setSpec(newSpec);
+    expectedExperiment.setExperimentId(experimentId);
+    expectedExperiment.rebuild(result);
+
+
+    // Stub service select
+    // Pretend there is a entity in db
+    when(mockService.select(any(String.class))).thenReturn(entity);
+
+    // Stub mockSubmitter patchExperiment
+    when(mockSubmitter.patchExperiment(any(ExperimentSpec.class))).thenReturn(result);
+
+    // patch experiment
+    Experiment actualExperiment = experimentManager.patchExperiment(experimentId.toString(), newSpec);
+
+    verifyResult(expectedExperiment, actualExperiment);
+  }
+
+  @Test
+  public void testDeleteExperiment() {
+
+    // Create the experimentID for this experiment
+    ExperimentId experimentId = new ExperimentId();
+    experimentId.setServerTimestamp(System.currentTimeMillis());
+    experimentId.setId(1);
+
+    // Create the entity
+    ExperimentEntity entity = new ExperimentEntity();
+    entity.setExperimentSpec(toJson(spec));
+    entity.setId(experimentId.toString());
+
+    // Construct expected result
+    Experiment expectedExperiment = new Experiment();
+    expectedExperiment.setSpec(spec);
+    expectedExperiment.setExperimentId(experimentId);
+    expectedExperiment.rebuild(status);
+
+
+    // Stub service select
+    // Pretend there is a entity in db
+    when(mockService.select(any(String.class))).thenReturn(entity);
+
+    // Stub mockSubmitter deleteExperiment
+    when(mockSubmitter.deleteExperiment(any(ExperimentSpec.class))).thenReturn(status);
+
+    // delete experiment
+    Experiment actualExperiment = experimentManager.deleteExperiment(experimentId.toString());
+
+    verifyResult(expectedExperiment, actualExperiment);
+  }
+
+  @Test(expected = SubmarineRuntimeException.class)
+  public void testGetNotFoundExperiment() {
+    // Create the experimentID for this experiment
+    ExperimentId experimentId = new ExperimentId();
+    experimentId.setServerTimestamp(System.currentTimeMillis());
+    experimentId.setId(1);
+
+    // Stub service select
+    // Pretend that we cannot find the entity
+    when(mockService.select(any(String.class))).thenReturn(null);
+
+    // get experiment
+    experimentManager.getExperiment(experimentId.toString());
+  }
+
+  private void verifyResult(Experiment expected, Experiment actual) {
+    assertEquals(expected.getUid(), actual.getUid());
+    assertEquals(expected.getCreatedTime(), actual.getCreatedTime());
+    assertEquals(expected.getRunningTime(), actual.getRunningTime());
+    assertEquals(expected.getAcceptedTime(), actual.getAcceptedTime());
+    assertEquals(expected.getName(), actual.getName());
+    assertEquals(expected.getStatus(), actual.getStatus());
+    assertEquals(expected.getExperimentId(), actual.getExperimentId());
+    assertEquals(expected.getFinishedTime(), actual.getFinishedTime());
+    assertEquals(expected.getSpec().getMeta().getName(), actual.getSpec().getMeta().getName());
+    assertEquals(expected.getSpec().getMeta().getFramework(), actual.getSpec().getMeta().getFramework());
+    assertEquals(expected.getSpec().getMeta().getNamespace(), actual.getSpec().getMeta().getNamespace());
+    assertEquals(
+        expected.getSpec().getEnvironment().getImage(),
+        actual.getSpec().getEnvironment().getImage())
+    ;
+  }
+
+  private Object buildFromJsonFile(Object obj, String filePath) throws SubmarineException {
+    Gson gson = new GsonBuilder().create();
+    try (Reader reader = Files.newBufferedReader(getCustomJobSpecFile(filePath).toPath(),
+      StandardCharsets.UTF_8)) {
+      if (obj.equals(ExperimentSpec.class)) {
+        return gson.fromJson(reader, ExperimentSpec.class);
+      } else {
+        return gson.fromJson(reader, Experiment.class);
+      }
+    } catch (Exception e) {
+      LOG.error(e.getMessage());
+      throw new SubmarineException(e.getMessage());
+    }
+  }
+
+  private File getCustomJobSpecFile(String path) throws URISyntaxException {
+    URL fileUrl = this.getClass().getResource(path);
+    return new File(fileUrl.toURI());
+  }
+
+  private <T> String toJson(T object) {
+    return new GsonBuilder().disableHtmlEscaping().create().toJson(object);
+  }
+}

--- a/submarine-server/server-core/src/test/java/org/apache/submarine/server/experiment/ExperimentManagerTest.java
+++ b/submarine-server/server-core/src/test/java/org/apache/submarine/server/experiment/ExperimentManagerTest.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.apache.submarine.server.experiment;
 
 

--- a/submarine-server/server-core/src/test/java/org/apache/submarine/server/experiment/database/ExperimentServiceTest.java
+++ b/submarine-server/server-core/src/test/java/org/apache/submarine/server/experiment/database/ExperimentServiceTest.java
@@ -42,94 +42,74 @@ public class ExperimentServiceTest {
 
   @Test
   public void testInsert() throws Exception {
-    try {
-      ExperimentEntity entity = new ExperimentEntity();
-      String id = "experiment_1230";
-      String spec = "{\"value\": 1}";
+    ExperimentEntity entity = new ExperimentEntity();
+    String id = "experiment_1230";
+    String spec = "{\"value\": 1}";
 
-      entity.setId(id);
-      entity.setExperimentSpec(spec);
+    entity.setId(id);
+    entity.setExperimentSpec(spec);
 
-      experimentService.insert(entity);
+    experimentService.insert(entity);
 
-      ExperimentEntity entitySelected = experimentService.select(id);
+    ExperimentEntity entitySelected = experimentService.select(id);
 
-      compareEntity(entity, entitySelected);
-    } catch (Exception e) {
-      LOG.error(e.getMessage(), e);
-      throw new Exception(e);
-    }
+    compareEntity(entity, entitySelected);
   }
 
   @Test
   public void testSelectAll() throws Exception  {
-    try {
-      final int SIZE = 3;
-      List<ExperimentEntity> entities = new ArrayList<ExperimentEntity>();
+    final int SIZE = 3;
+    List<ExperimentEntity> entities = new ArrayList<ExperimentEntity>();
 
-      for (int i = 0; i < SIZE; i++) {
-        ExperimentEntity entity = new ExperimentEntity();
-        entity.setId(String.format("experiment_%d", i));
-        entity.setExperimentSpec(String.format("{\"value\": %d}", i));
-        experimentService.insert(entity);
-        entities.add(entity);
-      }
+    for (int i = 0; i < SIZE; i++) {
+      ExperimentEntity entity = new ExperimentEntity();
+      entity.setId(String.format("experiment_%d", i));
+      entity.setExperimentSpec(String.format("{\"value\": %d}", i));
+      experimentService.insert(entity);
+      entities.add(entity);
+    }
 
-      List<ExperimentEntity> entities_selected = experimentService.selectAll();
+    List<ExperimentEntity> entities_selected = experimentService.selectAll();
 
-      Assert.assertEquals(SIZE, entities_selected.size());
-      for (int i = 0; i < entities_selected.size(); i++) {
-        compareEntity(entities.get(i), entities_selected.get(i));
-      }
-    } catch (Exception e) {
-      LOG.error(e.getMessage(), e);
-      throw new Exception(e);
+    Assert.assertEquals(SIZE, entities_selected.size());
+    for (int i = 0; i < entities_selected.size(); i++) {
+      compareEntity(entities.get(i), entities_selected.get(i));
     }
   };
 
   @Test
   public void testUpdate() throws Exception {
-    try {
-      ExperimentEntity entity = new ExperimentEntity();
-      String id = "experiment_1230";
-      String spec = "{\"value\": 1}";
-      entity.setId(id);
-      entity.setExperimentSpec(spec);
-      experimentService.insert(entity);
+    ExperimentEntity entity = new ExperimentEntity();
+    String id = "experiment_1230";
+    String spec = "{\"value\": 1}";
+    entity.setId(id);
+    entity.setExperimentSpec(spec);
+    experimentService.insert(entity);
 
-      String new_spec = "{\"value\": 2}";
-      entity.setExperimentSpec(new_spec);
-      experimentService.update(entity);
+    String new_spec = "{\"value\": 2}";
+    entity.setExperimentSpec(new_spec);
+    experimentService.update(entity);
 
-      ExperimentEntity entitySelected = experimentService.select(id);
-      compareEntity(entity, entitySelected);
-    } catch (Exception e) {
-      LOG.error(e.getMessage(), e);
-      throw new Exception(e);
-    }
+    ExperimentEntity entitySelected = experimentService.select(id);
+    compareEntity(entity, entitySelected);
   };
 
   @Test
   public void testDelete() throws Exception {
-    try {
-      ExperimentEntity entity = new ExperimentEntity();
-      String id = "experiment_1230";
-      String spec = "{\"value\": 1}";
+    ExperimentEntity entity = new ExperimentEntity();
+    String id = "experiment_1230";
+    String spec = "{\"value\": 1}";
 
-      entity.setId(id);
-      entity.setExperimentSpec(spec);
+    entity.setId(id);
+    entity.setExperimentSpec(spec);
 
-      experimentService.insert(entity);
+    experimentService.insert(entity);
 
-      experimentService.delete(id);
+    experimentService.delete(id);
 
-      List<ExperimentEntity> entitySelected = experimentService.selectAll();
+    List<ExperimentEntity> entitySelected = experimentService.selectAll();
 
-      Assert.assertEquals(0, entitySelected.size());
-    } catch (Exception e) {
-      LOG.error(e.getMessage(), e);
-      throw new Exception(e);
-    }
+    Assert.assertEquals(0, entitySelected.size());
   };
 
   private void compareEntity(ExperimentEntity expected, ExperimentEntity actual) {

--- a/submarine-server/server-core/src/test/java/org/apache/submarine/server/experiment/database/ExperimentServiceTest.java
+++ b/submarine-server/server-core/src/test/java/org/apache/submarine/server/experiment/database/ExperimentServiceTest.java
@@ -1,0 +1,120 @@
+package org.apache.submarine.server.experiment.database;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ExperimentServiceTest {
+  private static final Logger LOG = LoggerFactory.getLogger(ExperimentServiceTest.class);
+  ExperimentService experimentService = new ExperimentService();
+
+  @After
+  public void cleanExperimentTable() throws Exception {
+    List<ExperimentEntity> entities = experimentService.selectAll();
+    for (ExperimentEntity entity: entities) {
+      experimentService.delete(entity.getId());
+    }
+  }
+
+  @Test
+  public void testInsert() throws Exception {
+    try {
+      ExperimentEntity entity = new ExperimentEntity();
+      String id = "experiment_1230";
+      String spec = "{\"value\": 1}";
+
+      entity.setId(id);
+      entity.setExperimentSpec(spec);
+
+      experimentService.insert(entity);
+
+      ExperimentEntity entitySelected = experimentService.select(id);
+
+      compareEntity(entity, entitySelected);
+    } catch (Exception e) {
+      LOG.error(e.getMessage(), e);
+      throw new Exception(e);
+    }
+  }
+
+  @Test
+  public void testSelectAll() throws Exception  {
+    try {
+      final int SIZE = 3;
+      List<ExperimentEntity> entities = new ArrayList<ExperimentEntity>();
+
+      for (int i = 0; i < SIZE; i++) {
+        ExperimentEntity entity = new ExperimentEntity();
+        entity.setId(String.format("experiment_%d", i));
+        entity.setExperimentSpec(String.format("{\"value\": %d}", i));
+        experimentService.insert(entity);
+        entities.add(entity);
+      }
+
+      List<ExperimentEntity> entities_selected = experimentService.selectAll();
+
+      Assert.assertEquals(SIZE, entities_selected.size());
+      for (int i = 0; i < entities_selected.size(); i++) {
+        compareEntity(entities.get(i), entities_selected.get(i));
+      }
+    } catch (Exception e) {
+      LOG.error(e.getMessage(), e);
+      throw new Exception(e);
+    }
+  };
+
+  @Test
+  public void testUpdate() throws Exception {
+    try {
+      ExperimentEntity entity = new ExperimentEntity();
+      String id = "experiment_1230";
+      String spec = "{\"value\": 1}";
+      entity.setId(id);
+      entity.setExperimentSpec(spec);
+      experimentService.insert(entity);
+
+      String new_spec = "{\"value\": 2}";
+      entity.setExperimentSpec(new_spec);
+      experimentService.update(entity);
+
+      ExperimentEntity entitySelected = experimentService.select(id);
+      compareEntity(entity, entitySelected);
+    } catch (Exception e) {
+      LOG.error(e.getMessage(), e);
+      throw new Exception(e);
+    }
+  };
+
+  @Test
+  public void testDelete() throws Exception {
+    try {
+      ExperimentEntity entity = new ExperimentEntity();
+      String id = "experiment_1230";
+      String spec = "{\"value\": 1}";
+
+      entity.setId(id);
+      entity.setExperimentSpec(spec);
+
+      experimentService.insert(entity);
+
+      experimentService.delete(id);
+
+      List<ExperimentEntity> entitySelected = experimentService.selectAll();
+
+      Assert.assertEquals(0, entitySelected.size());
+    } catch (Exception e) {
+      LOG.error(e.getMessage(), e);
+      throw new Exception(e);
+    }
+  };
+
+  private void compareEntity(ExperimentEntity expected, ExperimentEntity actual) {
+    Assert.assertEquals(expected.getId(), actual.getId());
+    Assert.assertEquals(expected.getExperimentSpec(), actual.getExperimentSpec());
+  }
+}

--- a/submarine-server/server-core/src/test/java/org/apache/submarine/server/experiment/database/ExperimentServiceTest.java
+++ b/submarine-server/server-core/src/test/java/org/apache/submarine/server/experiment/database/ExperimentServiceTest.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.apache.submarine.server.experiment.database;
 
 import org.junit.After;

--- a/submarine-server/server-core/src/test/resources/experiment/new_spec.json
+++ b/submarine-server/server-core/src/test/resources/experiment/new_spec.json
@@ -1,0 +1,20 @@
+{
+  "meta": {
+    "name": "tensorflow-dist-mnist-new",
+    "namespace": "submarine",
+    "framework": "TensorFlow",
+    "cmd": "python /var/tf_mnist/mnist_with_summaries.py --log_dir=/train/log --learning_rate=0.01 --batch_size=150",
+    "envVars": {
+      "ENV_1": "ENV_1"
+    }
+  },
+  "environment": {
+    "image": "apache/submarine:tf-mnist-with-summaries-1.0"
+  },
+  "spec": {
+    "Worker": {
+      "replicas": 1,
+      "resources": "cpu=1,memory=1024M"
+    }
+  }
+}

--- a/submarine-server/server-core/src/test/resources/experiment/result.json
+++ b/submarine-server/server-core/src/test/resources/experiment/result.json
@@ -1,0 +1,7 @@
+{
+  "name":"tensorflow-dist-mnist",
+  "uid":"c9f6bf7a-5bc2-11eb-8f96-0242a5374496",
+  "status":"Created",
+  "acceptedTime":"2021-01-21T16:29:33.000+08:00",
+  "createdTime":"2021-01-21T16:29:33.000+08:00"
+}

--- a/submarine-server/server-core/src/test/resources/experiment/spec.json
+++ b/submarine-server/server-core/src/test/resources/experiment/spec.json
@@ -1,0 +1,20 @@
+{
+  "meta": {
+    "name": "tensorflow-dist-mnist",
+    "namespace": "submarine",
+    "framework": "TensorFlow",
+    "cmd": "python /var/tf_mnist/mnist_with_summaries.py --log_dir=/train/log --learning_rate=0.01 --batch_size=150",
+    "envVars": {
+      "ENV_1": "ENV1"
+    }
+  },
+  "environment": {
+    "image": "apache/submarine:tf-mnist-with-summaries-1.0"
+  },
+  "spec": {
+    "Worker": {
+      "replicas": 1,
+      "resources": "cpu=1,memory=1024M"
+    }
+  }
+}

--- a/submarine-server/server-core/src/test/resources/experiment/status.json
+++ b/submarine-server/server-core/src/test/resources/experiment/status.json
@@ -1,0 +1,5 @@
+{
+  "name":"tensorflow-dist-mnist",
+  "uid":"c9f6bf7a-5bc2-11eb-8f96-0242a5374496",
+  "status":"Deleted"
+}


### PR DESCRIPTION
### What is this PR for?
In the past, we temporarily stored experiment metadata in memory. However, it is not persistent, when we restart the server, the data will be lost. Alternatively, we should store it in MySQL database.

### What type of PR is it?
[Improvement]

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-714

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
