### PR TITLE
SUBMARINE-719. Remove redundant swagger API calls.

### DIFF
--- a/submarine-server/server-core/src/main/java/org/apache/submarine/server/Bootstrap.java
+++ b/submarine-server/server-core/src/main/java/org/apache/submarine/server/Bootstrap.java
@@ -41,9 +41,10 @@ public class Bootstrap extends HttpServlet {
 
     OpenAPI oas = new OpenAPI();
     Info info = new Info()
-             .title("Submarine Experiment API")
-             .description("The Submarine REST API allows you to create, list, and get experiments. The\n" +
-                     "API is hosted under the /v1/experiment route on the Submarine server. For example,\n" +
+             .title("Submarine API")
+             .description("The Submarine REST API allows you to access Submarine resources such as, \n" +
+                     "experiments, environments and notebooks. The \n" +
+                     "API is hosted under the /v1 path on the Submarine server. For example, \n" +
                      "to list experiments on a server hosted at http://localhost:8080, access\n" +
                      "http://localhost:8080/api/v1/experiment/")
              .termsOfService("http://swagger.io/terms/")
@@ -59,41 +60,14 @@ public class Bootstrap extends HttpServlet {
     servers.add(new Server().url("/api"));
     oas.servers(servers);
 
-    OpenAPI oasEnvironment = new OpenAPI();
-    Info infoEnvironment = new Info().title("Submarine Environment API")
-        .description("The Submarine REST API allows you to create, update, "
-            + "delete, get and list environments\n. The API is hosted under "
-            + "the /v1/environment route on the Submarine server.\n "
-            + "For example, to list experiments on a server hosted at "
-            + "http://localhost:8080, access http://localhost:8080/api/v1/"
-            + "environment/")
-        .termsOfService("http://swagger.io/terms/")
-        .contact(
-            new Contact().email("dev@submarine.apache.org"))
-        .version("0.6.0-SNAPSHOT")
-        .license(
-            new License().name("Apache 2.0").
-            url("http://www.apache.org/licenses/LICENSE-2.0.html"));
-
-    oasEnvironment.info(infoEnvironment);
-    oasEnvironment.servers(servers);
-
     SwaggerConfiguration oasConfig = new SwaggerConfiguration()
             .openAPI(oas)
             .resourcePackages(Stream.of("org.apache.submarine.server.rest").collect(Collectors.toSet()));
 
-    SwaggerConfiguration oasConfigEnvironment =
-        new SwaggerConfiguration().openAPI(oasEnvironment)
-            .resourcePackages(Stream.of("org.apache.submarine.server.rest")
-                .collect(Collectors.toSet()));
     try {
       new JaxrsOpenApiContextBuilder()
               .servletConfig(config)
               .openApiConfiguration(oasConfig)
-              .buildContext(true);
-      new JaxrsOpenApiContextBuilder()
-              .servletConfig(config)
-              .openApiConfiguration(oasConfigEnvironment)
               .buildContext(true);
     } catch (OpenApiConfigurationException e) {
       throw new ServletException(e.getMessage(), e);


### PR DESCRIPTION
### What is this PR for?

The swagger Bootstrap.java instantiates two sets of same swagger rest end points. I believe this is redundant. Open this PR to test.

### What type of PR is it?
Improvement

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-719

### How should this be tested?
* First time? Setup Travis CI as described on https://submarine.apache.org/contribution/contributions.html#continuous-integration
* Strongly recommended: add automated unit tests for any new or changed behavior
* Outline any manual steps to test the PR here.

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? Yes/No
* Is there breaking changes for older versions? Yes/No
* Does this needs documentation? Yes/No
