### PR TITLE
SUBMARINE-726. Run qlib workflow in the notebook

### DIFF
--- a/dev-support/docker-images/jupyter/Dockerfile
+++ b/dev-support/docker-images/jupyter/Dockerfile
@@ -96,11 +96,18 @@ RUN git clone https://github.com/apache/submarine && \
     pip install submarine/submarine-sdk/pysubmarine && \
     conda install nodejs && \
     conda install -c conda-forge jupyterlab jupyterlab-git && \
-    jupyter lab build && \
-    cp submarine/submarine-sdk/pysubmarine/example/submarine_experiment_sdk.ipynb $HOME && \
+    jupyter lab build
+
+# Add DeepFM example into notebook
+RUN cp submarine/submarine-sdk/pysubmarine/example/submarine_experiment_sdk.ipynb $HOME && \
     cp -r submarine/submarine-sdk/pysubmarine/example/{data,deepfm_example.ipynb,deepfm.json} $HOME && \
     rm submarine -rf
 
+# Install latest stable qlib
+RUN pip install numpy==1.19.5 pyqlib==0.6.1
+
+# Add qlib example in notebook
+RUN wget https://raw.githubusercontent.com/microsoft/qlib/main/examples/workflow_by_code.ipynb -P $HOME
 
 
 EXPOSE $NB_PORT


### PR DESCRIPTION
### What is this PR for?
Add a qlib example in jupyter notebook, so that users can directly run a qlib workflow when creating a notebook.

qlib example:
https://github.com/microsoft/qlib/blob/main/examples/workflow_by_code.ipynb
https://colab.research.google.com/github/microsoft/qlib/blob/main/examples/workflow_by_code.ipynb#scrollTo=t1kkNKGi3Lle

**Note**:
Currently, we don't support install pip package in the environment, so I pre-installed `pyqlib` in docker images. 
We only can install python packages that are in the conda channel. 

### What type of PR is it?
[Feature]

### Todos
* [ ] - Suppoprt pip install in Submarine Environment

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-726

### How should this be tested?
https://www.travis-ci.com/github/pingsutw/hadoop-submarine/builds/215961270

### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/37936015/106873396-463eb700-6689-11eb-917b-19e365fd9cb6.png)

### Questions:
* Does the license files need an update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
