### PR TITLE
SUBMARINE-732. Wrap tensorboard logdir into an environment variable

### DIFF
--- a/submarine-server/server-core/src/main/java/org/apache/submarine/server/experiment/ExperimentManager.java
+++ b/submarine-server/server-core/src/main/java/org/apache/submarine/server/experiment/ExperimentManager.java
@@ -105,6 +105,8 @@ public class ExperimentManager {
     String url = getSQLAlchemyURL();
     spec.getMeta().getEnvVars().put(RestConstants.JOB_ID, id.toString());
     spec.getMeta().getEnvVars().put(RestConstants.SUBMARINE_TRACKING_URI, url);
+    spec.getMeta().getEnvVars().put(RestConstants.LOG_DIR_KEY, RestConstants.LOG_DIR_VALUE);
+    
     String lowerName = spec.getMeta().getName().toLowerCase();
     spec.getMeta().setName(lowerName);
 
@@ -113,6 +115,8 @@ public class ExperimentManager {
 
     spec.getMeta().getEnvVars().remove(RestConstants.JOB_ID);
     spec.getMeta().getEnvVars().remove(RestConstants.SUBMARINE_TRACKING_URI);
+    spec.getMeta().getEnvVars().remove(RestConstants.LOG_DIR_KEY);
+
     experiment.setSpec(spec);
 
     ExperimentEntity entity = buildEntityFromExperiment(experiment);

--- a/submarine-server/server-core/src/main/java/org/apache/submarine/server/rest/RestConstants.java
+++ b/submarine-server/server-core/src/main/java/org/apache/submarine/server/rest/RestConstants.java
@@ -70,4 +70,10 @@ public class RestConstants {
 
   public static final String NOTEBOOK_ID = "id";
 
+  /**
+   * Tensorboard
+   */
+  public static final String LOG_DIR_KEY = "LOG_DIR";
+  public static final String LOG_DIR_VALUE = "/logs/mylog";
+
 }

--- a/submarine-server/server-core/src/main/java/org/apache/submarine/server/rest/RestConstants.java
+++ b/submarine-server/server-core/src/main/java/org/apache/submarine/server/rest/RestConstants.java
@@ -73,7 +73,7 @@ public class RestConstants {
   /**
    * Tensorboard
    */
-  public static final String LOG_DIR_KEY = "LOG_DIR";
+  public static final String LOG_DIR_KEY = "SUBMARINE_LOG_DIR";
   public static final String LOG_DIR_VALUE = "/logs/mylog";
 
 }

--- a/submarine-server/server-core/src/main/java/org/apache/submarine/server/rest/RestConstants.java
+++ b/submarine-server/server-core/src/main/java/org/apache/submarine/server/rest/RestConstants.java
@@ -73,7 +73,7 @@ public class RestConstants {
   /**
    * Tensorboard
    */
-  public static final String LOG_DIR_KEY = "SUBMARINE_LOG_DIR";
+  public static final String LOG_DIR_KEY = "SUBMARINE_TENSORBOARD_LOG_DIR";
   public static final String LOG_DIR_VALUE = "/logs/mylog";
 
 }


### PR DESCRIPTION
### What is this PR for?
It is inconvenient for users to manually specify the tensorboard logdir every time, so I wrap the real logdir path into an env variable (SUBMARINE_LOG_DIR). 
The usage is as the following:

```json
  "meta": {
    "name": "tensorflow-tensorboard-dist-mnist-13",
    "namespace": "default",
    "framework": "TensorFlow",
    "cmd": "python /var/tf_mnist/mnist_with_summaries.py --log_dir=$(SUBMARINE_LOG_DIR) --learning_rate=0.01 --batch_size=20",
    "envVars": {
      "ENV_1": "ENV1"
    }
  },
```

### What type of PR is it?
[Improvement]

### Todos
* [ ] - Tensorboard user doc

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-732

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? Yes
