### PR TITLE
SUBMARINE-729. Blank Page after redirect

### DIFF
--- a/submarine-workbench/workbench-web/src/app/pages/workbench/workbench.component.html
+++ b/submarine-workbench/workbench-web/src/app/pages/workbench/workbench.component.html
@@ -26,7 +26,7 @@
   [nzTrigger]="null"
 >
   <div class="sidebar-logo">
-    <a routerLink="/workbench/dashboard" target="_blank">
+    <a routerLink="/workbench/experiment">
       <img src="/assets/logo.png" alt="logo" />
       <h1>Submarine</h1>
     </a>


### PR DESCRIPTION
### What is this PR for?
Fix the problem of redirecting to a blank page when clicking the submarine icon on the workbench.
Now it will redirect to experiment page.


### What type of PR is it?
[Bug Fix]

### Todos

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-729

### How should this be tested?
https://travis-ci.org/github/kobe860219/submarine/builds/757821165

### Screenshots (if appropriate)
![SUBMARINE-729](https://user-images.githubusercontent.com/48027290/107121636-82168e00-68ce-11eb-9732-81b914ebb6b7.gif)


### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions?No
* Does this needs documentation? No
