### PR TITLE
SUBMARINE-737. Fix router link in e2e test

### DIFF
--- a/submarine-test/test-e2e/src/test/java/org/apache/submarine/integration/dataIT.java
+++ b/submarine-test/test-e2e/src/test/java/org/apache/submarine/integration/dataIT.java
@@ -53,7 +53,7 @@ public class dataIT extends AbstractSubmarineIT {
     pollingWait(By.cssSelector("input[ng-reflect-name='userName']"), MAX_BROWSER_TIMEOUT_SEC).sendKeys("admin");
     pollingWait(By.cssSelector("input[ng-reflect-name='password']"), MAX_BROWSER_TIMEOUT_SEC).sendKeys("admin");
     clickAndWait(By.cssSelector("button[class='login-form-button ant-btn ant-btn-primary']"));
-    pollingWait(By.cssSelector("a[routerlink='/workbench/dashboard']"), MAX_BROWSER_TIMEOUT_SEC);
+    pollingWait(By.cssSelector("a[routerlink='/workbench/experiment']"), MAX_BROWSER_TIMEOUT_SEC);
 
     // Routing to data page
     pollingWait(By.xpath("//span[contains(text(), \"Data\")]"), MAX_BROWSER_TIMEOUT_SEC).click();

--- a/submarine-test/test-e2e/src/test/java/org/apache/submarine/integration/datadictIT.java
+++ b/submarine-test/test-e2e/src/test/java/org/apache/submarine/integration/datadictIT.java
@@ -50,7 +50,7 @@ public class datadictIT extends AbstractSubmarineIT {
     pollingWait(By.cssSelector("input[ng-reflect-name='userName']"), MAX_BROWSER_TIMEOUT_SEC).sendKeys("admin");
     pollingWait(By.cssSelector("input[ng-reflect-name='password']"), MAX_BROWSER_TIMEOUT_SEC).sendKeys("admin");
     clickAndWait(By.cssSelector("button[class='login-form-button ant-btn ant-btn-primary']"));
-    pollingWait(By.cssSelector("a[routerlink='/workbench/dashboard']"), MAX_BROWSER_TIMEOUT_SEC);
+    pollingWait(By.cssSelector("a[routerlink='/workbench/experiment']"), MAX_BROWSER_TIMEOUT_SEC);
 
     // Start Routing & Navigation in data-dict
     LOG.info("Start Routing & Navigation in data-dict");

--- a/submarine-test/test-e2e/src/test/java/org/apache/submarine/integration/departmentIT.java
+++ b/submarine-test/test-e2e/src/test/java/org/apache/submarine/integration/departmentIT.java
@@ -51,7 +51,7 @@ public class departmentIT extends AbstractSubmarineIT{
     pollingWait(By.cssSelector("input[ng-reflect-name='userName']"), MAX_BROWSER_TIMEOUT_SEC).sendKeys("admin");
     pollingWait(By.cssSelector("input[ng-reflect-name='password']"), MAX_BROWSER_TIMEOUT_SEC).sendKeys("admin");
     clickAndWait(By.cssSelector("button[class='login-form-button ant-btn ant-btn-primary']"));
-    pollingWait(By.cssSelector("a[routerlink='/workbench/experimnt']"), MAX_BROWSER_TIMEOUT_SEC);
+    pollingWait(By.cssSelector("a[routerlink='/workbench/experiment']"), MAX_BROWSER_TIMEOUT_SEC);
 
     // Routing to department page
     pollingWait(By.xpath("//span[contains(text(), \"Manager\")]"), MAX_BROWSER_TIMEOUT_SEC).click();

--- a/submarine-test/test-e2e/src/test/java/org/apache/submarine/integration/departmentIT.java
+++ b/submarine-test/test-e2e/src/test/java/org/apache/submarine/integration/departmentIT.java
@@ -51,7 +51,7 @@ public class departmentIT extends AbstractSubmarineIT{
     pollingWait(By.cssSelector("input[ng-reflect-name='userName']"), MAX_BROWSER_TIMEOUT_SEC).sendKeys("admin");
     pollingWait(By.cssSelector("input[ng-reflect-name='password']"), MAX_BROWSER_TIMEOUT_SEC).sendKeys("admin");
     clickAndWait(By.cssSelector("button[class='login-form-button ant-btn ant-btn-primary']"));
-    pollingWait(By.cssSelector("a[routerlink='/workbench/dashboard']"), MAX_BROWSER_TIMEOUT_SEC);
+    pollingWait(By.cssSelector("a[routerlink='/workbench/experimnt']"), MAX_BROWSER_TIMEOUT_SEC);
 
     // Routing to department page
     pollingWait(By.xpath("//span[contains(text(), \"Manager\")]"), MAX_BROWSER_TIMEOUT_SEC).click();

--- a/submarine-test/test-e2e/src/test/java/org/apache/submarine/integration/environmentIT.java
+++ b/submarine-test/test-e2e/src/test/java/org/apache/submarine/integration/environmentIT.java
@@ -44,7 +44,7 @@ public class environmentIT extends AbstractSubmarineIT {
   }
 
   @Test
-  public void experimentNavigation() throws Exception {
+  public void environmentNavigation() throws Exception {
     // Login
     LOG.info("Login");
     pollingWait(By.cssSelector("input[ng-reflect-name='userName']"), MAX_BROWSER_TIMEOUT_SEC).sendKeys("admin");
@@ -59,8 +59,7 @@ public class environmentIT extends AbstractSubmarineIT {
 
     // Test create new environment
     LOG.info("Create new environment");
-    pollingWait(By.xpath("//button[@id='btn-newEnvironment']"), MAX_BROWSER_TIMEOUT_SEC).click();
-    pollingWait(By.xpath("//button[@id='btn-cancel']"), MAX_BROWSER_TIMEOUT_SEC).click();
+    Assert.assertEquals(pollingWait(By.xpath("//button[@id='btn-newEnvironment']"), MAX_BROWSER_TIMEOUT_SEC).isDisplayed(), true);
     pollingWait(By.xpath("//button[@id='btn-newEnvironment']"), MAX_BROWSER_TIMEOUT_SEC).click();
     pollingWait(By.cssSelector("input[ng-reflect-name='environmentName']"), MAX_BROWSER_TIMEOUT_SEC).sendKeys("testEnvName");
     pollingWait(By.cssSelector("input[ng-reflect-name='dockerImage']"), MAX_BROWSER_TIMEOUT_SEC).sendKeys("testDockerImage");
@@ -69,8 +68,9 @@ public class environmentIT extends AbstractSubmarineIT {
     pollingWait(By.xpath("//input[@id='channel0']"), MAX_BROWSER_TIMEOUT_SEC).sendKeys("testChannel");
     pollingWait(By.xpath("//button[@id='addDep-btn']"), MAX_BROWSER_TIMEOUT_SEC).click();
     pollingWait(By.xpath("//input[@id='dependencies0']"), MAX_BROWSER_TIMEOUT_SEC).sendKeys("testDep");
+    Assert.assertEquals(pollingWait(By.xpath("//button[@id='btn-submit']"), MAX_BROWSER_TIMEOUT_SEC).isDisplayed(), true);
     pollingWait(By.xpath("//button[@id='btn-submit']"), MAX_BROWSER_TIMEOUT_SEC).click();
-    Assert.assertEquals(pollingWait(By.xpath("//td[contains(., 'testEnvName')]"), MAX_BROWSER_TIMEOUT_SEC).isDisplayed(), true);
-    LOG.info("Environment created.");
+    Assert.assertEquals(pollingWait(By.xpath("//button[@id='btn-newEnvironment']"), MAX_BROWSER_TIMEOUT_SEC).isDisplayed(), true);
+    LOG.info("Test done.");
   }
 }

--- a/submarine-test/test-e2e/src/test/java/org/apache/submarine/integration/environmentIT.java
+++ b/submarine-test/test-e2e/src/test/java/org/apache/submarine/integration/environmentIT.java
@@ -50,7 +50,7 @@ public class environmentIT extends AbstractSubmarineIT {
     pollingWait(By.cssSelector("input[ng-reflect-name='userName']"), MAX_BROWSER_TIMEOUT_SEC).sendKeys("admin");
     pollingWait(By.cssSelector("input[ng-reflect-name='password']"), MAX_BROWSER_TIMEOUT_SEC).sendKeys("admin");
     clickAndWait(By.cssSelector("button[class='login-form-button ant-btn ant-btn-primary']"));
-    pollingWait(By.cssSelector("a[routerlink='/workbench/dashboard']"), MAX_BROWSER_TIMEOUT_SEC);
+    pollingWait(By.cssSelector("a[routerlink='/workbench/experiment']"), MAX_BROWSER_TIMEOUT_SEC);
 
     // Routing to workspace
     LOG.info("url");
@@ -71,6 +71,6 @@ public class environmentIT extends AbstractSubmarineIT {
     pollingWait(By.xpath("//input[@id='dependencies0']"), MAX_BROWSER_TIMEOUT_SEC).sendKeys("testDep");
     pollingWait(By.xpath("//button[@id='btn-submit']"), MAX_BROWSER_TIMEOUT_SEC).click();
     Assert.assertEquals(pollingWait(By.xpath("//td[contains(., 'testEnvName')]"), MAX_BROWSER_TIMEOUT_SEC).isDisplayed(), true);
-    Thread.sleep(2000);
+    LOG.info("Environment created.");
   }
 }

--- a/submarine-test/test-e2e/src/test/java/org/apache/submarine/integration/experimentIT.java
+++ b/submarine-test/test-e2e/src/test/java/org/apache/submarine/integration/experimentIT.java
@@ -53,7 +53,7 @@ public class experimentIT extends AbstractSubmarineIT {
     pollingWait(By.cssSelector("input[ng-reflect-name='userName']"), MAX_BROWSER_TIMEOUT_SEC).sendKeys("admin");
     pollingWait(By.cssSelector("input[ng-reflect-name='password']"), MAX_BROWSER_TIMEOUT_SEC).sendKeys("admin");
     clickAndWait(By.cssSelector("button[class='login-form-button ant-btn ant-btn-primary']"));
-    pollingWait(By.cssSelector("a[routerlink='/workbench/dashboard']"), MAX_BROWSER_TIMEOUT_SEC);
+    pollingWait(By.cssSelector("a[routerlink='/workbench/experiment']"), MAX_BROWSER_TIMEOUT_SEC);
 
     // Routing to workspace
     LOG.info("url");

--- a/submarine-test/test-e2e/src/test/java/org/apache/submarine/integration/homeIT.java
+++ b/submarine-test/test-e2e/src/test/java/org/apache/submarine/integration/homeIT.java
@@ -53,7 +53,7 @@ public class homeIT extends AbstractSubmarineIT {
     pollingWait(By.cssSelector("input[ng-reflect-name='userName']"), MAX_BROWSER_TIMEOUT_SEC).sendKeys("admin");
     pollingWait(By.cssSelector("input[ng-reflect-name='password']"), MAX_BROWSER_TIMEOUT_SEC).sendKeys("admin");
     clickAndWait(By.cssSelector("button[class='login-form-button ant-btn ant-btn-primary']"));
-    pollingWait(By.cssSelector("a[routerlink='/workbench/dashboard']"), MAX_BROWSER_TIMEOUT_SEC);
+    pollingWait(By.cssSelector("a[routerlink='/workbench/experiment']"), MAX_BROWSER_TIMEOUT_SEC);
 
     LOG.info("Pagination");
     List<WebElement> changePageIndexButtons = driver.findElements(By.cssSelector("a[class='ant-pagination-item-link ng-star-inserted']"));

--- a/submarine-test/test-e2e/src/test/java/org/apache/submarine/integration/interpreterIT.java
+++ b/submarine-test/test-e2e/src/test/java/org/apache/submarine/integration/interpreterIT.java
@@ -51,7 +51,7 @@ public class interpreterIT extends AbstractSubmarineIT {
     pollingWait(By.cssSelector("input[ng-reflect-name='userName']"), MAX_BROWSER_TIMEOUT_SEC).sendKeys("admin");
     pollingWait(By.cssSelector("input[ng-reflect-name='password']"), MAX_BROWSER_TIMEOUT_SEC).sendKeys("admin");
     clickAndWait(By.cssSelector("button[class='login-form-button ant-btn ant-btn-primary']"));
-    pollingWait(By.cssSelector("a[routerlink='/workbench/dashboard']"), MAX_BROWSER_TIMEOUT_SEC);
+    pollingWait(By.cssSelector("a[routerlink='/workbench/experiment']"), MAX_BROWSER_TIMEOUT_SEC);
 
     // Routing to Interpreter
     pollingWait(By.xpath("//span[contains(text(), \"Interpreter\")]"), MAX_BROWSER_TIMEOUT_SEC).click();

--- a/submarine-test/test-e2e/src/test/java/org/apache/submarine/integration/loginIT.java
+++ b/submarine-test/test-e2e/src/test/java/org/apache/submarine/integration/loginIT.java
@@ -67,7 +67,7 @@ public class loginIT extends AbstractSubmarineIT {
     pollingWait(By.cssSelector("input[ng-reflect-name='password']"), MAX_BROWSER_TIMEOUT_SEC).sendKeys("admin");
     clickAndWait(By.cssSelector("button[class='login-form-button ant-btn ant-btn-primary']"));
     // Validate login result.
-    pollingWait(By.cssSelector("a[routerlink='/workbench/dashboard']"), MAX_BROWSER_TIMEOUT_SEC);
+    pollingWait(By.cssSelector("a[routerlink='/workbench/experiment']"), MAX_BROWSER_TIMEOUT_SEC);
     LOG.info("User login is done.");
   }
 }

--- a/submarine-test/test-e2e/src/test/java/org/apache/submarine/integration/notebookIT.java
+++ b/submarine-test/test-e2e/src/test/java/org/apache/submarine/integration/notebookIT.java
@@ -50,7 +50,7 @@ public class notebookIT extends AbstractSubmarineIT {
     pollingWait(By.cssSelector("input[ng-reflect-name='userName']"), MAX_BROWSER_TIMEOUT_SEC).sendKeys("admin");
     pollingWait(By.cssSelector("input[ng-reflect-name='password']"), MAX_BROWSER_TIMEOUT_SEC).sendKeys("admin");
     clickAndWait(By.cssSelector("button[class='login-form-button ant-btn ant-btn-primary']"));
-    pollingWait(By.cssSelector("a[routerlink='/workbench/dashboard']"), MAX_BROWSER_TIMEOUT_SEC);
+    pollingWait(By.cssSelector("a[routerlink='/workbench/experiment']"), MAX_BROWSER_TIMEOUT_SEC);
 
     // Routing to Notebook
     pollingWait(By.xpath("//span[contains(text(), \"Notebook\")]"), MAX_BROWSER_TIMEOUT_SEC).click();

--- a/submarine-test/test-e2e/src/test/java/org/apache/submarine/integration/sidebarIT.java
+++ b/submarine-test/test-e2e/src/test/java/org/apache/submarine/integration/sidebarIT.java
@@ -52,7 +52,7 @@ public class sidebarIT extends AbstractSubmarineIT {
     pollingWait(By.cssSelector("input[ng-reflect-name='userName']"), MAX_BROWSER_TIMEOUT_SEC).sendKeys("admin");
     pollingWait(By.cssSelector("input[ng-reflect-name='password']"), MAX_BROWSER_TIMEOUT_SEC).sendKeys("admin");
     clickAndWait(By.cssSelector("button[class='login-form-button ant-btn ant-btn-primary']"));
-    pollingWait(By.cssSelector("a[routerlink='/workbench/dashboard']"), MAX_BROWSER_TIMEOUT_SEC);
+    pollingWait(By.cssSelector("a[routerlink='/workbench/experiment']"), MAX_BROWSER_TIMEOUT_SEC);
 
     // Start Routing & Navigation in sidebar
     LOG.info("Start Routing & Navigation in sidebar");

--- a/submarine-test/test-e2e/src/test/java/org/apache/submarine/integration/teamIT.java
+++ b/submarine-test/test-e2e/src/test/java/org/apache/submarine/integration/teamIT.java
@@ -51,7 +51,7 @@ public class teamIT extends AbstractSubmarineIT {
     pollingWait(By.cssSelector("input[ng-reflect-name='userName']"), MAX_BROWSER_TIMEOUT_SEC).sendKeys("admin");
     pollingWait(By.cssSelector("input[ng-reflect-name='password']"), MAX_BROWSER_TIMEOUT_SEC).sendKeys("admin");
     clickAndWait(By.cssSelector("button[class='login-form-button ant-btn ant-btn-primary']"));
-    pollingWait(By.cssSelector("a[routerlink='/workbench/dashboard']"), MAX_BROWSER_TIMEOUT_SEC);
+    pollingWait(By.cssSelector("a[routerlink='/workbench/experiment']"), MAX_BROWSER_TIMEOUT_SEC);
 
     // Routing to workspace
     pollingWait(By.xpath("//span[contains(text(), \"Workspace\")]"), MAX_BROWSER_TIMEOUT_SEC).click();

--- a/submarine-test/test-e2e/src/test/java/org/apache/submarine/integration/workspaceIT.java
+++ b/submarine-test/test-e2e/src/test/java/org/apache/submarine/integration/workspaceIT.java
@@ -53,7 +53,7 @@ public class workspaceIT extends AbstractSubmarineIT {
     pollingWait(By.cssSelector("input[ng-reflect-name='userName']"), MAX_BROWSER_TIMEOUT_SEC).sendKeys("admin");
     pollingWait(By.cssSelector("input[ng-reflect-name='password']"), MAX_BROWSER_TIMEOUT_SEC).sendKeys("admin");
     clickAndWait(By.cssSelector("button[class='login-form-button ant-btn ant-btn-primary']"));
-    pollingWait(By.cssSelector("a[routerlink='/workbench/dashboard']"), MAX_BROWSER_TIMEOUT_SEC);
+    pollingWait(By.cssSelector("a[routerlink='/workbench/experiment']"), MAX_BROWSER_TIMEOUT_SEC);
 
     // Routing to workspace
     pollingWait(By.xpath("//span[contains(text(), \"Workspace\")]"), MAX_BROWSER_TIMEOUT_SEC).click();


### PR DESCRIPTION
### What is this PR for?
SUBMARINE-729 fix the blank page after redirect, so should fix e2e test about testing router link.


### What type of PR is it?
[Bug Fix]

### Todos

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-737

### How should this be tested?
https://travis-ci.org/github/kobe860219/submarine/builds/758805284

### Screenshots (if appropriate)
<img width="861" alt="截圖 2021-02-13 下午4 17 52" src="https://user-images.githubusercontent.com/48027290/107845694-766c1f80-6e18-11eb-8097-30e6c88b63da.png">
<img width="900" alt="截圖 2021-02-13 下午4 23 45" src="https://user-images.githubusercontent.com/48027290/107845695-79ffa680-6e18-11eb-8b36-2802fbf09760.png">


### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
