### PR TITLE
SUBMARINE-740. Update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,9 @@ venv.bak/
 .python-version
 .DS_Store
 .idea
+.mvn/
+mvnw
+mvnw.cmd
 *.iml
 *.gradle
 *.tgz


### PR DESCRIPTION
### What is this PR for?
Exclude `.mvn/`, `mvnw`, `mvnw.cmd` when developers use maven wrapper.

### What type of PR is it?
[Improvement]

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-740

### How should this be tested?
https://travis-ci.com/github/pingsutw/hadoop-submarine/builds/217454670

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
