### PR TITLE
SUBMARINE-738. Automatically Deploy Submarine Docker images

### DIFF
--- a/.github/workflows/deploy_docker_images.yml
+++ b/.github/workflows/deploy_docker_images.yml
@@ -1,0 +1,44 @@
+name: Deploy submarine docker images
+
+on:
+  push:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 240
+    strategy:
+      fail-fast: true
+    env:
+      SUBMARINE_VERSION: 0.6.0-SNAPSHOT 
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+        with: 
+          repository: apache/submarine
+      - uses: docker/login-action@v1
+        name: Login to Docker Hub
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Build Submarine repo
+        run: mvn clean install -DskipTests
+      
+      - name: Build submarine server
+        run: ./dev-support/docker-images/submarine/build.sh
+      - name: Push submarine-server docker image
+        run: docker push apache/submarine:server-$SUBMARINE_VERSION
+      
+      - name: Build submarine database
+        run: ./dev-support/docker-images/database/build.sh
+      - name: Push submarine-database docker image
+        run: docker push apache/submarine:database-$SUBMARINE_VERSION
+      
+      - name: Build submarine jupyter
+        run: ./dev-support/docker-images/jupyter/build.sh
+      - name: Push submarine-jupyter docker image
+        run: docker push apache/submarine:jupyter-notebook-$SUBMARINE_VERSION
+      
+      - name: Build submarine operator
+        run: ./dev-support/docker-images/operator/build.sh
+      - name: Push submarine-operator docker image
+        run: docker push apache/submarine:operator-$SUBMARINE_VERSION

--- a/.github/workflows/deploy_docker_images.yml
+++ b/.github/workflows/deploy_docker_images.yml
@@ -2,6 +2,7 @@ name: Deploy submarine docker images
 
 on:
   push:
+    branches: [master]
 jobs:
   deploy-images:
     if: github.repository == ‘apache/submarine’

--- a/.github/workflows/deploy_docker_images.yml
+++ b/.github/workflows/deploy_docker_images.yml
@@ -3,7 +3,8 @@ name: Deploy submarine docker images
 on:
   push:
 jobs:
-  build:
+  deploy-images:
+    if: github.repository == ‘apache/submarine’
     runs-on: ubuntu-latest
     timeout-minutes: 240
     strategy:


### PR DESCRIPTION
### What is this PR for?
Currently, We need to manually upload docker images to the docker hub.
Add a Github Action for automatically deploy submarine docker images.

btw, I've added docker password secret to the submarine repo.
Related to https://issues.apache.org/jira/browse/INFRA-21383 

### What type of PR is it?
[Improvement]

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-738

### How should this be tested?
https://travis-ci.com/github/pingsutw/hadoop-submarine/builds/217454412
and 
https://github.com/pingsutw/submarine-bot/runs/1924601621

### Screenshots (if appropriate)

### Questions:
* Does the license files need an update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
