### PR TITLE
SUBMARINE-742. Fix typo in deploy_docker_images.yml

### DIFF
--- a/.github/workflows/deploy_docker_images.yml
+++ b/.github/workflows/deploy_docker_images.yml
@@ -5,7 +5,7 @@ on:
     branches: [master]
 jobs:
   deploy-images:
-    if: github.repository == ‘apache/submarine’
+    if: github.repository == 'apache/submarine'
     runs-on: ubuntu-latest
     timeout-minutes: 240
     strategy:


### PR DESCRIPTION
### What is this PR for?
if: github.repository == ‘apache/submarine’
should change to
if: github.repository == 'apache/submarine'

https://github.com/apache/submarine/blob/master/.github/workflows/deploy_docker_images.yml

https://github.com/apache/submarine/actions/runs/580108825 


### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-742

### How should this be tested?


### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
