### PR TITLE
SUBMARINE-752. Drop profile spark 2.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -254,36 +254,6 @@ matrix:
         - TEST_MODULES="-pl org.apache.submarine:submarine-workbench-web"
         - TEST_PROJECTS=""
 
-    - name: Test submarine spark security with spark 2.3 and ranger 1.0
-      language: scala
-      jdk: openjdk8
-      env:
-        - MAVEN_OPTS="-Xmx2g -XX:ReservedCodeCacheSize=512m -Dorg.slf4j.simpleLogger.defaultLogLevel=WARN"
-        - BUILD_FLAG="--batch-mode clean install -Dmaven.javadoc.skip=true"
-        - TEST_FLAG=$BUILD_FLAG
-        - PROFILE="-Pspark-2.3 -Pranger-1.0"
-        - MODULES="-pl :submarine-spark-security"
-
-    - name: Test submarine spark security with spark 2.3 and ranger 1.1
-      language: scala
-      jdk: openjdk8
-      env:
-        - MAVEN_OPTS="-Xmx2g -XX:ReservedCodeCacheSize=512m -Dorg.slf4j.simpleLogger.defaultLogLevel=WARN"
-        - BUILD_FLAG="--batch-mode clean install -Dmaven.javadoc.skip=true"
-        - TEST_FLAG=$BUILD_FLAG
-        - PROFILE="-Pspark-2.3 -Pranger-1.1"
-        - MODULES="-pl :submarine-spark-security"
-
-    - name: Test submarine spark security with spark 2.3 and ranger 1.2
-      language: scala
-      jdk: openjdk8
-      env:
-        - MAVEN_OPTS="-Xmx2g -XX:ReservedCodeCacheSize=512m -Dorg.slf4j.simpleLogger.defaultLogLevel=WARN"
-        - BUILD_FLAG="--batch-mode clean install -Dmaven.javadoc.skip=true"
-        - TEST_FLAG=$BUILD_FLAG
-        - PROFILE="-Pspark-2.3 -Pranger-1.2"
-        - MODULES="-pl :submarine-spark-security"
-
     - name: Test submarine spark security with spark 2.3 and ranger 2.0
       language: scala
       jdk: openjdk8

--- a/submarine-security/spark-security/pom.xml
+++ b/submarine-security/spark-security/pom.xml
@@ -51,7 +51,7 @@
     <scala.binary.version>2.11</scala.binary.version>
     <scalatest.version>2.2.6</scalatest.version>
     <solr.version>5.5.4</solr.version>
-    <spark.version>2.3.4</spark.version>
+    <spark.version>2.4.7</spark.version>
     <spark.scope>provided</spark.scope>
     <gethostname4j.version>0.0.2</gethostname4j.version>
     <gethostname4j.scope>test</gethostname4j.scope>
@@ -555,17 +555,9 @@
 
   <profiles>
     <profile>
-      <id>spark-2.3</id>
-      <properties>
-        <spark.version>2.3.4</spark.version>
-        <scalatest.version>3.0.3</scalatest.version>
-      </properties>
-    </profile>
-
-    <profile>
       <id>spark-2.4</id>
       <properties>
-        <spark.version>2.4.5</spark.version>
+        <spark.version>2.4.7</spark.version>
         <scalatest.version>3.0.3</scalatest.version>
       </properties>
     </profile>
@@ -573,7 +565,7 @@
     <profile>
       <id>spark-3.0</id>
       <properties>
-        <spark.version>3.0.1</spark.version>
+        <spark.version>3.0.2</spark.version>
         <scala.version>2.12.10</scala.version>
         <scala.binary.version>2.12</scala.binary.version>
         <!--<scalatest.version>3.2.0</scalatest.version>-->


### PR DESCRIPTION
### What is this PR for?


We use Apache Spark 2.4.x as default and drop profile spark-2.3 for future-proofing updating

the Spark 2.4 is LTS and it's better for us to maintain. The functionality for spark 2.3 and earlier is still kept

closes #475 
### What type of PR is it?

Improvement
### Todos
* [ ] - Task

### What is the Jira issue?
* Open an issue on Jira https://issues.apache.org/jira/browse/SUBMARINE-752

### How should this be tested?
* First time? Setup Travis CI as described on https://submarine.apache.org/contribution/contributions.html#continuous-integration
* Strongly recommended: add automated unit tests for any new or changed behavior
* Outline any manual steps to test the PR here.

PASSING existing tests
### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? Yes/No
* Is there breaking changes for older versions? Yes/No
* Does this needs documentation? Yes/No
