### PR TITLE
SUBMARINE-753. Submarine-security doesn't support 'show tables' filtering

### DIFF
--- a/submarine-security/spark-security/src/main/scala/org/apache/submarine/spark/security/RangerSparkAuthorizer.scala
+++ b/submarine-security/spark-security/src/main/scala/org/apache/submarine/spark/security/RangerSparkAuthorizer.scala
@@ -173,7 +173,7 @@ object RangerSparkAuthorizer {
       case SparkPrivilegeObjectType.DATABASE =>
         Some(RangerSparkResource(SparkObjectType.DATABASE, Option(objectName)))
       case SparkPrivilegeObjectType.TABLE_OR_VIEW =>
-        Some(RangerSparkResource(SparkObjectType.DATABASE, Option(dbName), objectName))
+        Some(RangerSparkResource(SparkObjectType.TABLE, Option(dbName), objectName))
       case _ =>
         LOG.warn(s"RangerSparkAuthorizer.createSparkResource: unexpected objectType: $objectType")
         None


### PR DESCRIPTION
### What is this PR for?
Fix the bug that 'show tables' doesn't work in submarine-security module.


### What type of PR is it?
Bug Fix

### Todos

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-753 
Submarine-security doesn't support 'show tables' filtering

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
