### PR TITLE
SUBMARINE-739. Automatically Deploy Submarine Website

### DIFF
--- a/.github/workflows/deploy_website.yml
+++ b/.github/workflows/deploy_website.yml
@@ -1,0 +1,62 @@
+name: Deploy Submarine documentation
+
+on:
+  pull_request:
+    branches: [master]
+  push:
+    branches: [master]
+
+jobs:
+  checks-website:
+    if: github.event_name != 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
+      - name: Test Build
+        run: |
+          cd website
+          if [ -e yarn.lock ]; then
+          yarn install --frozen-lockfile
+          elif [ -e package-lock.json ]; then
+          npm ci
+          else
+          npm i
+          fi
+          npm run build
+  deploy-website:
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
+      - name: Add key to allow access to repository
+        env:
+          SSH_AUTH_SOCK: /tmp/ssh_agent.sock
+        run: |
+          mkdir -p ~/.ssh
+          ssh-keyscan github.com >> ~/.ssh/known_hosts
+          echo "${{ secrets.GH_PAGES_DEPLOY }}" > ~/.ssh/id_rsa
+          chmod 600 ~/.ssh/id_rsa
+      - name: Deploy Submarine website
+        env:
+          USE_SSH: true
+          GIT_USER: pingsutw
+          DEPLOYMENT_BRANCH: asf-site
+        run: |
+          cd website
+          git config --global user.email "pingsutw@apache.org"
+          git config --global user.name "pingsutw"
+          if [ -e yarn.lock ]; then
+          yarn install --frozen-lockfile
+          elif [ -e package-lock.json ]; then
+          npm ci
+          else
+          npm i
+          fi
+          yarn deploy
+


### PR DESCRIPTION
### What is this PR for?
We have updated the Submarine website in SUBMARINE-724.
Add a Github Action for automatically deploying the website when other contributors update the docs.
Related to https://v2.docusaurus.io/docs/deployment#triggering-deployment-with-github-actions 

### What type of PR is it?
[Improvement]

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-739

### How should this be tested?
https://travis-ci.com/github/pingsutw/hadoop-submarine/builds/217975280

### Screenshots (if appropriate)

### Questions:
* Does the license files need an update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
