### PR TITLE
SUBMARINE-773. Support MLflow model registry

### DIFF
--- a/dev-support/docker-images/jupyter/Dockerfile
+++ b/dev-support/docker-images/jupyter/Dockerfile
@@ -19,7 +19,7 @@ ARG NB_USER="jovyan"
 ARG NB_UID="1000"
 ARG NB_PREFIX="/"
 ARG NB_PORT=8888
-ARG MLFLOW_TRACKING_URI="http://10.96.0.3:8080"
+ARG MLFLOW_TRACKING_URI="http://10.96.0.3:5000"
 
 USER root
 
@@ -107,7 +107,10 @@ RUN cp submarine/submarine-sdk/pysubmarine/example/submarine_experiment_sdk.ipyn
     rm submarine -rf
 
 # Install latest stable qlib
-RUN pip install numpy==1.19.5 pyqlib==0.6.1 boto3
+RUN pip install numpy==1.19.5 pyqlib==0.6.1
+
+# Install mlflow & minio dependencies
+RUN pip install boto3
 
 # Add qlib example in notebook
 RUN wget https://raw.githubusercontent.com/microsoft/qlib/main/examples/workflow_by_code.ipynb -P $HOME

--- a/dev-support/docker-images/jupyter/Dockerfile
+++ b/dev-support/docker-images/jupyter/Dockerfile
@@ -107,11 +107,15 @@ RUN cp submarine/submarine-sdk/pysubmarine/example/submarine_experiment_sdk.ipyn
     rm submarine -rf
 
 # Install latest stable qlib
-RUN pip install numpy==1.19.5 pyqlib==0.6.1
+RUN pip install numpy==1.19.5 pyqlib==0.6.1 boto3
 
 # Add qlib example in notebook
 RUN wget https://raw.githubusercontent.com/microsoft/qlib/main/examples/workflow_by_code.ipynb -P $HOME
 
+
+ENV MLFLOW_S3_ENDPOINT_URL http://10.96.0.4:9000
+ENV AWS_ACCESS_KEY_ID submarine_minio
+ENV AWS_SECRET_ACCESS_KEY submarine_minio
 
 EXPOSE $NB_PORT
 ENTRYPOINT ["tini", "-g", "--"]

--- a/dev-support/docker-images/jupyter/Dockerfile
+++ b/dev-support/docker-images/jupyter/Dockerfile
@@ -107,7 +107,7 @@ RUN cp submarine/submarine-sdk/pysubmarine/example/submarine_experiment_sdk.ipyn
     rm submarine -rf
 
 # Install mlflow & minio dependencies
-RUN pip install boto3=1.17.58 mlflow=1.15.0
+RUN pip install boto3==1.17.58 mlflow==1.15.0
 
 # Install latest stable qlib
 RUN pip install numpy==1.19.5 pyqlib==0.6.1

--- a/dev-support/docker-images/jupyter/Dockerfile
+++ b/dev-support/docker-images/jupyter/Dockerfile
@@ -106,11 +106,11 @@ RUN cp submarine/submarine-sdk/pysubmarine/example/submarine_experiment_sdk.ipyn
     cp -r submarine/submarine-sdk/pysubmarine/example/{data,deepfm_example.ipynb,deepfm.json} $HOME && \
     rm submarine -rf
 
+# Install mlflow & minio dependencies
+RUN pip install boto3=1.17.58 mlflow=1.15.0
+
 # Install latest stable qlib
 RUN pip install numpy==1.19.5 pyqlib==0.6.1
-
-# Install mlflow & minio dependencies
-RUN pip install boto3
 
 # Add qlib example in notebook
 RUN wget https://raw.githubusercontent.com/microsoft/qlib/main/examples/workflow_by_code.ipynb -P $HOME

--- a/dev-support/docker-images/mlflow/Dockerfile
+++ b/dev-support/docker-images/mlflow/Dockerfile
@@ -19,10 +19,7 @@ RUN pip install mlflow
 
 RUN apt-get update && apt-get -y install --no-install-recommends default-libmysqlclient-dev libpq-dev build-essential sqlite3 wget
     
-RUN pip install \
-    mlflow \
-    sqlalchemy \
-    boto3
+RUN pip install mlflow==1.15.0 sqlalchemy==1.4.11 boto3==1.17.58
 
 COPY start.sh /usr/local/bin
 

--- a/dev-support/docker-images/mlflow/Dockerfile
+++ b/dev-support/docker-images/mlflow/Dockerfile
@@ -24,9 +24,7 @@ RUN pip install \
     sqlalchemy \
     boto3
 
-RUN sqlite3 store.db
-
-COPY set.sh /usr/local/bin
+COPY start.sh /usr/local/bin
 
 WORKDIR /usr/local/bin
 
@@ -39,8 +37,4 @@ ENV BACKEND_URI sqlite:///store.db
 
 EXPOSE 5000
 
-CMD ./set.sh && mlflow server \
-    --host 0.0.0.0 \
-    --backend-store-uri ${BACKEND_URI} \
-    --default-artifact-root s3:/mlflow \
-    --static-prefix "/mlflow"
+CMD ./start.sh

--- a/dev-support/docker-images/mlflow/Dockerfile
+++ b/dev-support/docker-images/mlflow/Dockerfile
@@ -21,8 +21,22 @@ RUN mkdir /submarine-mlflow
 
 WORKDIR /submarine-mlflow
 
+RUN apt-get update && apt-get -y install --no-install-recommends default-libmysqlclient-dev libpq-dev build-essential sqlite3
+    
+RUN pip install \
+    mlflow \
+    sqlalchemy \
+    boto3
+
+RUN sqlite3 store.db
+
 EXPOSE 5000
+
+ENV BACKEND_URI sqlite:///store.db
+ENV ARTIFACT_ROOT /submarine-mlflow/mlflow-artifacts
 
 CMD mlflow server \
     --host 0.0.0.0 \
+    --backend-store-uri ${BACKEND_URI} \
+    --default-artifact-root ${ARTIFACT_ROOT} \
     --static-prefix "/mlflow"

--- a/dev-support/docker-images/mlflow/Dockerfile
+++ b/dev-support/docker-images/mlflow/Dockerfile
@@ -17,11 +17,7 @@ FROM python:3.7.0-slim
 
 RUN pip install mlflow
 
-RUN mkdir /submarine-mlflow
-
-WORKDIR /submarine-mlflow
-
-RUN apt-get update && apt-get -y install --no-install-recommends default-libmysqlclient-dev libpq-dev build-essential sqlite3
+RUN apt-get update && apt-get -y install --no-install-recommends default-libmysqlclient-dev libpq-dev build-essential sqlite3 wget
     
 RUN pip install \
     mlflow \
@@ -30,13 +26,21 @@ RUN pip install \
 
 RUN sqlite3 store.db
 
+COPY set.sh /usr/local/bin
+
+WORKDIR /usr/local/bin
+
+RUN wget https://dl.min.io/client/mc/release/linux-amd64/mc && chmod +x mc
+
+ENV MLFLOW_S3_ENDPOINT_URL http://10.96.0.4:9000
+ENV AWS_ACCESS_KEY_ID submarine_minio
+ENV AWS_SECRET_ACCESS_KEY submarine_minio
+ENV BACKEND_URI sqlite:///store.db
+
 EXPOSE 5000
 
-ENV BACKEND_URI sqlite:///store.db
-ENV ARTIFACT_ROOT /submarine-mlflow/mlflow-artifacts
-
-CMD mlflow server \
+CMD ./set.sh && mlflow server \
     --host 0.0.0.0 \
     --backend-store-uri ${BACKEND_URI} \
-    --default-artifact-root ${ARTIFACT_ROOT} \
+    --default-artifact-root s3:/mlflow \
     --static-prefix "/mlflow"

--- a/dev-support/docker-images/mlflow/set.sh
+++ b/dev-support/docker-images/mlflow/set.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# description: Start and stop daemon script for.
+#
+
+set -euo pipefail
+
+/bin/bash -c "sleep 60; ./mc config host add minio http://10.96.0.4:9000 submarine_minio submarine_minio"
+
+/bin/bash -c "./mc mb minio/mlflow"

--- a/dev-support/docker-images/mlflow/start.sh
+++ b/dev-support/docker-images/mlflow/start.sh
@@ -21,6 +21,17 @@
 
 set -euo pipefail
 
-/bin/bash -c "sleep 60; ./mc config host add minio http://10.96.0.4:9000 submarine_minio submarine_minio"
+MLFLOW_S3_ENDPOINT_URL="http://10.96.0.4:9000"
+AWS_ACCESS_KEY_ID="submarine_minio"
+AWS_SECRET_ACCESS_KEY="submarine_minio"
+BACKEND_URI="sqlite:///store.db"
+DEFAULT_ARTIFACT_ROOT="s3://mlflow"
+STATIC_PREFIX="/mlflow"
+
+/bin/bash -c "sqlite3 store.db"
+
+/bin/bash -c "sleep 60; ./mc config host add minio ${MLFLOW_S3_ENDPOINT_URL} ${AWS_ACCESS_KEY_ID} ${AWS_SECRET_ACCESS_KEY}"
 
 /bin/bash -c "./mc mb minio/mlflow"
+
+/bin/bash -c "mlflow server --host 0.0.0.0 --backend-store-uri ${BACKEND_URI} --default-artifact-root ${DEFAULT_ARTIFACT_ROOT} --static-prefix ${STATIC_PREFIX}"

--- a/helm-charts/submarine/templates/submarine-minio.yaml
+++ b/helm-charts/submarine/templates/submarine-minio.yaml
@@ -1,0 +1,114 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: submarine-minio-pv
+spec:
+  accessModes:
+    - ReadWriteMany
+  capacity:
+    storage: "{{ .Values.submarine.minio.storage }}"
+{{- with .Values.submarine.storage }}
+  {{- if eq (.type | lower) "nfs" }}
+  nfs:
+    server: {{ .nfs.ip }}
+    path: {{ .nfs.path }}
+  {{- else }}
+  hostPath:
+    path: "{{ .host.path }}"
+    type: DirectoryOrCreate
+  {{- end }}
+{{- end}}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: submarine-minio-pvc
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: ""
+  resources:
+    requests:
+      storage: "{{ .Values.submarine.minio.storage }}"
+  volumeName: submarine-minio-pv
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: submarine-minio
+spec:
+  selector:
+    matchLabels:
+      app: submarine-minio-pod
+  template:
+    metadata:
+      labels:
+        app: submarine-minio-pod
+    spec:
+      containers:
+      - name: submarine-minio-container
+        image: minio/minio:latest
+        imagePullPolicy: IfNotPresent
+        args:
+        - server
+        - /data
+        env:
+        - name: MINIO_ACCESS_KEY
+          value: "submarine_minio"
+        - name: MINIO_SECRET_KEY
+          value: "submarine_minio"
+        ports:
+        - containerPort: 9000
+        volumeMounts:
+          - mountPath: "/data"
+            name: "volume"
+            subPath: "submarine-minio"
+      volumes:
+        - name: "volume"
+          persistentVolumeClaim:
+            claimName: "submarine-minio-pvc"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: submarine-minio-service
+spec:
+  clusterIP: 10.96.0.4
+  selector:
+    app: submarine-minio-pod
+  ports:
+  - protocol: TCP
+    port: 9000
+    targetPort: 9000
+---
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRoute
+metadata:
+  name: submarine-minio-ingressroute
+spec:
+  entryPoints:
+    - web
+  routes:
+  - kind: Rule
+    match: "PathPrefix(`{{ .Values.submarine.minio.ingressPath }}`)"
+    services:
+    - kind: Service
+      name: submarine-minio-service
+      port: 9000

--- a/helm-charts/submarine/values.yaml
+++ b/helm-charts/submarine/values.yaml
@@ -34,13 +34,13 @@ submarine:
   traefik:
     enabled: true
   tensorboard:
-    storage: 5Gi
+    storage: 10Gi
     ingressPath: "/tensorboard"
   mlflow:
-    storage: 5Gi
+    storage: 10Gi
     ingressPath: "/mlflow"
   minio:
-    storage: 5Gi
+    storage: 10Gi
     ingressPath: "/minio"
   storage:
     type: host # "host" or "nfs"

--- a/helm-charts/submarine/values.yaml
+++ b/helm-charts/submarine/values.yaml
@@ -34,11 +34,14 @@ submarine:
   traefik:
     enabled: true
   tensorboard:
-    storage: 10Gi
+    storage: 5Gi
     ingressPath: "/tensorboard"
   mlflow:
-    storage: 10Gi
+    storage: 5Gi
     ingressPath: "/mlflow"
+  minio:
+    storage: 5Gi
+    ingressPath: "/minio"
   storage:
     type: host # "host" or "nfs"
     host:


### PR DESCRIPTION
### What is this PR for?
Support MLflow model registry. Using minIO as artifacts storage. User now could use submarine jupyter notebook for developing ML code with MLflow api. And the model's metadata will store in mlflow backend, artifacts will store in minIO server.

### What type of PR is it?
[Feature]

### Todos

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-773

### How should this be tested?
https://travis-ci.org/github/kobe860219/submarine/builds/764073079

### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/48027290/112129040-f482c980-8c01-11eb-9ff8-9fe2098c56ae.png)


### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
