### PR TITLE
SUBMARINE-788. Upgrade npm and node version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,9 +87,9 @@
 
     <!-- frontend maven plugin related versions-->
     <plugin.frontend.version>1.6</plugin.frontend.version>
-    <node.version>v10.12.0</node.version>
+    <node.version>v14.16.0</node.version>
     <yarn.version>v1.10.1</yarn.version>
-    <npm.version>6.4.1</npm.version>
+    <npm.version>6.14.11</npm.version>
     <io.swagger.version>2.1.2</io.swagger.version>
 
     <hadoop.common.build.dir>${basedir}/../hadoop-common-project/hadoop-common/target</hadoop.common.build.dir>


### PR DESCRIPTION
### What is this PR for?
The current npm version is outdated. It breaks in Ubuntu 20.04.
Upgrade both npm and node version.

### What type of PR is it?
[Bug Fix]

### Todos

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-788

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
