### PR TITLE
SUBMARINE-793. Drop old Ranger version support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -264,26 +264,6 @@ matrix:
         - PROFILE="-Pspark-2.3 -Pranger-2.0"
         - MODULES="-pl :submarine-spark-security"
 
-    - name: Test submarine spark security with spark 2.4 and ranger 1.0
-      language: scala
-      jdk: openjdk8
-      env:
-        - MAVEN_OPTS="-Xmx2g -XX:ReservedCodeCacheSize=512m -Dorg.slf4j.simpleLogger.defaultLogLevel=WARN"
-        - BUILD_FLAG="--batch-mode clean install -Dmaven.javadoc.skip=true"
-        - TEST_FLAG=$BUILD_FLAG
-        - PROFILE="-Pspark-2.4 -Pranger-1.0"
-        - MODULES="-pl :submarine-spark-security"
-
-    - name: Test submarine spark security with spark 2.4 and ranger 1.1
-      language: scala
-      jdk: openjdk8
-      env:
-        - MAVEN_OPTS="-Xmx2g -XX:ReservedCodeCacheSize=512m -Dorg.slf4j.simpleLogger.defaultLogLevel=WARN"
-        - BUILD_FLAG="--batch-mode clean install -Dmaven.javadoc.skip=true"
-        - TEST_FLAG=$BUILD_FLAG
-        - PROFILE="-Pspark-2.4 -Pranger-1.1"
-        - MODULES="-pl :submarine-spark-security"
-
     - name: Test submarine spark security with spark 2.4 and ranger 1.2
       language: scala
       jdk: openjdk8
@@ -302,26 +282,6 @@ matrix:
         - BUILD_FLAG="--batch-mode clean install -Dmaven.javadoc.skip=true"
         - TEST_FLAG=$BUILD_FLAG
         - PROFILE="-Pspark-2.4 -Pranger-2.0"
-        - MODULES="-pl :submarine-spark-security"
-
-    - name: Test submarine spark security with spark 3.0 and ranger 1.0
-      language: scala
-      jdk: openjdk8
-      env:
-        - MAVEN_OPTS="-Xmx2g -XX:ReservedCodeCacheSize=512m -Dorg.slf4j.simpleLogger.defaultLogLevel=WARN"
-        - BUILD_FLAG="--batch-mode clean install -Dmaven.javadoc.skip=true"
-        - TEST_FLAG=$BUILD_FLAG
-        - PROFILE="-Pspark-3.0 -Pranger-1.0"
-        - MODULES="-pl :submarine-spark-security"
-
-    - name: Test submarine spark security with spark 3.0 and ranger 1.1
-      language: scala
-      jdk: openjdk8
-      env:
-        - MAVEN_OPTS="-Xmx2g -XX:ReservedCodeCacheSize=512m -Dorg.slf4j.simpleLogger.defaultLogLevel=WARN"
-        - BUILD_FLAG="--batch-mode clean install -Dmaven.javadoc.skip=true"
-        - TEST_FLAG=$BUILD_FLAG
-        - PROFILE="-Pspark-3.0 -Pranger-1.1"
         - MODULES="-pl :submarine-spark-security"
 
     - name: Test submarine spark security with spark 3.0 and ranger 1.2

--- a/submarine-security/spark-security/pom.xml
+++ b/submarine-security/spark-security/pom.xml
@@ -44,7 +44,7 @@
     <jersey-bundle.version>1.19.3</jersey-bundle.version>
     <noggit.version>0.6</noggit.version>
     <ranger.spark.package>submarine_spark_ranger_project</ranger.spark.package>
-    <ranger.version>1.1.0</ranger.version>
+    <ranger.version>1.2.0</ranger.version>
     <ranger.major.version>1</ranger.major.version>
     <spark.compatible.version>2</spark.compatible.version>
     <scala.version>2.11.8</scala.version>
@@ -573,38 +573,6 @@
         <commons-lang3.version>3.9</commons-lang3.version>
         <jackson-databind.version>2.10.5</jackson-databind.version>
         <jackson-annotations.version>2.10.5</jackson-annotations.version>
-      </properties>
-    </profile>
-
-    <profile>
-      <id>ranger-1.0</id>
-      <properties>
-        <eclipse.jpa.version>2.5.2</eclipse.jpa.version>
-        <gson.version>2.2.4</gson.version>
-        <httpcomponents.httpclient.version>4.2.5</httpcomponents.httpclient.version>
-        <httpcomponents.httpcore.version>4.2.4</httpcomponents.httpcore.version>
-        <httpcomponents.httpmime.version>4.5.3</httpcomponents.httpmime.version>
-        <javax.persistence.version>2.1.0</javax.persistence.version>
-        <jersey-bundle.version>1.19.3</jersey-bundle.version>
-        <noggit.version>0.6</noggit.version>
-        <ranger.version>1.0.0</ranger.version>
-        <solr.version>5.5.4</solr.version>
-      </properties>
-    </profile>
-
-    <profile>
-      <id>ranger-1.1</id>
-      <properties>
-        <eclipse.jpa.version>2.5.2</eclipse.jpa.version>
-        <gson.version>2.2.4</gson.version>
-        <httpcomponents.httpclient.version>4.5.3</httpcomponents.httpclient.version>
-        <httpcomponents.httpcore.version>4.4.6</httpcomponents.httpcore.version>
-        <httpcomponents.httpmime.version>4.5.3</httpcomponents.httpmime.version>
-        <javax.persistence.version>2.1.0</javax.persistence.version>
-        <jersey-bundle.version>1.19.3</jersey-bundle.version>
-        <noggit.version>0.6</noggit.version>
-        <ranger.version>1.1.0</ranger.version>
-        <solr.version>5.5.4</solr.version>
       </properties>
     </profile>
 

--- a/website/docs/userDocs/submarine-security/spark-security/build-submarine-spark-security-plugin.md
+++ b/website/docs/userDocs/submarine-security/spark-security/build-submarine-spark-security-plugin.md
@@ -29,4 +29,4 @@ Currently, available profiles are:
 
 **Spark**: `-Pspark-2.3`, `-Pspark-2.4`, `-Pspark-3.0`
 
-**Ranger**: `-Pranger-1.0`, `-Pranger-1.1`, `-Pranger-1.2`, `-Pranger-2.0`
+**Ranger**: `-Pranger-1.2`, `-Pranger-2.0`


### PR DESCRIPTION
### What is this PR for?
More recently, the precommit takes hours to complete, a lot of it is spent on running UT for different combination of Hadoop, Spark and Ranger.

We currently run against Ranger 1.0, 1.1, 1.2 and 2.0. I propose we retain 1.2 and 2.0 and drop 1.0 and 1.1. Dropping these two will save around 40 minutes per precommit (out of more than 3 hours).

### What type of PR is it?
[Improvement]

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/projects/SUBMARINE/issues/SUBMARINE-793

### How should this be tested?
https://travis-ci.org/github/aeioulisa/submarine/builds/767357154

### Screenshots (if appropriate)

### Questions:
* Do the license files need updating? Yes/No
* Are there breaking changes for older versions? Yes/No
* Does this need new documentation? Yes/No
