### PR TITLE
SUBMARINE-800. Create an ingress for a single user

### DIFF
--- a/submarine-cloud-v2/artifacts/examples/submarine-operator-service-account.yaml
+++ b/submarine-cloud-v2/artifacts/examples/submarine-operator-service-account.yaml
@@ -36,6 +36,7 @@ rules:
   - namespaces
   - deployments
   - jobs
+  - serviceaccounts
   verbs:
   - '*'
 - apiGroups:
@@ -45,10 +46,10 @@ rules:
   - replicasets
   verbs:
   - '*'
-- apiGroups:
-  - "rbac.authorization.k8s.io"
+- apiGroups: 
+  - "extensions"
   resources:
-  - serviceaccounts
+  - ingresses
   verbs:
   - '*'
 ---

--- a/submarine-cloud-v2/main.go
+++ b/submarine-cloud-v2/main.go
@@ -78,6 +78,7 @@ func main() {
 		kubeInformerFactory.Apps().V1().Deployments(),
 		kubeInformerFactory.Core().V1().Services(),
 		kubeInformerFactory.Core().V1().ServiceAccounts(),
+		kubeInformerFactory.Extensions().V1beta1().Ingresses(),
 		submarineInformerFactory.Submarine().V1alpha1().Submarines())
 
 	// notice that there is no need to run Start methods in a separate goroutine. (i.e. go kubeInformerFactory.Start(stopCh)


### PR DESCRIPTION
### What is this PR for?
Create an ingress for a single user via the submarine operator.
Reference: https://github.com/apache/submarine/blob/master/helm-charts/submarine/templates/submarine-ingress.yaml

This issue is a child issue of [SUBMARINE-797](https://issues.apache.org/jira/browse/SUBMARINE-797).

### What type of PR is it?
[Feature]

### Todos

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-800

### How should this be tested?
```
# helm
helm install submarine ./helm-charts/submarine
kubectl get ingress
kubectl describe ingress submarine-server-ingress

# submarine-operator
go build -o submarine-operator
./submarine-operator
kubectl get ingress
kubectl describe ingress submarine-server-ingress
```

### Screenshots (if appropriate)
* submarine-server-ingress (helm)
<img width="817" alt="截圖 2021-04-22 下午2 25 25" src="https://user-images.githubusercontent.com/20109646/115666391-1d1fef80-a377-11eb-9d14-7282636d2efe.png">

* submarine-server-ingress (submarine-operator)
<img width="935" alt="截圖 2021-04-22 下午2 11 18" src="https://user-images.githubusercontent.com/20109646/115666380-198c6880-a377-11eb-957a-11bf24c07c7c.png">



### Questions:
* Do the license files need updating? No
* Are there breaking changes for older versions? No
* Does this need new documentation? No
