### PR TITLE
SUBMARINE-803. Update travis link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 ![Colored_logo_with_text](website/docs/assets/color_logo_with_text.png)
 
-[![Build Status](https://travis-ci.org/apache/submarine.svg?branch=master)](https://travis-ci.org/apache/submarine) [![License](https://img.shields.io/badge/license-Apache%202-4EB1BA.svg)](https://www.apache.org/licenses/LICENSE-2.0.html)  [![HitCount](http://hits.dwyl.com/apache/submarine.svg)](http://hits.dwyl.io/apache/submarine) [![PyPI version](https://badge.fury.io/py/apache-submarine.svg)](https://badge.fury.io/py/apache-submarine)
+[![Build Status](https://travis-ci.com/apache/submarine.svg?branch=master)](https://travis-ci.com/apache/submarine) [![License](https://img.shields.io/badge/license-Apache%202-4EB1BA.svg)](https://www.apache.org/licenses/LICENSE-2.0.html)  [![HitCount](http://hits.dwyl.com/apache/submarine.svg)](http://hits.dwyl.io/apache/submarine) [![PyPI version](https://badge.fury.io/py/apache-submarine.svg)](https://badge.fury.io/py/apache-submarine)
 
 </div>
 

--- a/website/docs/devDocs/IntegrationTest.md
+++ b/website/docs/devDocs/IntegrationTest.md
@@ -74,7 +74,7 @@ Each time a code is submitted, travis is automatically triggered for testing.
 * Run E2E tests in Travis:
   *  Step1: Make sure that the port must be 8080 rather than in [WebDriverManager.java](https://github.com/apache/submarine/blob/master/submarine-test/test-e2e/src/test/java/org/apache/submarine/WebDriverManager.java) and [all test cases](https://github.com/apache/submarine/tree/master/submarine-test/test-e2e/src/test/java/org/apache/submarine/integration).
   *  Step2: Make sure that the `headless` option is not commented in [ChromeWebDriverProvider.java](https://github.com/apache/submarine/blob/master/submarine-test/test-e2e/src/test/java/org/apache/submarine/ChromeWebDriverProvider.java).
-  *  Step3: If you push the commit to Github, the Travis CI will execute automatically and you can check it in `https://travis-ci.org/${your_github_account}/${your_repo_name}`.
+  *  Step3: If you push the commit to Github, the Travis CI will execute automatically and you can check it in `https://travis-ci.com/${your_github_account}/${your_repo_name}`.
 ### Run the existing tests.
 ##### Move to the working directory.
 ```


### PR DESCRIPTION
### What is this PR for?
"Please be aware travis-ci.org will be shutting down in several weeks, with all accounts migrating to travis-ci.com. Please stay tuned here for more information."

Reference: travis-ci.org
<img width="1068" alt="截圖 2021-04-25 上午11 02 34" src="https://user-images.githubusercontent.com/20109646/115978993-c0f6de80-a5b5-11eb-957f-719d900c2f4f.png">


### What type of PR is it?
[Documentation]

### Todos


### What is the Jira issue?
https://issues.apache.org/jira/projects/SUBMARINE/issues/SUBMARINE-803?filter=allissues

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* Do the license files need updating? No
* Are there breaking changes for older versions? No
* Does this need new documentation? No
