### PR TITLE
SUBMARINE-804. Modify the apiGroup field in rbac.yaml

### DIFF
--- a/helm-charts/submarine/templates/rbac.yaml
+++ b/helm-charts/submarine/templates/rbac.yaml
@@ -80,4 +80,4 @@ subjects:
 roleRef:
   kind: ClusterRole
   name: "{{ .Values.submarine.server.name }}"
-  apiGroup: ""
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
### What is this PR for?
As shown in [rbac.yaml:83](https://github.com/apache/submarine/blob/2faebb8efd69833853f62d89b4f1fea1b1718148/helm-charts/submarine/templates/rbac.yaml#L83), the value of apiGroup is "".

However, the value of apiGroup in all of the following examples is "rbac.authorization.k8s.io".

Ref1: [Kubernetes official guide](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#clusterrolebinding-example)
Ref2: [kube-lego](https://github.com/jetstack/kube-lego/blob/master/examples/gce/lego/cluster-role-binding.yaml) (Github Star: 2.2k)
Ref3: [redis-operator](https://github.com/spotahome/redis-operator/blob/b3dad57f5c4c94fe48824deacf391ab82232b3d5/charts/redisoperator/templates/rbac.yaml#L100) (Github Star: 672)


### What type of PR is it?
[Improvement]

### Todos


### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-804

### How should this be tested?

### Screenshots (if appropriate)
* (apiGroup = "") `kubectl describe clusterrolebinding submarine-server` 
<img width="793" alt="without_change" src="https://user-images.githubusercontent.com/20109646/115979711-04ebe280-a5ba-11eb-94f2-3d271278955a.png">

* (apiGroup = rbac.authorization.k8s.io) `kubectl describe clusterrolebinding submarine-server` 
<img width="807" alt="rbac" src="https://user-images.githubusercontent.com/20109646/115979646-b0486780-a5b9-11eb-8652-98c9d0f1b4a7.png">

With these two figures, the value of apiGroup seems to have no effect on ClusterRoleBinding submarine-server. Nevertheless,  I have never seen any project use "" as the value of ClusterRole apiGroup.  

### Questions:
* Do the license files need updating? No
* Are there breaking changes for older versions? No
* Does this need new documentation? No
