### PR TITLE
SUBMARINE-810. Avoid duplicated icon of MLflow with Tensorboard

### DIFF
--- a/submarine-workbench/workbench-web/src/app/pages/workbench/experiment/experiment-home/experiment-home.component.html
+++ b/submarine-workbench/workbench-web/src/app/pages/workbench/experiment/experiment-home/experiment-home.component.html
@@ -37,7 +37,7 @@
       [nzLoading]="isMlflowLoading"
       [href]="mlflowUrl"
     >
-      <i nz-icon nzType="area-chart"></i>
+      <i nz-icon nzType="radar-chart"></i>
       MLflow UI
     </a>
     <a


### PR DESCRIPTION
### What is this PR for?
Minor change.
The MLflow icon is the same as the tensorboard's.
It might be confusing for the users, so we should replace it with a new one.

### What type of PR is it?
[Improvement]

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/projects/SUBMARINE/issues/SUBMARINE-810

### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/24364830/116412187-03941180-a869-11eb-96a5-f03511709c05.png)

### Questions:
* Do the license files need updating? No
* Are there breaking changes for older versions? No
* Does this need new documentation? No
