### PR TITLE
SUBMARINE-811. Install local notebook-controller chart via helm golang API

### DIFF
--- a/submarine-cloud-v2/artifacts/examples/submarine-operator-service-account.yaml
+++ b/submarine-cloud-v2/artifacts/examples/submarine-operator-service-account.yaml
@@ -39,6 +39,12 @@ rules:
     verbs:
       - "*"
   - apiGroups:
+      - kubeflow.org
+    resources:
+      - notebooks
+    verbs:
+      - "*"
+  - apiGroups:
       - ""
     resources:
       - pods

--- a/submarine-cloud-v2/controller.go
+++ b/submarine-cloud-v2/controller.go
@@ -725,6 +725,17 @@ func (c *Controller) newSubCharts(namespace string) error {
 		)
 	}
 
+	if !helm.CheckRelease("notebook-controller", namespace) {
+		klog.Info("[Helm] Install Notebook-Controller")
+		helm.HelmInstallLocalChart(
+			"notebook-controller",
+			"charts/notebook-controller",
+			"notebook-controller",
+			namespace,
+			map[string]string{},
+		)
+	}
+
 	// TODO: maintain "error"
 	// TODO: (sample-controller) controller.go:287 ~ 293
 	// TODO: port-forward


### PR DESCRIPTION
### What is this PR for?
Install local notebook-controller chart via Helm golang API.

notebook-controller chart: https://github.com/apache/submarine/tree/master/helm-charts/submarine/charts/notebook-controller

Helm golang API: https://github.com/apache/submarine/blob/master/submarine-cloud-v2/pkg/helm/helm.go

### What type of PR is it?
[Feature]

### Todos

### What is the Jira issue?
https://issues.apache.org/jira/projects/SUBMARINE/issues/SUBMARINE-811

### How should this be tested?
https://travis-ci.org/github/MortalHappiness/submarine/builds/769140540

### Screenshots (if appropriate)

Helm install
![helm_all](https://user-images.githubusercontent.com/47914085/116788786-3eeb4600-aade-11eb-9f3a-8980b81435bc.png)

In-cluster operator

![helm_ls](https://user-images.githubusercontent.com/47914085/116788792-414da000-aade-11eb-92c4-c21ae9e7e0cf.png)

![operator_all](https://user-images.githubusercontent.com/47914085/116788794-43affa00-aade-11eb-9256-06c0c99c523d.png)

### Questions:
* Do the license files need updating? No
* Are there breaking changes for older versions? No
* Does this need new documentation? No
