### PR TITLE
SUBMARINE-816. Implement Submarine delete event handler

### DIFF
--- a/submarine-cloud-v2/README.md
+++ b/submarine-cloud-v2/README.md
@@ -62,7 +62,8 @@ make image
 kubectl apply -f artifacts/examples/submarine-operator-service-account.yaml
 
 # Step3: Deploy a submarine-operator
-kubectl apply -f artifacts/examples/submarine-operator.yaml
+kubectl create ns submarine-operator-test
+kubectl apply -n submarine-operator-test -f artifacts/examples/example-submarine.yaml
 
 # Step4: Inspect submarine-operator POD logs 
 kubectl logs ${submarine-operator POD}


### PR DESCRIPTION
### What is this PR for?
This Jira aims to handle the delete events of custom resource "submarine". To elaborate, when the informer of the custom resource "submarine" receives a delete event, the submarine operator needs to delete the resources related to the "submarine" instance.

Reference:
(1) CRD: https://github.com/apache/submarine/blob/master/submarine-cloud-v2/artifacts/examples/crd.yaml
(2) CR: https://github.com/apache/submarine/blob/master/submarine-cloud-v2/artifacts/examples/example-submarine.yaml
### What type of PR is it?
[Feature]

### Todos
* Create namespace via submarine operator

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-816

### How should this be tested?
```
# Step1-1: In-cluster
eval $(minikube docker-env)
make image
kubectl apply -f artifacts/examples/submarine-operator-service-account.yaml
kubectl create ns submarine-operator-test
kubectl apply -n submarine-operator-test -f artifacts/examples/example-submarine.yaml

# Step1-2: Out-of-cluster
go build -o submarine-operator
./submarine-operator
kubectl create ns submarine-operator-test
kubectl apply -n submarine-operator-test -f artifacts/examples/example-submarine.yaml

# Step2: Delete Custom Resource
kubectl delete submarine example-submarine -n submarine-operator-test

# Step3: Check the result
kubectl get ns
kubectl get pv
```

### Screenshots (if appropriate)
* Step1: Create example-submarine (custom resource) in namespace submarine-operator-test
* Step2: Delete example-submarine



https://user-images.githubusercontent.com/20109646/117336563-eeedf400-aece-11eb-8d11-aff3b146de6e.mov



### Questions:
* Do the license files need updating? No
* Are there breaking changes for older versions? No
* Does this need new documentation? Yes
