### PR TITLE
SUBMARINE-820. Fix github action error

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -12,6 +12,14 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: '1.8'
+      - name: Set up Maven 3.6.3
+        uses: stCarolas/setup-maven@v4
+        with:
+          maven-version: 3.6.3
+      - name: Check version
+        run: |
+          mvn --version
+          java -version
       - uses: actions/cache@v1
         with:
           path: ~/.m2/repository/com
@@ -56,9 +64,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-java@v1
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
         with:
           java-version: '1.8'
+      - name: Set up Maven 3.6.3
+        uses: stCarolas/setup-maven@v4
+        with:
+          maven-version: 3.6.3
+      - name: Check version
+        run: |
+          mvn --version
+          java -version
       - uses: actions/cache@v1
         with:
           path: ~/.m2/repository/com

--- a/submarine-sdk/pysubmarine/submarine/ml/pytorch/input/libsvm_dataset.py
+++ b/submarine-sdk/pysubmarine/submarine/ml/pytorch/input/libsvm_dataset.py
@@ -30,6 +30,7 @@ from typing import List, Tuple
 class LIBSVMDataset(Dataset):
 
     def __init__(self, data_uri: str, sample_offset: np.ndarray):
+        super().__init__()
         self.data_uri = data_uri
         self.sample_offset = sample_offset
 

--- a/website/docs/devDocs/BuildFromCode.md
+++ b/website/docs/devDocs/BuildFromCode.md
@@ -19,7 +19,7 @@ title: How to Build Submarine
 ## Prerequisites
 
 + JDK 1.8
-+ Maven 3.3 or later ( 3.6.2 is known to fail, see SUBMARINE-273 )
++ Maven 3.3 or later ( < 3.8.1 )
 + Docker
 
 ## Quick Start

--- a/website/docs/devDocs/Development.md
+++ b/website/docs/devDocs/Development.md
@@ -44,7 +44,7 @@ From [This Video](https://youtu.be/32Na2k6Alv4), you will know how to deal with 
 ### Prerequisites
 
 - JDK 1.8
-- Maven 3.3 or later ( 3.6.2 is known to fail, see SUBMARINE-273 )
+- Maven 3.3 or later ( < 3.8.1 )
 - Docker
 
 ### Setting up checkstyle in IDE


### PR DESCRIPTION
### What is this PR for?
[This commit](https://github.com/actions/virtual-environments/commit/7a712168c20dcbccb1286056c0b5c0bd765f5bba) of Ubuntu runner at 20210504 updates Maven from 3.6.3 to 3.8.1, and causes our task to fail. I fix Maven version at 3.6.3 to solve this problem.

### What type of PR is it?
[Bug Fix]

### Questions:
* Do the license files need updating? No
* Are there breaking changes for older versions? No
* Does this need new documentation? No
