### PR TITLE
SUBMARINE-825. Handle non-namespaced resources in delete event handler 

### DIFF
--- a/submarine-cloud-v2/README.md
+++ b/submarine-cloud-v2/README.md
@@ -62,10 +62,13 @@ make image
 kubectl apply -f artifacts/examples/submarine-operator-service-account.yaml
 
 # Step3: Deploy a submarine-operator
+kubectl apply -f artifacts/examples/submarine-operator.yaml
+
+# Step4: Deploy a submarine
 kubectl create ns submarine-operator-test
 kubectl apply -n submarine-operator-test -f artifacts/examples/example-submarine.yaml
 
-# Step4: Inspect submarine-operator POD logs 
+# Step5: Inspect submarine-operator POD logs 
 kubectl logs ${submarine-operator POD}
 ```
 

--- a/submarine-cloud-v2/controller.go
+++ b/submarine-cloud-v2/controller.go
@@ -189,7 +189,7 @@ func (c *Controller) Run(threadiness int, stopCh <-chan struct{}) error {
 	}
 
 	klog.Info("Starting workers")
-	// Launch two workers to process Submarine resources
+	// Launch $threadiness workers to process Submarine resources
 	for i := 0; i < threadiness; i++ {
 		go wait.Until(c.runWorker, time.Second, stopCh)
 	}

--- a/submarine-cloud-v2/main.go
+++ b/submarine-cloud-v2/main.go
@@ -102,7 +102,7 @@ func main() {
 	traefikInformerFactory.Start(stopCh)
 
 	// Run controller
-	if err = controller.Run(2, stopCh); err != nil {
+	if err = controller.Run(1, stopCh); err != nil {
 		klog.Fatalf("Error running controller: %s", err.Error())
 	}
 }


### PR DESCRIPTION
### What is this PR for?
#### Issue 1

Resources can be categorized into four categories

Type 1: namespaced resource created by client-go API

Type 2: non-namespaced resource created by client-go API, ex: persistent volume

Type 3: namespaced resource created by Helm API

Type 4: non-namespaced resource created by Helm API, ex: clusterrole (traefik)

Currently, the delete event resource handler can handle type 1, 2, 3, but this is not enough. Thus, this Jira aims to handle Type 4. If we do not handle Type 4, the error message will be shown as follows.

```
2021/05/11 09:58:50 rendered manifests contain a resource that already exists. Unable to continue with install: ClusterRole "traefik" in namespace "" exists and cannot be imported into the current release: invalid ownership metadata; annotation validation error: key "meta.helm.sh/release-namespace" must equal "submarine-operator-test": current value is "submarine-operator-test-2"
```

#### Issue 2
Originally, we have two workers to handle the WorkQueueItems in the WorkQueue. However, it will cause some race conditions. To elaborate, worker A and worker B call `helm install traefik` at the same time, and thus one of the workers will report the error `release exist `.

To solve this problem, we change the number of workers to 1 temporarily. However, this solution is not good enough, and thus we need use concurrency techniques, such as Lock and Channel, to avoid these race conditions.


### What type of PR is it?
[Bug Fix]

### Todos
* Handle race conditions caused by multi workers
* Maintain `charts []helm.HelmUninstallInfo` for multi-tenant

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-825

### How should this be tested?
```
# Step1: Out-of-cluster
go build -o submarine-operator
./submarine-operator

# Step2: Create submarine in namespace "submarine-operator-test"
kubectl create ns submarine-operator-test
kubectl apply -n submarine-operator-test -f artifacts/examples/example-submarine.yaml

# Step2: Delete Custom Resource
kubectl delete submarine example-submarine -n submarine-operator-test

# Step3: Check the result (non-namespaced resources)
kubectl get ns 
kubectl get pv
kubectl get clusterrole

# Step4: Create submarine in namespace "submarine-operator-test-2"
kubectl create ns submarine-operator-test-2
kubectl apply -n submarine-operator-test-2 -f artifacts/examples/example-submarine.yaml

# Step5: Delete Custom Resource
kubectl delete submarine example-submarine -n submarine-operator-test-2

# Step6: Check the result (non-namespaced resources)
kubectl get ns
kubectl get pv
kubectl get clusterrole
```

### Screenshots (if appropriate)

### Questions:
* Do the license files need updating? No
* Are there breaking changes for older versions? No
* Does this need new documentation? No
