### PR TITLE
SUBMARINE 819. Create namespace for single user

### DIFF
--- a/submarine-cloud-v2/controller.go
+++ b/submarine-cloud-v2/controller.go
@@ -1069,16 +1069,9 @@ func (c *Controller) syncHandler(workqueueItem WorkQueueItem) error {
 		utilruntime.HandleError(fmt.Errorf("Invalid resource key: %s", key))
 		return nil
 	}
+	newNamespace := "submarine-user-test"
 
 	klog.Info("syncHandler: ", key, " / ", action)
-
-	// create submarine in a new namespace
-	newNamespace := "submarine-user-test"
-	nsSpec := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: newNamespace}}
-	_, err = c.kubeclientset.CoreV1().Namespaces().Create(context.TODO(), nsSpec, metav1.CreateOptions{})
-	if err != nil {
-		return err
-	}
 
 	if action != DELETE { // Case: ADD & UPDATE
 		klog.Info("Add / Update: ", key)
@@ -1096,6 +1089,13 @@ func (c *Controller) syncHandler(workqueueItem WorkQueueItem) error {
 		// Print out the spec of the Submarine resource
 		b, err := json.MarshalIndent(submarine.Spec, "", "  ")
 		fmt.Println(string(b))
+
+		// create submarine in a new namespace
+		nsSpec := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: newNamespace}}
+		_, err = c.kubeclientset.CoreV1().Namespaces().Create(context.TODO(), nsSpec, metav1.CreateOptions{})
+		if err != nil {
+			return err
+		}
 
 		// Install subcharts
 		c.newSubCharts(newNamespace)

--- a/submarine-cloud-v2/controller.go
+++ b/submarine-cloud-v2/controller.go
@@ -1152,8 +1152,8 @@ func (c *Controller) syncHandler(workqueueItem WorkQueueItem) error {
 		if err != nil {
 			return err
 		}
-		klog.Info("Delete Namespace: ", namespace)
 
+		// Delete non-namespaced resources (ex: PersistentVolume)
 		err = c.kubeclientset.CoreV1().PersistentVolumes().Delete(context.TODO(), "submarine-database-pv--"+newNamespace, metav1.DeleteOptions{})
 		if err != nil {
 			return err
@@ -1163,7 +1163,6 @@ func (c *Controller) syncHandler(workqueueItem WorkQueueItem) error {
 		if err != nil {
 			return err
 		}
-		klog.Info("Delete pv")
 	}
 
 	return nil

--- a/submarine-cloud-v2/main.go
+++ b/submarine-cloud-v2/main.go
@@ -19,16 +19,17 @@ package main
 
 import (
 	"flag"
-	kubeinformers "k8s.io/client-go/informers"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
-	"k8s.io/klog/v2"
 	"os"
 	clientset "submarine-cloud-v2/pkg/generated/clientset/versioned"
 	informers "submarine-cloud-v2/pkg/generated/informers/externalversions"
 	"submarine-cloud-v2/pkg/signals"
 	"time"
+
+	kubeinformers "k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/klog/v2"
 
 	traefikclientset "github.com/traefik/traefik/v2/pkg/provider/kubernetes/crd/generated/clientset/versioned"
 	traefikinformers "github.com/traefik/traefik/v2/pkg/provider/kubernetes/crd/generated/informers/externalversions"


### PR DESCRIPTION
### What is this PR for?

Create a namespace `submarine-user-test` of submarine for single user

### What type of PR is it?
[Feature]

### Todos

### What is the Jira issue?

https://issues.apache.org/jira/projects/SUBMARINE/issues/SUBMARINE-819

### How should this be tested?

Create submarine:
```bash
cd submarine-cloud-v2
kubectl create ns submarine-operator-test
kubectl apply -f artifacts/example/crd.yaml
kubectl apply -f artifacts/examples/example-submarine.yaml -n submarine-operator-test
go builld -o submarine-operator
./submarine-operator
kubectl port-forward --address 0.0.0.0 service/traefik 32080:80 -n submarine-user-test
```

Delete submarine:
```bash
kubectl delete submarine example-submarine -n submarine-operator-test
```

### Screenshots (if appropriate)

https://user-images.githubusercontent.com/17617373/118001859-b1c7ad00-b379-11eb-8651-a829e90c050a.mov

### Questions:

* Do the license files need updating? No
* Are there breaking changes for older versions? No
* Does this need new documentation? No
