### PR TITLE
SUBMARINE-826. Tensorboard and mlflow can't be connected in custom namespace

### DIFF
--- a/submarine-cloud-v2/controller.go
+++ b/submarine-cloud-v2/controller.go
@@ -359,6 +359,10 @@ func (c *Controller) newSubmarineServer(namespace string, serverImage string, se
 											Name:  "K8S_APISERVER_URL",
 											Value: "kubernetes.default.svc",
 										},
+										{
+											Name: "ENV_NAMESPACE",
+											Value: namespace,
+										},
 									},
 									Ports: []corev1.ContainerPort{
 										{

--- a/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/K8sSubmitter.java
+++ b/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/K8sSubmitter.java
@@ -264,7 +264,7 @@ public class K8sSubmitter implements Submitter {
   @Override
   public TensorboardInfo getTensorboardInfo() throws SubmarineRuntimeException {
     final String name = "submarine-tensorboard";
-    final String namespace = "default";
+    final String namespace = "submarine-operator-test";
     final String ingressRouteName = "submarine-tensorboard-ingressroute";
 
     try {
@@ -303,7 +303,7 @@ public class K8sSubmitter implements Submitter {
   @Override
   public MlflowInfo getMlflowInfo() throws SubmarineRuntimeException {
     final String name = "submarine-mlflow";
-    final String namespace = "default";
+    final String namespace = "submarine-operator-test";
     final String ingressRouteName = "submarine-mlflow-ingressroute";
 
     try {

--- a/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/K8sSubmitter.java
+++ b/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/K8sSubmitter.java
@@ -83,6 +83,8 @@ public class K8sSubmitter implements Submitter {
 
   private static final String TF_JOB_SELECTOR_KEY = "tf-job-name=";
   private static final String PYTORCH_JOB_SELECTOR_KEY = "pytorch-job-name=";
+  
+  private static final String ENV_NAMESPACE = "ENV_NAMESPACE";
 
   // K8s API client for CRD
   private CustomObjectsApi api;
@@ -264,8 +266,11 @@ public class K8sSubmitter implements Submitter {
   @Override
   public TensorboardInfo getTensorboardInfo() throws SubmarineRuntimeException {
     final String name = "submarine-tensorboard";
-    final String namespace = "submarine-operator-test";
     final String ingressRouteName = "submarine-tensorboard-ingressroute";
+    String namespace = "default";
+    if (System.getenv(ENV_NAMESPACE) != null) {
+      namespace = System.getenv(ENV_NAMESPACE);
+    }
 
     try {
       V1Deployment deploy =  appsV1Api.readNamespacedDeploymentStatus(name, namespace, "true");
@@ -303,8 +308,11 @@ public class K8sSubmitter implements Submitter {
   @Override
   public MlflowInfo getMlflowInfo() throws SubmarineRuntimeException {
     final String name = "submarine-mlflow";
-    final String namespace = "submarine-operator-test";
     final String ingressRouteName = "submarine-mlflow-ingressroute";
+    String namespace = "default";
+    if (System.getenv(ENV_NAMESPACE) != null) {
+      namespace = System.getenv(ENV_NAMESPACE);
+    }
 
     try {
       V1Deployment deploy =  appsV1Api.readNamespacedDeploymentStatus(name, namespace, "true");


### PR DESCRIPTION
### What is this PR for?
Can't connect tensorboard and mlflow from workbench in custom namespace created by operator.
K8sSubmitter have set namespace to "default" on tensorboard and mlflow

Reference:
https://github.com/apache/submarine/blob/master/submarine-server/server-submitter/[…]ava/org/apache/submarine/server/submitter/k8s/K8sSubmitter.java

### What type of PR is it?
[Bug Fix]

### Todos

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-826

### How should this be tested?

https://user-images.githubusercontent.com/17617373/118857684-e7850c80-b90a-11eb-8a3c-cd256cd33a6b.mov



### Screenshots (if appropriate)

### Questions:
* Do the license files need updating? No
* Are there breaking changes for older versions? No
* Does this need new documentation? No
