### PR TITLE
SUBMARINE-836. Frontend E2E test for Submarine Operator

### DIFF
--- a/submarine-cloud-v2/README.md
+++ b/submarine-cloud-v2/README.md
@@ -155,3 +155,19 @@ Examples:
 ./hack/build_image.sh all     # build all images
 ./hack/build_image.sh server  # only build the server image
 ```
+
+# Run frontend E2E tests
+
+Use the following helper script to run frontend E2E tests.
+
+```
+# Prerequisite: Make sure Workbench is running on 127.0.0.1:8080.
+./hack/run_frontend_e2e.sh [testcase]
+```
+* [testcase]: Check the directory [integration](../submarine-test/test-e2e/src/test/java/org/apache/submarine/integration/).
+
+Examples:
+
+```
+./hack/run_frontend_e2e.sh loginIT
+```

--- a/submarine-cloud-v2/controller.go
+++ b/submarine-cloud-v2/controller.go
@@ -360,7 +360,7 @@ func (c *Controller) newSubmarineServer(namespace string, serverImage string, se
 											Value: "kubernetes.default.svc",
 										},
 										{
-											Name: "ENV_NAMESPACE",
+											Name:  "ENV_NAMESPACE",
 											Value: namespace,
 										},
 									},
@@ -1153,7 +1153,7 @@ func (c *Controller) syncHandler(workqueueItem WorkQueueItem) error {
 		//   (3) in-cluster
 		if action == ADD {
 			if !c.incluster {
-				c.portfwdCmd = k8sutil.ServicePortForwardPort(context.TODO(), newNamespace, "traefik", 32080, 80, color.FgGreen)
+				c.portfwdCmd = k8sutil.ServicePortForwardPort(context.TODO(), newNamespace, "traefik", 8080, 80, color.FgGreen)
 			}
 		}
 	} else { // Case: DELETE

--- a/submarine-cloud-v2/hack/run_frontend_e2e.sh
+++ b/submarine-cloud-v2/hack/run_frontend_e2e.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Description: Run a frontend E2E tests
+# Usage: ./run_frontend_e2e.sh [Testcase]
+#       Testcase: Check the directory "submarine-test/test-e2e/src/test/java/org/apache/submarine/integration"
+#       Example : ./run_frontend_e2e.sh loginIT
+
+SUBMARINE_HOME=`git rev-parse --show-toplevel`
+
+# Do not modify these two variables.
+WORKBENCH_PORT=8080
+URL="127.0.0.1"
+
+cd "$SUBMARINE_HOME"
+
+HTTP_CODE=$(curl -sL -w "%{http_code}\\n" $URL:$WORKBENCH_PORT -o /dev/null)
+if [[ "$HTTP_CODE" != "200" ]]; then
+  echo "Make sure Submarine Workbench is running on $URL:$WORKBENCH_PORT"
+  exit 1
+else
+  echo "HTTP_CODE ($URL:$WORKBENCH_PORT): $HTTP_CODE"
+fi
+
+set -e
+TESTCASE=$1
+mvn -f submarine-test/test-e2e/ -Dtest=$TESTCASE -DSUBMARINE_E2E_LOCAL=true test

--- a/submarine-test/test-e2e/src/test/java/org/apache/submarine/ChromeWebDriverProvider.java
+++ b/submarine-test/test-e2e/src/test/java/org/apache/submarine/ChromeWebDriverProvider.java
@@ -101,7 +101,9 @@ public class ChromeWebDriverProvider implements WebDriverProvider {
     ChromeOptions chromeOptions = new ChromeOptions();
     chromeOptions.setExperimentalOption("prefs", chromePrefs);
     LOG.info("Set default download directory: " + downloadPath);
-    chromeOptions.addArguments("--headless");
+    if (Boolean.valueOf(System.getProperty("SUBMARINE_E2E_LOCAL")) == false) {
+      chromeOptions.addArguments("--headless");
+    }
     return new ChromeDriver(chromeOptions);
   }
 


### PR DESCRIPTION
### What is this PR for?
To make sure of the correctness of Submarine Operator, a helper script to execute the frontend E2E test is necessary.

### What type of PR is it?
[Feature]

### Todos
* Survey unstable testcases (sidebarIT, departmentIT, loginIT, notebookIT, environmentIT)
  * Start from departmentIT
* Improve the flexibility of E2E test framework (ex: Make the port in run_frontend_e2e.sh modifiable.)
* Update [IntegrationTest.md](https://github.com/apache/submarine/blob/master/website/docs/devDocs/IntegrationTest.md)
* Testcases for experiment page are not enough


### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-836

### How should this be tested?
```
# Step1: Build & Run submarine operator (out-of-cluster)
go build -o submarine-operator
./submarine-operator

# Step2: Create a Custom Resource
kubectl create ns submarine-operator-test
kubectl apply -n submarine-operator-test -f artifacts/examples/example-submarine.yaml

# Step3: Check Cluster status (Until every resource is ready)
kubectl get all -n submarine-user-test

# Step4: Check Workbench (127.0.0.1:8080)

# Step5: Run a frontend E2E testcase
#             Usage: ./hack/run_frontend_e2e.sh [testcase]
#             [testcase]: Check the directory "submarine-test/test-e2e/src/test/java/org/apache/submarine/integration"
./hack/run_frontend_e2e.sh loginIT
```

### Screenshots (if appropriate)

https://user-images.githubusercontent.com/20109646/119352359-2a146380-bcd4-11eb-825f-1492328f03c3.mov


<img width="953" alt="截圖 2021-05-24 下午9 07 52" src="https://user-images.githubusercontent.com/20109646/119352331-1ff26500-bcd4-11eb-9540-043ee47b3747.png">


### Questions:
* Do the license files need updating? No
* Are there breaking changes for older versions? No
* Does this need new documentation? No
