### PR TITLE
SUBMARINE-845. Fix submarine-server test->ClusterRestApiTest->testGetClusterNode

### DIFF
--- a/submarine-server/server-core/src/test/java/org/apache/submarine/server/rest/ClusterRestApiTest.java
+++ b/submarine-server/server-core/src/test/java/org/apache/submarine/server/rest/ClusterRestApiTest.java
@@ -145,7 +145,8 @@ public class ClusterRestApiTest {
         result.get(0).get(ClusterMeta.NODE_NAME));
     assertEquals("ONLINE", properties.get("STATUS"));
     assertEquals(INTP_START_TIME.format(DateTimeFormatter.ISO_DATE_TIME), properties.get("INTP_START_TIME"));
-    assertEquals(LATEST_HEARTBEAT.format(DateTimeFormatter.ISO_DATE_TIME), properties.get("LATEST_HEARTBEAT"));
+    assertEquals(LATEST_HEARTBEAT.format(DateTimeFormatter.ISO_DATE_TIME),
+        properties.get("LATEST_HEARTBEAT"));
   }
 
   private <T> List<T> getResultListFromResponse(Response response, Class<T> typeT) {

--- a/submarine-server/server-core/src/test/java/org/apache/submarine/server/rest/ClusterRestApiTest.java
+++ b/submarine-server/server-core/src/test/java/org/apache/submarine/server/rest/ClusterRestApiTest.java
@@ -34,6 +34,7 @@ import org.junit.BeforeClass;
 
 import javax.ws.rs.core.Response;
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -143,8 +144,8 @@ public class ClusterRestApiTest {
     assertEquals(clusterMetas.get(nodeName1).get(ClusterMeta.NODE_NAME),
         result.get(0).get(ClusterMeta.NODE_NAME));
     assertEquals("ONLINE", properties.get("STATUS"));
-    assertEquals(INTP_START_TIME.toString(), properties.get("INTP_START_TIME"));
-    assertEquals(LATEST_HEARTBEAT.toString(), properties.get("LATEST_HEARTBEAT"));
+    assertEquals(INTP_START_TIME.format(DateTimeFormatter.ISO_DATE_TIME), properties.get("INTP_START_TIME"));
+    assertEquals(LATEST_HEARTBEAT.format(DateTimeFormatter.ISO_DATE_TIME), properties.get("LATEST_HEARTBEAT"));
   }
 
   private <T> List<T> getResultListFromResponse(Response response, Class<T> typeT) {


### PR DESCRIPTION
### What is this PR for?
ISO DATE TIME FORMAT will remove the last 0 in the DateTime object (ex: XXX-XXX-XXX0 -> XXX-XXX-XXX), but DateTime object to string will keep the origin format (ex: XXX-XXX-XXX0 -> XXX-XXX-XXX0)
Solved by using the same formatter.

### What type of PR is it?
[CI/CD]

### Todos

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-845

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* Do the license files need updating? No
* Are there breaking changes for older versions? No
* Does this need new documentation? No
