### PR TITLE
SUBMARINE-844. allow notebook operation could work on assigned namespace

### DIFF
--- a/bin/common.sh
+++ b/bin/common.sh
@@ -88,8 +88,11 @@ function download_mysql_jdbc_jar(){
   echo "Mysql jdbc jar is downloaded and put in the path of submarine/lib."
 }
 
+ENV_NAMESPACE="default"
+
 JAVA_OPTS+=" -Dfile.encoding=UTF-8"
 JAVA_OPTS+=" -Dlog4j.configuration=file://${SUBMARINE_CONF_DIR}/log4j.properties"
+JAVA_OPTS+=" -DENV_NAMESPACE=${ENV_NAMESPACEn}"
 export JAVA_OPTS
 
 if [[ -n "${JAVA_HOME}" ]]; then

--- a/bin/common.sh
+++ b/bin/common.sh
@@ -92,7 +92,7 @@ ENV_NAMESPACE="default"
 
 JAVA_OPTS+=" -Dfile.encoding=UTF-8"
 JAVA_OPTS+=" -Dlog4j.configuration=file://${SUBMARINE_CONF_DIR}/log4j.properties"
-JAVA_OPTS+=" -DENV_NAMESPACE=${ENV_NAMESPACEn}"
+JAVA_OPTS+=" -DENV_NAMESPACE=${ENV_NAMESPACE}"
 export JAVA_OPTS
 
 if [[ -n "${JAVA_HOME}" ]]; then

--- a/bin/common.sh
+++ b/bin/common.sh
@@ -88,11 +88,8 @@ function download_mysql_jdbc_jar(){
   echo "Mysql jdbc jar is downloaded and put in the path of submarine/lib."
 }
 
-ENV_NAMESPACE="default"
-
 JAVA_OPTS+=" -Dfile.encoding=UTF-8"
 JAVA_OPTS+=" -Dlog4j.configuration=file://${SUBMARINE_CONF_DIR}/log4j.properties"
-JAVA_OPTS+=" -DENV_NAMESPACE=${ENV_NAMESPACE}"
 export JAVA_OPTS
 
 if [[ -n "${JAVA_HOME}" ]]; then

--- a/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/K8sSubmitter.java
+++ b/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/K8sSubmitter.java
@@ -268,9 +268,9 @@ public class K8sSubmitter implements Submitter {
     final String name = "submarine-tensorboard";
     final String ingressRouteName = "submarine-tensorboard-ingressroute";
     String namespace = "default";
-    if (System.getProperty(ENV_NAMESPACE) != null) {
-      namespace = System.getProperty(ENV_NAMESPACE);
-    }
+    if (System.getenv(ENV_NAMESPACE) != null) {
+        namespace = System.getenv(ENV_NAMESPACE);
+      }
 
     try {
       V1Deployment deploy =  appsV1Api.readNamespacedDeploymentStatus(name, namespace, "true");
@@ -429,9 +429,9 @@ public class K8sSubmitter implements Submitter {
     final String pvcName = NotebookUtils.PVC_PREFIX + name;
     String namespace = "default";
     
-    if (System.getProperty(ENV_NAMESPACE) != null) {
-      namespace = System.getenv(ENV_NAMESPACE);
-    }
+    if (System.getenv(ENV_NAMESPACE) != null) {
+        namespace = System.getenv(ENV_NAMESPACE);
+      }
     
     try {
       NotebookCR notebookCR = NotebookSpecParser.parseNotebook(spec);

--- a/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/K8sSubmitter.java
+++ b/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/K8sSubmitter.java
@@ -118,6 +118,7 @@ public class K8sSubmitter implements Submitter {
       api = new CustomObjectsApi();
     }
     if (coreApi == null) {
+      client.setDebugging(true);
       coreApi = new CoreV1Api(client);
     }
 
@@ -355,18 +356,25 @@ public class K8sSubmitter implements Submitter {
     final String host = NotebookUtils.HOST_PATH;
     final String storage = NotebookUtils.STORAGE;
     final String pvcName = NotebookUtils.PVC_PREFIX + name;
+    String namespace = "default";
+    
+    if (System.getenv(ENV_NAMESPACE) != null) {
+      namespace = System.getenv(ENV_NAMESPACE);
+    }
+    
     try {
       // create notebook custom resource
       NotebookCR notebookCR = NotebookSpecParser.parseNotebook(spec);
       Map<String, String> labels = new HashMap<>();
       labels.put(NotebookCR.NOTEBOOK_OWNER_SELECTOR_KET, spec.getMeta().getOwnerId());
       notebookCR.getMetadata().setLabels(labels);
-
+      notebookCR.getMetadata().setNamespace(namespace);
+      
       // create persistent volume
       createPersistentVolume(pvName, host, storage);
 
       // create persistent volume claim
-      createPersistentVolumeClaim(pvcName, spec.getMeta().getNamespace(), pvName, storage);
+      createPersistentVolumeClaim(pvcName, namespace, pvName, storage);
 
       // bind persistent volume claim
       V1PersistentVolumeClaimVolumeSource pvcSource = new V1PersistentVolumeClaimVolumeSource()
@@ -374,7 +382,7 @@ public class K8sSubmitter implements Submitter {
       notebookCR.getSpec().getTemplate().getSpec().getVolumes().get(0).persistentVolumeClaim(pvcSource);
 
       Object object = api.createNamespacedCustomObject(notebookCR.getGroup(), notebookCR.getVersion(),
-              notebookCR.getMetadata().getNamespace(), notebookCR.getPlural(), notebookCR, "true");
+              namespace, notebookCR.getPlural(), notebookCR, "true");
       notebook = NotebookUtils.parseObject(object, NotebookUtils.ParseOpt.PARSE_OPT_CREATE);
 
       // create Traefik custom resource
@@ -394,10 +402,18 @@ public class K8sSubmitter implements Submitter {
   @Override
   public Notebook findNotebook(NotebookSpec spec) throws SubmarineRuntimeException {
     Notebook notebook;
+    String namespace = "default";
+    
+    if (System.getenv(ENV_NAMESPACE) != null) {
+      namespace = System.getenv(ENV_NAMESPACE);
+    }
+    
     try {
+           
+        
       NotebookCR notebookCR = NotebookSpecParser.parseNotebook(spec);
       Object object = api.getNamespacedCustomObject(notebookCR.getGroup(), notebookCR.getVersion(),
-              notebookCR.getMetadata().getNamespace(),
+              namespace,
               notebookCR.getPlural(), notebookCR.getMetadata().getName());
       notebook = NotebookUtils.parseObject(object, NotebookUtils.ParseOpt.PARSE_OPT_GET);
     } catch (ApiException e) {
@@ -412,16 +428,22 @@ public class K8sSubmitter implements Submitter {
     final String name = spec.getMeta().getName();
     final String pvName = NotebookUtils.PV_PREFIX + name;
     final String pvcName = NotebookUtils.PVC_PREFIX + name;
+    String namespace = "default";
+    
+    if (System.getenv(ENV_NAMESPACE) != null) {
+      namespace = System.getenv(ENV_NAMESPACE);
+    }
+    
     try {
       NotebookCR notebookCR = NotebookSpecParser.parseNotebook(spec);
       Object object = api.deleteNamespacedCustomObject(notebookCR.getGroup(), notebookCR.getVersion(),
-              notebookCR.getMetadata().getNamespace(), notebookCR.getPlural(),
+              namespace, notebookCR.getPlural(),
               notebookCR.getMetadata().getName(),
               new V1DeleteOptionsBuilder().withApiVersion(notebookCR.getApiVersion()).build(),
               null, null, null);
       notebook = NotebookUtils.parseObject(object, NotebookUtils.ParseOpt.PARSE_OPT_DELETE);
-      deleteIngressRoute(notebookCR.getMetadata().getNamespace(), notebookCR.getMetadata().getName());
-      deletePersistentVolumeClaim(pvcName, spec.getMeta().getNamespace());
+      deleteIngressRoute(namespace, notebookCR.getMetadata().getName());
+      deletePersistentVolumeClaim(pvcName, namespace);
       deletePersistentVolume(pvName);
     } catch (ApiException e) {
       throw new SubmarineRuntimeException(e.getCode(), e.getMessage());

--- a/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/K8sSubmitter.java
+++ b/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/K8sSubmitter.java
@@ -269,8 +269,8 @@ public class K8sSubmitter implements Submitter {
     final String ingressRouteName = "submarine-tensorboard-ingressroute";
     String namespace = "default";
     if (System.getenv(ENV_NAMESPACE) != null) {
-        namespace = System.getenv(ENV_NAMESPACE);
-      }
+      namespace = System.getenv(ENV_NAMESPACE);
+    }
 
     try {
       V1Deployment deploy =  appsV1Api.readNamespacedDeploymentStatus(name, namespace, "true");
@@ -430,8 +430,8 @@ public class K8sSubmitter implements Submitter {
     String namespace = "default";
     
     if (System.getenv(ENV_NAMESPACE) != null) {
-        namespace = System.getenv(ENV_NAMESPACE);
-      }
+      namespace = System.getenv(ENV_NAMESPACE);
+    }
     
     try {
       NotebookCR notebookCR = NotebookSpecParser.parseNotebook(spec);

--- a/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/K8sSubmitter.java
+++ b/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/K8sSubmitter.java
@@ -269,8 +269,8 @@ public class K8sSubmitter implements Submitter {
     final String name = "submarine-tensorboard";
     final String ingressRouteName = "submarine-tensorboard-ingressroute";
     String namespace = "default";
-    if (System.getenv(ENV_NAMESPACE) != null) {
-      namespace = System.getenv(ENV_NAMESPACE);
+    if (System.getProperty(ENV_NAMESPACE) != null) {
+      namespace = System.getProperty(ENV_NAMESPACE);
     }
 
     try {
@@ -311,8 +311,8 @@ public class K8sSubmitter implements Submitter {
     final String name = "submarine-mlflow";
     final String ingressRouteName = "submarine-mlflow-ingressroute";
     String namespace = "default";
-    if (System.getenv(ENV_NAMESPACE) != null) {
-      namespace = System.getenv(ENV_NAMESPACE);
+    if (System.getProperty(ENV_NAMESPACE) != null) {
+      namespace = System.getProperty(ENV_NAMESPACE);
     }
 
     try {
@@ -358,8 +358,8 @@ public class K8sSubmitter implements Submitter {
     final String pvcName = NotebookUtils.PVC_PREFIX + name;
     String namespace = "default";
     
-    if (System.getenv(ENV_NAMESPACE) != null) {
-      namespace = System.getenv(ENV_NAMESPACE);
+    if (System.getProperty(ENV_NAMESPACE) != null) {
+      namespace = System.getProperty(ENV_NAMESPACE);
     }
     
     try {
@@ -404,7 +404,7 @@ public class K8sSubmitter implements Submitter {
     Notebook notebook;
     String namespace = "default";
     
-    if (System.getenv(ENV_NAMESPACE) != null) {
+    if (System.getProperty(ENV_NAMESPACE) != null) {
       namespace = System.getenv(ENV_NAMESPACE);
     }
     
@@ -430,7 +430,7 @@ public class K8sSubmitter implements Submitter {
     final String pvcName = NotebookUtils.PVC_PREFIX + name;
     String namespace = "default";
     
-    if (System.getenv(ENV_NAMESPACE) != null) {
+    if (System.getProperty(ENV_NAMESPACE) != null) {
       namespace = System.getenv(ENV_NAMESPACE);
     }
     

--- a/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/K8sSubmitter.java
+++ b/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/K8sSubmitter.java
@@ -118,7 +118,6 @@ public class K8sSubmitter implements Submitter {
       api = new CustomObjectsApi();
     }
     if (coreApi == null) {
-      client.setDebugging(true);
       coreApi = new CoreV1Api(client);
     }
 
@@ -405,7 +404,7 @@ public class K8sSubmitter implements Submitter {
     String namespace = "default";
     
     if (System.getProperty(ENV_NAMESPACE) != null) {
-      namespace = System.getenv(ENV_NAMESPACE);
+      namespace = System.getProperty(ENV_NAMESPACE);
     }
     
     try {

--- a/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/K8sSubmitter.java
+++ b/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/K8sSubmitter.java
@@ -310,8 +310,8 @@ public class K8sSubmitter implements Submitter {
     final String name = "submarine-mlflow";
     final String ingressRouteName = "submarine-mlflow-ingressroute";
     String namespace = "default";
-    if (System.getProperty(ENV_NAMESPACE) != null) {
-      namespace = System.getProperty(ENV_NAMESPACE);
+    if (System.getenv(ENV_NAMESPACE) != null) {
+      namespace = System.getenv(ENV_NAMESPACE);
     }
 
     try {
@@ -357,8 +357,8 @@ public class K8sSubmitter implements Submitter {
     final String pvcName = NotebookUtils.PVC_PREFIX + name;
     String namespace = "default";
     
-    if (System.getProperty(ENV_NAMESPACE) != null) {
-      namespace = System.getProperty(ENV_NAMESPACE);
+    if (System.getenv(ENV_NAMESPACE) != null) {
+      namespace = System.getenv(ENV_NAMESPACE);
     }
     
     try {
@@ -403,8 +403,8 @@ public class K8sSubmitter implements Submitter {
     Notebook notebook;
     String namespace = "default";
     
-    if (System.getProperty(ENV_NAMESPACE) != null) {
-      namespace = System.getProperty(ENV_NAMESPACE);
+    if (System.getenv(ENV_NAMESPACE) != null) {
+      namespace = System.getenv(ENV_NAMESPACE);
     }
     
     try {


### PR DESCRIPTION
**What is this PR for?**
Currently the namespace which we use to execute notebook operation is passed from the frontend, which is hardcore which "default" value.(https://github.com/apache/submarine/blob/master/submarine-workbench/workbench-web/src/app/pages/workbench/notebook/notebook-home/notebook-form/notebook-form.component.ts#L184)
Per discussion with @kevin85421, we would like to make some change here to align the similar behavior in TFBoard(https://github.com/apache/submarine/blob/master/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/K8sSubmitter.java#L270-L273) which is assgend by operator.

**What type of PR is it?**
 Improvement 
**Todos**
 how to pass the assigned namespace via script or helm.
**What is the Jira issue?**
 https://issues.apache.org/jira/browse/SUBMARINE-844
**How should this be tested?**
create a notebook from UI, then check that is the notebook is created in the same namespace withe other modules insted of "default".

**Screenshots** 

<img width="1399" alt="截圖 2021-06-11 下午5 21 14" src="https://user-images.githubusercontent.com/5687317/121697297-7f87a780-caff-11eb-9a74-6798fbe9ce82.png">
<img width="1443" alt="截圖 2021-06-12 下午6 09 05" src="https://user-images.githubusercontent.com/5687317/121772727-df3a8d00-cba9-11eb-9db1-493e2924ed89.png">


**Questions:**
Do the license files need updating? No
Are there breaking changes for older versions? No
Does this need new documentation? No