### PR TITLE
SUBMARINE-853. [E2E] Avoid mixing implicit and explicit waits

### DIFF
--- a/submarine-test/test-e2e/src/test/java/org/apache/submarine/AbstractSubmarineIT.java
+++ b/submarine-test/test-e2e/src/test/java/org/apache/submarine/AbstractSubmarineIT.java
@@ -55,10 +55,6 @@ abstract public class AbstractSubmarineIT {
   protected static final long MAX_BROWSER_TIMEOUT_SEC = 60;
   protected static final long MAX_PARAGRAPH_TIMEOUT_SEC = 120;
 
-  protected String getParagraphXPath(int paragraphNo) {
-    return "(//div[@ng-controller=\"ParagraphCtrl\"])[" + paragraphNo + "]";
-  }
-
   protected WebElement pollingWait(final By locator, final long timeWait) {
     Wait<WebDriver> wait = new FluentWait<>(driver)
         .withTimeout(timeWait, TimeUnit.SECONDS)
@@ -91,12 +87,50 @@ abstract public class AbstractSubmarineIT {
     return URL;
   }
 
+  protected void Login() {
+    String username = "admin";
+    String password = "admin";
+    waitToPresent(By.cssSelector("input[ng-reflect-name='userName']"), MAX_BROWSER_TIMEOUT_SEC).sendKeys(username);
+    waitToPresent(By.cssSelector("input[ng-reflect-name='password']"), MAX_BROWSER_TIMEOUT_SEC).sendKeys(password);
+    Click(By.cssSelector("button[class='login-form-button ant-btn ant-btn-primary']"), MAX_BROWSER_TIMEOUT_SEC);
+    waitToPresent(By.cssSelector("a[routerlink='/workbench/experiment']"), MAX_BROWSER_TIMEOUT_SEC);
+  }
+
   protected WebElement buttonCheck(final By locator, final long timeWait) {
-    Wait<WebDriver> wait = new FluentWait<>(driver)
-        .withTimeout(timeWait, TimeUnit.SECONDS)
-        .pollingEvery(1, TimeUnit.SECONDS)
-        .ignoring(NoSuchElementException.class);
-    return wait.until(ExpectedConditions.elementToBeClickable(locator));
+    return new WebDriverWait(driver, timeWait)
+            .until(ExpectedConditions.elementToBeClickable(locator));
+  }
+
+  protected WebElement waitToPresent(final By locator, final long timeWait) {
+    return new WebDriverWait(driver, timeWait)
+              .until(ExpectedConditions.presenceOfElementLocated(locator));
+  }
+
+  protected void waitURL(String URL, final long timeWait) {
+    new WebDriverWait(driver, timeWait).until(ExpectedConditions.urlToBe​(URL)); 
+  }
+
+  protected void waitVisibility(WebElement element, final long timeWait) {
+    new WebDriverWait(driver, timeWait).until(ExpectedConditions.visibilityOf(element));
+  }
+
+  protected WebElement SendKeys(final By locator, final long timeWait, String content) {
+    WebElement input = waitToPresent(locator, timeWait);
+    waitVisibility(input, timeWait);
+    input.sendKeys(content);
+    return input;
+  }
+
+  protected WebElement Click(final By locator, final long timeWait) {
+    WebElement button = buttonCheck(locator, timeWait);
+    button.click();
+    return button;
+  }
+
+  protected WebElement ClickAndNavigate(final By locator, final long timeWait, String URL) {
+    WebElement button = Click(locator, timeWait);
+    waitURL(URL, timeWait);
+    return button;
   }
 
   protected void takeScreenShot(final String path) {

--- a/submarine-test/test-e2e/src/test/java/org/apache/submarine/WebDriverManager.java
+++ b/submarine-test/test-e2e/src/test/java/org/apache/submarine/WebDriverManager.java
@@ -68,7 +68,7 @@ public class WebDriverManager {
       url = System.getenv("url");
     } else if ((System.getProperty("SUBMARINE_WORKBENCH_URL") != null) || (System.getProperty("SUBMARINE_WORKBENCH_PORT") == null)) {
       if (System.getProperty("SUBMARINE_WORKBENCH_URL") == null) {
-        url = "http://localhost";
+        url = "http://127.0.0.1";
       } else {
         url = System.getProperty("SUBMARINE_WORKBENCH_URL"); 
       }
@@ -82,13 +82,11 @@ public class WebDriverManager {
         url = url.concat(String.valueOf(port));
       }
     } else {
-      url = "http://localhost:8080";
+      url = "http://127.0.0.1:8080";
     }
 
     long start = System.currentTimeMillis();
     boolean loaded = false;
-    driver.manage().timeouts().implicitlyWait(AbstractSubmarineIT.MAX_IMPLICIT_WAIT,
-        TimeUnit.SECONDS);
     driver.get(url);
 
     while (System.currentTimeMillis() - start < 60 * 1000) {

--- a/submarine-test/test-e2e/src/test/java/org/apache/submarine/integration/dataIT.java
+++ b/submarine-test/test-e2e/src/test/java/org/apache/submarine/integration/dataIT.java
@@ -48,7 +48,7 @@ public class dataIT extends AbstractSubmarineIT {
 
   @Test
   public void dataNavigation() throws Exception {
-    String URL = getURL("http://localhost", 8080);
+    String URL = getURL("http://127.0.0.1", 8080);
     // Login
     LOG.info("Login");
     pollingWait(By.cssSelector("input[ng-reflect-name='userName']"), MAX_BROWSER_TIMEOUT_SEC).sendKeys("admin");

--- a/submarine-test/test-e2e/src/test/java/org/apache/submarine/integration/datadictIT.java
+++ b/submarine-test/test-e2e/src/test/java/org/apache/submarine/integration/datadictIT.java
@@ -45,7 +45,7 @@ public class datadictIT extends AbstractSubmarineIT {
 
   // @Test TODO(kevin85421): Due to the undeterministic behavior of travis, I decide to comment it.
   public void dataDictTest() throws Exception {
-    String URL = getURL("http://localhost", 8080);
+    String URL = getURL("http://127.0.0.1", 8080);
     // Login
     LOG.info("Login");
     pollingWait(By.cssSelector("input[ng-reflect-name='userName']"), MAX_BROWSER_TIMEOUT_SEC).sendKeys("admin");

--- a/submarine-test/test-e2e/src/test/java/org/apache/submarine/integration/departmentIT.java
+++ b/submarine-test/test-e2e/src/test/java/org/apache/submarine/integration/departmentIT.java
@@ -46,29 +46,20 @@ public class departmentIT extends AbstractSubmarineIT{
 
   @Test
   public void dataNavigation() throws Exception {
-    String URL = getURL("http://localhost", 8080);
+    String URL = getURL("http://127.0.0.1", 8080);
     // Login
-    LOG.info("Login");
-    pollingWait(By.cssSelector("input[ng-reflect-name='userName']"), MAX_BROWSER_TIMEOUT_SEC).sendKeys("admin");
-    pollingWait(By.cssSelector("input[ng-reflect-name='password']"), MAX_BROWSER_TIMEOUT_SEC).sendKeys("admin");
-    clickAndWait(By.cssSelector("button[class='login-form-button ant-btn ant-btn-primary']"));
-    pollingWait(By.cssSelector("a[routerlink='/workbench/experiment']"), MAX_BROWSER_TIMEOUT_SEC);
+    Login();
 
     // Routing to department page
-    pollingWait(By.xpath("//span[contains(text(), \"Manager\")]"), MAX_BROWSER_TIMEOUT_SEC).click();
-    WebDriverWait wait = new WebDriverWait( driver, 60);
-    pollingWait(By.xpath("//a[@href='/workbench/manager/department']"), MAX_BROWSER_TIMEOUT_SEC).click();
-    wait.until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//span[@class='ant-breadcrumb-link ng-star-inserted']")));
-    Assert.assertEquals(driver.getCurrentUrl(), URL.concat("/workbench/manager/department"));
+    Click(By.xpath("//span[contains(text(), \"Manager\")]"), MAX_BROWSER_TIMEOUT_SEC);
+    ClickAndNavigate(By.xpath("//a[@href='/workbench/manager/department']"), MAX_BROWSER_TIMEOUT_SEC, 
+                      URL.concat("/workbench/manager/department"));
 
     // Test create new department
-    pollingWait(By.xpath("//button[@id='btnAddDepartment']"), MAX_BROWSER_TIMEOUT_SEC).click();
-    pollingWait(By.xpath("//input[@id='codeInput'] "), MAX_BROWSER_TIMEOUT_SEC).sendKeys("e2e Test");
-    pollingWait(By.xpath("//input[@id='nameInput']"), MAX_BROWSER_TIMEOUT_SEC).sendKeys("e2e Test");
-    wait.until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//label[@id='validCode']")));
-    pollingWait(By.xpath("//button[@id='btnSubmit']"), MAX_BROWSER_TIMEOUT_SEC).click();
-    wait.until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//nz-table[@id='departmentTable']")));
-    Assert.assertEquals(pollingWait(By.xpath("//td[contains(., 'e2e Test')]"), MAX_BROWSER_TIMEOUT_SEC).isDisplayed(), true);
-    
+    Click(By.xpath("//button[@id='btnAddDepartment']"), MAX_BROWSER_TIMEOUT_SEC);
+    SendKeys(By.xpath("//input[@id='codeInput'] "), MAX_BROWSER_TIMEOUT_SEC, "e2e Test");
+    SendKeys(By.xpath("//input[@id='nameInput']"), MAX_BROWSER_TIMEOUT_SEC, "e2e Test");
+    Click(By.xpath("//button[@id='btnSubmit']"), MAX_BROWSER_TIMEOUT_SEC);
+    waitToPresent(By.xpath("//td[contains(., 'e2e Test')]"), MAX_BROWSER_TIMEOUT_SEC); 
   }
 }

--- a/submarine-test/test-e2e/src/test/java/org/apache/submarine/integration/environmentIT.java
+++ b/submarine-test/test-e2e/src/test/java/org/apache/submarine/integration/environmentIT.java
@@ -56,33 +56,26 @@ public class environmentIT extends AbstractSubmarineIT {
 
   @Test
   public void environmentNavigation() throws Exception {
-    String URL = getURL("http://localhost", 8080);
+    String URL = getURL("http://127.0.0.1", 8080);
     // Login
-    LOG.info("Login");
-    pollingWait(By.cssSelector("input[ng-reflect-name='userName']"), MAX_BROWSER_TIMEOUT_SEC).sendKeys("admin");
-    pollingWait(By.cssSelector("input[ng-reflect-name='password']"), MAX_BROWSER_TIMEOUT_SEC).sendKeys("admin");
-    clickAndWait(By.cssSelector("button[class='login-form-button ant-btn ant-btn-primary']"));
-    pollingWait(By.cssSelector("a[routerlink='/workbench/experiment']"), MAX_BROWSER_TIMEOUT_SEC);
+    Login();
 
     // Routing to workspace
-    LOG.info("url");
-    pollingWait(By.xpath("//span[contains(text(), \"Environment\")]"), MAX_BROWSER_TIMEOUT_SEC).click();
-    Assert.assertEquals(driver.getCurrentUrl(), URL.concat("/workbench/environment"));
+    ClickAndNavigate(By.xpath("//span[contains(text(), \"Environment\")]"), MAX_BROWSER_TIMEOUT_SEC, URL.concat("/workbench/environment"));
 
     // Test create new environment
     LOG.info("Create new environment");
-    Assert.assertEquals(pollingWait(By.xpath("//button[@id='btn-newEnvironment']"), MAX_BROWSER_TIMEOUT_SEC).isDisplayed(), true);
-    pollingWait(By.xpath("//button[@id='btn-newEnvironment']"), MAX_BROWSER_TIMEOUT_SEC).click();
-    pollingWait(By.cssSelector("input[ng-reflect-name='environmentName']"), MAX_BROWSER_TIMEOUT_SEC).sendKeys("testEnvName");
-    pollingWait(By.cssSelector("input[ng-reflect-name='dockerImage']"), MAX_BROWSER_TIMEOUT_SEC).sendKeys("testDockerImage");
-    pollingWait(By.xpath("//nz-upload[@id='upload-config']"), MAX_BROWSER_TIMEOUT_SEC).click();
-    pollingWait(By.cssSelector("input[type=file]"), MAX_BROWSER_TIMEOUT_SEC).sendKeys(System.getProperty("user.dir") + "/src/test/resources/test_config_1.yml");
-    Assert.assertEquals(pollingWait(By.xpath("//button[@id='btn-submit']"), MAX_BROWSER_TIMEOUT_SEC).isDisplayed(), true);
-    pollingWait(By.xpath("//button[@id='btn-submit']"), MAX_BROWSER_TIMEOUT_SEC).click();
-    Assert.assertEquals(pollingWait(By.xpath("//button[@id='btn-newEnvironment']"), MAX_BROWSER_TIMEOUT_SEC).isDisplayed(), true);
+    Click(By.xpath("//button[@id='btn-newEnvironment']"), MAX_BROWSER_TIMEOUT_SEC);
+    SendKeys(By.cssSelector("input[ng-reflect-name='environmentName']"), MAX_BROWSER_TIMEOUT_SEC, "testEnvName");
+    SendKeys(By.cssSelector("input[ng-reflect-name='dockerImage']"), MAX_BROWSER_TIMEOUT_SEC, "testDockerImage");
+    Click(By.xpath("//nz-upload[@id='upload-config']"), MAX_BROWSER_TIMEOUT_SEC);
+
+    // Because "//input[@type="file"]" will not display, we cannot use SendKeys which calls waitVisibility.   
+    waitToPresent(By.xpath("//input[@type=\"file\"]"), MAX_BROWSER_TIMEOUT_SEC).sendKeys(System.getProperty("user.dir") + "/src/test/resources/test_config_1.yml");
+    Click(By.xpath("//button[@id='btn-submit']"), MAX_BROWSER_TIMEOUT_SEC);
 
     // Test download environment spec
-    pollingWait(By.xpath("//a[@id='btn-downloadEnvironmentSpec0']"), MAX_BROWSER_TIMEOUT_SEC).click();
+    Click(By.xpath("//a[@id='btn-downloadEnvironmentSpec0']"), MAX_BROWSER_TIMEOUT_SEC);
     File fileToCheck = Paths.get(WebDriverManager.getDownloadPath()).resolve("environmentSpec.json").toFile();
     Wait wait = new FluentWait(driver).withTimeout(MAX_BROWSER_TIMEOUT_SEC, SECONDS);
     wait.until(WebDriver -> fileToCheck.exists());

--- a/submarine-test/test-e2e/src/test/java/org/apache/submarine/integration/experimentIT.java
+++ b/submarine-test/test-e2e/src/test/java/org/apache/submarine/integration/experimentIT.java
@@ -45,21 +45,17 @@ public class experimentIT extends AbstractSubmarineIT {
 
   @Test
   public void experimentNavigation() throws Exception {
-    String URL = getURL("http://localhost", 8080);
+    String URL = getURL("http://127.0.0.1", 8080);
     LOG.info("[Test case]: experimentNavigation]");
     // Init the page object
     ExperimentPage experimentPage = new ExperimentPage(driver);
     // Login
     LOG.info("Login");
-    pollingWait(By.cssSelector("input[ng-reflect-name='userName']"), MAX_BROWSER_TIMEOUT_SEC).sendKeys("admin");
-    pollingWait(By.cssSelector("input[ng-reflect-name='password']"), MAX_BROWSER_TIMEOUT_SEC).sendKeys("admin");
-    clickAndWait(By.cssSelector("button[class='login-form-button ant-btn ant-btn-primary']"));
-    pollingWait(By.cssSelector("a[routerlink='/workbench/experiment']"), MAX_BROWSER_TIMEOUT_SEC);
+    Login();
 
     // Routing to workspace
     LOG.info("url");
-    pollingWait(By.xpath("//span[contains(text(), \"Experiment\")]"), MAX_BROWSER_TIMEOUT_SEC).click();
-    Assert.assertEquals(driver.getCurrentUrl(), URL.concat("/workbench/experiment"));
+    ClickAndNavigate(By.xpath("//span[contains(text(), \"Experiment\")]"), MAX_BROWSER_TIMEOUT_SEC, URL.concat("/workbench/experiment"));
 
     // Test create new experiment
     LOG.info("First step");
@@ -73,7 +69,7 @@ public class experimentIT extends AbstractSubmarineIT {
                     " --learning_rate=0.01 --batch_size=150",
             "apache/submarine:tf-mnist-with-summaries-1.0",
             "ENV_1", "ENV1");
-    pollingWait(By.xpath("//input[@id='git-repo']"), MAX_BROWSER_TIMEOUT_SEC).sendKeys("https://github.com/apache/submarine.git");
+    SendKeys(By.xpath("//input[@id='git-repo']"), MAX_BROWSER_TIMEOUT_SEC, "https://github.com/apache/submarine.git");
     Assert.assertTrue(experimentPage.getGoButton().isEnabled());
     experimentPage.goButtonClick();
 

--- a/submarine-test/test-e2e/src/test/java/org/apache/submarine/integration/interpreterIT.java
+++ b/submarine-test/test-e2e/src/test/java/org/apache/submarine/integration/interpreterIT.java
@@ -46,7 +46,7 @@ public class interpreterIT extends AbstractSubmarineIT {
 
   @Test
   public void workspaceNavigation() throws Exception {
-    String URL = getURL("http://localhost", 8080);
+    String URL = getURL("http://127.0.0.1", 8080);
     // Login
     LOG.info("Login");
     pollingWait(By.cssSelector("input[ng-reflect-name='userName']"), MAX_BROWSER_TIMEOUT_SEC).sendKeys("admin");

--- a/submarine-test/test-e2e/src/test/java/org/apache/submarine/integration/loginIT.java
+++ b/submarine-test/test-e2e/src/test/java/org/apache/submarine/integration/loginIT.java
@@ -19,6 +19,9 @@ package org.apache.submarine.integration;
 
 import org.apache.submarine.AbstractSubmarineIT;
 import org.apache.submarine.WebDriverManager;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.WebDriverWait;
+import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.By;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -46,26 +49,22 @@ public class loginIT extends AbstractSubmarineIT {
     // Testcase1
     LOG.info("[Sub-Testcase-1] Invalid User");
     LOG.info("Enter blank username and password");
-    clickAndWait(By.cssSelector("button[class='login-form-button ant-btn ant-btn-primary']"));
+    WebElement signin_button = buttonCheck(By.xpath("//span[text()='Sign In']/parent::button"), MAX_BROWSER_TIMEOUT_SEC);
+    signin_button.click();
     Assert.assertEquals( driver.findElements(By.xpath("//div[contains(text(), \"Please input your username!\")]")).size(), 1);
     Assert.assertEquals( driver.findElements(By.xpath("//div[contains(text(), \"Please input your Password!\")]")).size(), 1);
     LOG.info("Enter invalid username and password");
-    pollingWait(By.cssSelector("input[ng-reflect-name='userName']"), MAX_BROWSER_TIMEOUT_SEC).sendKeys("123");
-    pollingWait(By.cssSelector("input[ng-reflect-name='password']"), MAX_BROWSER_TIMEOUT_SEC).sendKeys("123");
-    clickAndWait(By.cssSelector("button[class='login-form-button ant-btn ant-btn-primary']"));
-    Assert.assertEquals( driver.findElements(By.xpath("//div[contains(text(), \"Username and password are incorrect, " +
-            "please try again or create an account\")]")).size(), 1);
-    pollingWait(By.cssSelector("input[ng-reflect-name='userName']"), MAX_BROWSER_TIMEOUT_SEC).sendKeys("\b\b\b");
-    pollingWait(By.cssSelector("input[ng-reflect-name='password']"), MAX_BROWSER_TIMEOUT_SEC).sendKeys("\b\b\b");
+    SendKeys(By.cssSelector("input[ng-reflect-name='userName']"), MAX_BROWSER_TIMEOUT_SEC, "123");
+    SendKeys(By.cssSelector("input[ng-reflect-name='password']"), MAX_BROWSER_TIMEOUT_SEC, "123");
+    signin_button.click();
+
+    waitToPresent(By.xpath("//div[contains(text(), \"Username and password are incorrect,\")]"), MAX_BROWSER_TIMEOUT_SEC);
+
+    SendKeys(By.cssSelector("input[ng-reflect-name='userName']"), MAX_BROWSER_TIMEOUT_SEC, "\b\b\b");
+    SendKeys(By.cssSelector("input[ng-reflect-name='password']"), MAX_BROWSER_TIMEOUT_SEC, "\b\b\b");
 
     // Testcase2
     LOG.info("[Sub-Testcase-2] Valid User");
-    LOG.info("Start to login user to submarine workbench.");
-    pollingWait(By.cssSelector("input[ng-reflect-name='userName']"), MAX_BROWSER_TIMEOUT_SEC).sendKeys("admin");
-    pollingWait(By.cssSelector("input[ng-reflect-name='password']"), MAX_BROWSER_TIMEOUT_SEC).sendKeys("admin");
-    clickAndWait(By.cssSelector("button[class='login-form-button ant-btn ant-btn-primary']"));
-    // Validate login result.
-    pollingWait(By.cssSelector("a[routerlink='/workbench/experiment']"), MAX_BROWSER_TIMEOUT_SEC);
-    LOG.info("User login is done.");
+    Login();
   }
 }

--- a/submarine-test/test-e2e/src/test/java/org/apache/submarine/integration/notebookIT.java
+++ b/submarine-test/test-e2e/src/test/java/org/apache/submarine/integration/notebookIT.java
@@ -45,36 +45,29 @@ public class notebookIT extends AbstractSubmarineIT {
 
   @Test
   public void notebookNavigation() throws Exception {
-    String URL = getURL("http://localhost", 8080);
+    String URL = getURL("http://127.0.0.1", 8080);
     // Login
-    LOG.info("Login");
-    pollingWait(By.cssSelector("input[ng-reflect-name='userName']"), MAX_BROWSER_TIMEOUT_SEC).sendKeys("admin");
-    pollingWait(By.cssSelector("input[ng-reflect-name='password']"), MAX_BROWSER_TIMEOUT_SEC).sendKeys("admin");
-    clickAndWait(By.cssSelector("button[class='login-form-button ant-btn ant-btn-primary']"));
-    pollingWait(By.cssSelector("a[routerlink='/workbench/experiment']"), MAX_BROWSER_TIMEOUT_SEC);
+    Login();
 
     // Routing to Notebook
-    pollingWait(By.xpath("//span[contains(text(), \"Notebook\")]"), MAX_BROWSER_TIMEOUT_SEC).click();
-    Assert.assertEquals(driver.getCurrentUrl(), URL.concat("/workbench/notebook"));
+    ClickAndNavigate(By.xpath("//span[contains(text(), \"Notebook\")]"), MAX_BROWSER_TIMEOUT_SEC, URL.concat("/workbench/notebook"));
 
     // Test for creating new notebook
     LOG.info("Create Notebook Test");
-    pollingWait(By.xpath("//button[@id='btn-newNotebook']"), MAX_BROWSER_TIMEOUT_SEC).click();
-    pollingWait(By.cssSelector("input[ng-reflect-name='notebookName']"), MAX_BROWSER_TIMEOUT_SEC).sendKeys("test-nb");
-    pollingWait(By.cssSelector("input[ng-reflect-name='cpus']"), MAX_BROWSER_TIMEOUT_SEC).clear();
-    pollingWait(By.cssSelector("input[ng-reflect-name='cpus']"), MAX_BROWSER_TIMEOUT_SEC).sendKeys("2");
-    pollingWait(By.cssSelector("input[ng-reflect-name='gpus']"), MAX_BROWSER_TIMEOUT_SEC).clear();
-    pollingWait(By.cssSelector("input[ng-reflect-name='gpus']"), MAX_BROWSER_TIMEOUT_SEC).sendKeys("1");
-    pollingWait(By.cssSelector("input[ng-reflect-name='memoryNum']"), MAX_BROWSER_TIMEOUT_SEC).sendKeys("1024");
-    pollingWait(By.xpath("//button[@id='envVar-btn']"), MAX_BROWSER_TIMEOUT_SEC).click();
-    pollingWait(By.xpath("//input[@name='key0']"), MAX_BROWSER_TIMEOUT_SEC).sendKeys("testKey0");
-    pollingWait(By.xpath("//input[@name='value0']"), MAX_BROWSER_TIMEOUT_SEC).sendKeys("testValue0");
-    pollingWait(By.xpath("//button[@id='nb-form-btn-create']"), MAX_BROWSER_TIMEOUT_SEC).click();
+    Click(By.xpath("//button[@id='btn-newNotebook']"), MAX_BROWSER_TIMEOUT_SEC);
+    SendKeys(By.cssSelector("input[ng-reflect-name='notebookName']"), MAX_BROWSER_TIMEOUT_SEC, "test-nb");
+    SendKeys(By.cssSelector("input[ng-reflect-name='cpus']"), MAX_BROWSER_TIMEOUT_SEC,"2");
+    SendKeys(By.cssSelector("input[ng-reflect-name='gpus']"), MAX_BROWSER_TIMEOUT_SEC, "1");
+    SendKeys(By.cssSelector("input[ng-reflect-name='memoryNum']"), MAX_BROWSER_TIMEOUT_SEC, "1024");
+    Click(By.xpath("//button[@id='envVar-btn']"), MAX_BROWSER_TIMEOUT_SEC);
+    SendKeys(By.xpath("//input[@name='key0']"), MAX_BROWSER_TIMEOUT_SEC, "testKey0");
+    SendKeys(By.xpath("//input[@name='value0']"), MAX_BROWSER_TIMEOUT_SEC, "testValue0");
+    Click(By.xpath("//button[@id='nb-form-btn-create']"), MAX_BROWSER_TIMEOUT_SEC);
     /*
     Future add k8s test.
     Assert.assertEquals(pollingWait(By.xpath("//td[contains(., 'test-nb')]"), MAX_BROWSER_TIMEOUT_SEC).isDisplayed(), true);
     */
-    Assert.assertEquals(pollingWait(By.xpath("//button[@id='btn-newNotebook']"), MAX_BROWSER_TIMEOUT_SEC).isDisplayed(), true);
+    waitToPresent(By.xpath("//button[@id='btn-newNotebook']"), MAX_BROWSER_TIMEOUT_SEC);
     LOG.info("Test Success!");
 
   }

--- a/submarine-test/test-e2e/src/test/java/org/apache/submarine/integration/registerIT.java
+++ b/submarine-test/test-e2e/src/test/java/org/apache/submarine/integration/registerIT.java
@@ -46,69 +46,65 @@ public class registerIT extends AbstractSubmarineIT {
 
   @Test
   public void registerFrontEndInvalidTest() throws Exception {
-    String URL = getURL("http://localhost", 8080);
+    String URL = getURL("http://127.0.0.1", 8080);
     // Navigate from Login page to Registration page
     LOG.info("Navigate from Login page to Registration page");
-    pollingWait(By.xpath("//a[contains(text(), \"Create an account!\")]"), MAX_BROWSER_TIMEOUT_SEC).click();
-    Assert.assertEquals(driver.getCurrentUrl(), URL.concat("/user/register"));
+    ClickAndNavigate(By.xpath("//a[contains(text(), \"Create an account!\")]"), MAX_BROWSER_TIMEOUT_SEC, URL.concat("/user/register"));
 
     // Username test
     //   Case1: empty username
-    pollingWait(By.cssSelector("input[formcontrolname='username']"), MAX_BROWSER_TIMEOUT_SEC).sendKeys(" \b");
-    Assert.assertEquals( driver.findElements(By.xpath("//div[contains(text(), \"Enter your username!\")]")).size(), 1);
+    SendKeys(By.cssSelector("input[formcontrolname='username']"), MAX_BROWSER_TIMEOUT_SEC, " \b");
+    waitToPresent(By.xpath("//div[contains(text(), \"Enter your username!\")]"), MAX_BROWSER_TIMEOUT_SEC);
     //   Case2: existed username
-    pollingWait(By.cssSelector("input[formcontrolname='username']"), MAX_BROWSER_TIMEOUT_SEC).sendKeys("test");
-    Assert.assertEquals( driver.findElements(By.xpath("//div[contains(text(), \"The username already exists!\")]")).size(), 1);
+    SendKeys(By.cssSelector("input[formcontrolname='username']"), MAX_BROWSER_TIMEOUT_SEC, "test");
+    waitToPresent(By.xpath("//div[contains(text(), \"The username already exists!\")]"), MAX_BROWSER_TIMEOUT_SEC);
 
     // Email test
     //   Case1: empty email
-    pollingWait(By.cssSelector("input[formcontrolname='email']"), MAX_BROWSER_TIMEOUT_SEC).sendKeys(" \b");
-    Assert.assertEquals( driver.findElements(By.xpath("//div[contains(text(), \"Type your email!\")]")).size(), 1);
+    SendKeys(By.cssSelector("input[formcontrolname='email']"), MAX_BROWSER_TIMEOUT_SEC, " \b");
+    waitToPresent(By.xpath("//div[contains(text(), \"Type your email!\")]"), MAX_BROWSER_TIMEOUT_SEC);
     //   Case2: existed email
     String existedEmailTestCase = "test@gmail.com";
-    pollingWait(By.cssSelector("input[formcontrolname='email']"), MAX_BROWSER_TIMEOUT_SEC).sendKeys(existedEmailTestCase);
-    Assert.assertEquals( driver.findElements(By.xpath("//div[contains(text(), \"The email is already used!\")]")).size(), 1); 
+    SendKeys(By.cssSelector("input[formcontrolname='email']"), MAX_BROWSER_TIMEOUT_SEC, existedEmailTestCase);
+    waitToPresent(By.xpath("//div[contains(text(), \"The email is already used!\")]"), MAX_BROWSER_TIMEOUT_SEC); 
     //   Case3: invalid email
     String backspaceKeys = "";
     for ( int i=0; i < (existedEmailTestCase.length() - existedEmailTestCase.indexOf("@")); i++) {
         backspaceKeys += "\b";
     };
-    pollingWait(By.cssSelector("input[formcontrolname='email']"), MAX_BROWSER_TIMEOUT_SEC).sendKeys(backspaceKeys);
-    Assert.assertEquals( driver.findElements(By.xpath("//div[contains(text(), \"The email is invalid!\")]")).size(), 1); 
+    SendKeys(By.cssSelector("input[formcontrolname='email']"), MAX_BROWSER_TIMEOUT_SEC, backspaceKeys);
+    waitToPresent(By.xpath("//div[contains(text(), \"The email is invalid!\")]"), MAX_BROWSER_TIMEOUT_SEC); 
     
     // Password test
     //   Case1: empty password
-    pollingWait(By.cssSelector("input[formcontrolname='password']"), MAX_BROWSER_TIMEOUT_SEC).sendKeys(" \b");
-    Assert.assertEquals( driver.findElements(By.xpath("//div[contains(text(), \"Type your password!\")]")).size(), 1);
+    SendKeys(By.cssSelector("input[formcontrolname='password']"), MAX_BROWSER_TIMEOUT_SEC, " \b");
+    waitToPresent(By.xpath("//div[contains(text(), \"Type your password!\")]"), MAX_BROWSER_TIMEOUT_SEC);
     //   Case2: string length must be in 6 ~ 20 characters
-    pollingWait(By.cssSelector("input[formcontrolname='password']"), MAX_BROWSER_TIMEOUT_SEC).sendKeys("testtesttesttesttesttest"); // length = 24
-    Assert.assertEquals( driver.findElements(By.xpath("//div[contains(text(), \"Password's length must be in 6 ~ 20 characters.\")]")).size(), 1);
-    pollingWait(By.cssSelector("input[formcontrolname='password']"), MAX_BROWSER_TIMEOUT_SEC).sendKeys("\b\b\b\b\b\b\b\b\b\b\b\b"); // length = 12
-    Assert.assertEquals( driver.findElements(By.xpath("//div[contains(text(), \"Password's length must be in 6 ~ 20 characters.\")]")).size(), 0);
+    SendKeys(By.cssSelector("input[formcontrolname='password']"), MAX_BROWSER_TIMEOUT_SEC, "testtesttesttesttesttest"); // length = 24
+    waitToPresent(By.xpath("//div[contains(text(), \"Password's length must be in 6 ~ 20 characters.\")]"), MAX_BROWSER_TIMEOUT_SEC);
+    SendKeys(By.cssSelector("input[formcontrolname='password']"), MAX_BROWSER_TIMEOUT_SEC, "\b\b\b\b\b\b\b\b\b\b\b\b"); // length = 12
+     Assert.assertEquals( driver.findElements(By.xpath("//div[contains(text(), \"Password's length must be in 6 ~ 20 characters.\")]")).size(), 0);
 
     // Re-enter password test
     //   Case1: empty re-enter password
-    pollingWait(By.cssSelector("input[formcontrolname='checkPassword']"), MAX_BROWSER_TIMEOUT_SEC).sendKeys(" \b");
-    Assert.assertEquals( driver.findElements(By.xpath("//div[contains(text(), \"Type your password again!\")]")).size(), 1);
+    SendKeys(By.cssSelector("input[formcontrolname='checkPassword']"), MAX_BROWSER_TIMEOUT_SEC, " \b");
+    waitToPresent(By.xpath("//div[contains(text(), \"Type your password again!\")]"), MAX_BROWSER_TIMEOUT_SEC);
     //   Case2: re-enter password != password    
-    pollingWait(By.cssSelector("input[formcontrolname='checkPassword']"), MAX_BROWSER_TIMEOUT_SEC).sendKeys("1234"); // "1234" != "testtesttest"
-    Assert.assertEquals( driver.findElements(By.xpath("//div[contains(text(), \"Passwords must match!\")]")).size(), 1);
-    pollingWait(By.xpath("//a[@href='/user/login']"), MAX_BROWSER_TIMEOUT_SEC).click();
-    Assert.assertEquals(driver.getCurrentUrl(), URL.concat("/user/login")); 
+    SendKeys(By.cssSelector("input[formcontrolname='checkPassword']"), MAX_BROWSER_TIMEOUT_SEC, "1234"); // "1234" != "testtesttest"
+    waitToPresent(By.xpath("//div[contains(text(), \"Passwords must match!\")]"), MAX_BROWSER_TIMEOUT_SEC);
+    ClickAndNavigate(By.xpath("//a[@href='/user/login']"), MAX_BROWSER_TIMEOUT_SEC, URL.concat("/user/login"));
   }
 
   @Test
   public void registerFrontEndValidTest() throws Exception {
-    String URL = getURL("http://localhost", 8080);
+    String URL = getURL("http://127.0.0.1", 8080);
     // Sign-Up successfully
-    pollingWait(By.xpath("//a[contains(text(), \"Create an account!\")]"), MAX_BROWSER_TIMEOUT_SEC).click();
-    Assert.assertEquals(driver.getCurrentUrl(), URL.concat("/user/register"));
-    pollingWait(By.cssSelector("input[formcontrolname='username']"), MAX_BROWSER_TIMEOUT_SEC).sendKeys("validusername");
-    pollingWait(By.cssSelector("input[formcontrolname='email']"), MAX_BROWSER_TIMEOUT_SEC).sendKeys("validemail@gmail.com");
-    pollingWait(By.cssSelector("input[formcontrolname='password']"), MAX_BROWSER_TIMEOUT_SEC).sendKeys("validpassword");
-    pollingWait(By.cssSelector("input[formcontrolname='checkPassword']"), MAX_BROWSER_TIMEOUT_SEC).sendKeys("validpassword");
-    pollingWait(By.cssSelector("label[formcontrolname='agree']"), MAX_BROWSER_TIMEOUT_SEC).click();
-    pollingWait(By.cssSelector("button[class='ant-btn ant-btn-primary ant-btn-block']"), MAX_BROWSER_TIMEOUT_SEC).click(); 
-    Assert.assertEquals(driver.getCurrentUrl(), URL.concat("/user/login"));
+    ClickAndNavigate(By.xpath("//a[contains(text(), \"Create an account!\")]"), MAX_BROWSER_TIMEOUT_SEC, URL.concat("/user/register"));
+    SendKeys(By.cssSelector("input[formcontrolname='username']"), MAX_BROWSER_TIMEOUT_SEC, "validusername");
+    SendKeys(By.cssSelector("input[formcontrolname='email']"), MAX_BROWSER_TIMEOUT_SEC, "validemail@gmail.com");
+    SendKeys(By.cssSelector("input[formcontrolname='password']"), MAX_BROWSER_TIMEOUT_SEC, "validpassword");
+    SendKeys(By.cssSelector("input[formcontrolname='checkPassword']"), MAX_BROWSER_TIMEOUT_SEC, "validpassword");
+    Click(By.cssSelector("label[formcontrolname='agree']"), MAX_BROWSER_TIMEOUT_SEC);
+    ClickAndNavigate(By.cssSelector("button[class='ant-btn ant-btn-primary ant-btn-block']"), MAX_BROWSER_TIMEOUT_SEC, URL.concat("/user/login")); 
   }
 }

--- a/submarine-test/test-e2e/src/test/java/org/apache/submarine/integration/sidebarIT.java
+++ b/submarine-test/test-e2e/src/test/java/org/apache/submarine/integration/sidebarIT.java
@@ -47,40 +47,18 @@ public class sidebarIT extends AbstractSubmarineIT {
 
   @Test
   public void sidebarNavigation() throws Exception {
-    String URL = getURL("http://localhost", 8080);
+    String URL = getURL("http://127.0.0.1", 8080);
     // Login
-    LOG.info("Login");
-    pollingWait(By.cssSelector("input[ng-reflect-name='userName']"), MAX_BROWSER_TIMEOUT_SEC).sendKeys("admin");
-    pollingWait(By.cssSelector("input[ng-reflect-name='password']"), MAX_BROWSER_TIMEOUT_SEC).sendKeys("admin");
-    clickAndWait(By.cssSelector("button[class='login-form-button ant-btn ant-btn-primary']"));
-    pollingWait(By.cssSelector("a[routerlink='/workbench/experiment']"), MAX_BROWSER_TIMEOUT_SEC);
+    Login();
 
     // Start Routing & Navigation in sidebar
     LOG.info("Start Routing & Navigation in sidebar");
-    pollingWait(By.xpath("//span[contains(text(), \"Experiment\")]"), MAX_BROWSER_TIMEOUT_SEC).click();
-    Assert.assertEquals(driver.getCurrentUrl(), URL.concat("/workbench/experiment"));
-    pollingWait(By.xpath("//span[contains(text(), \"Manager\")]"), MAX_BROWSER_TIMEOUT_SEC).click();
-    pollingWait(By.xpath("//a[@href='/workbench/manager/user']"), MAX_BROWSER_TIMEOUT_SEC).click();
-
-    // SUBMARINE-628. [WEB] Disable WIP page link
-//    pollingWait(By.xpath("//span[contains(text(), \"Workspace\")]"), MAX_BROWSER_TIMEOUT_SEC).click()
-//    Assert.assertEquals(driver.getCurrentUrl(), URL.concat("/workbench/workspace"));
-//    pollingWait(By.xpath("//span[contains(text(), \"Interpreter\")]"), MAX_BROWSER_TIMEOUT_SEC).click();
-//    Assert.assertEquals(driver.getCurrentUrl(), URL.concat("/workbench/interpreter"));
-//    pollingWait(By.xpath("//span[contains(text(), \"Data\")]"), MAX_BROWSER_TIMEOUT_SEC).click();
-//    Assert.assertEquals(driver.getCurrentUrl(), URL.concat("/workbench/data"));
-//    pollingWait(By.xpath("//span[contains(text(), \"Model\")]"), MAX_BROWSER_TIMEOUT_SEC).click();
-//    Assert.assertEquals(driver.getCurrentUrl(), URL.concat("/workbench/model"));
-//    pollingWait(By.xpath("//span[contains(text(), \"Home\")]"), MAX_BROWSER_TIMEOUT_SEC).click();
-//    Assert.assertEquals(driver.getCurrentUrl(), URL.concat("/workbench/home"));
+    ClickAndNavigate(By.xpath("//span[contains(text(), \"Experiment\")]"), MAX_BROWSER_TIMEOUT_SEC, URL.concat("/workbench/experiment"));
+    Click(By.xpath("//span[contains(text(), \"Manager\")]"), MAX_BROWSER_TIMEOUT_SEC);
+    Click(By.xpath("//a[@href='/workbench/manager/user']"), MAX_BROWSER_TIMEOUT_SEC);
 
     // Lazy-loading
-    WebDriverWait wait = new WebDriverWait( driver, 15, 5000);
-    pollingWait(By.xpath("//a[@href='/workbench/manager/user']"), MAX_BROWSER_TIMEOUT_SEC).click();
-    wait.until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//span[@class='ant-breadcrumb-link ng-star-inserted']")));
-    Assert.assertEquals(driver.getCurrentUrl(), URL.concat("/workbench/manager/user"));
-
-    pollingWait(By.xpath("//a[@href='/workbench/manager/dataDict']"), MAX_BROWSER_TIMEOUT_SEC).click();
-    Assert.assertEquals(driver.getCurrentUrl(), URL.concat("/workbench/manager/dataDict"));
+    ClickAndNavigate(By.xpath("//a[@href='/workbench/manager/user']"), MAX_BROWSER_TIMEOUT_SEC, URL.concat("/workbench/manager/user"));
+    ClickAndNavigate(By.xpath("//a[@href='/workbench/manager/dataDict']"), MAX_BROWSER_TIMEOUT_SEC, URL.concat("/workbench/manager/dataDict"));
   }
 }

--- a/submarine-test/test-e2e/src/test/java/org/apache/submarine/integration/teamIT.java
+++ b/submarine-test/test-e2e/src/test/java/org/apache/submarine/integration/teamIT.java
@@ -46,7 +46,7 @@ public class teamIT extends AbstractSubmarineIT {
 
   @Test
   public void teamTest() throws Exception {
-    String URL = getURL("http://localhost", 8080);
+    String URL = getURL("http://127.0.0.1", 8080);
     // Login
     LOG.info("Login");
     pollingWait(By.cssSelector("input[ng-reflect-name='userName']"), MAX_BROWSER_TIMEOUT_SEC).sendKeys("admin");

--- a/submarine-test/test-e2e/src/test/java/org/apache/submarine/integration/workspaceIT.java
+++ b/submarine-test/test-e2e/src/test/java/org/apache/submarine/integration/workspaceIT.java
@@ -48,7 +48,7 @@ public class workspaceIT extends AbstractSubmarineIT {
 
   @Test
   public void workspaceNavigation() throws Exception {
-    String URL = getURL("http://localhost", 8080);
+    String URL = getURL("http://127.0.0.1", 8080);
     // Login
     LOG.info("Login");
     pollingWait(By.cssSelector("input[ng-reflect-name='userName']"), MAX_BROWSER_TIMEOUT_SEC).sendKeys("admin");


### PR DESCRIPTION
### What is this PR for?
The selenium's official document indicates that

"Do not mix implicit and explicit waits. Doing so can cause unpredictable wait times. For example, setting an implicit wait of 10 seconds and an explicit wait of 15 seconds could cause a timeout to occur after 20 seconds."

Hence, we need to avoid mixing implicit and explicit waits.

https://www.selenium.dev/documentation/en/webdriver/waits/

### What type of PR is it?
[Bug Fix | Improvement | Refactoring]

### Todos
* Fix testcases ignored by release 5.0

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-853

### How should this be tested?
```
# Step1: Run Submarine workbench on 127.0.0.1:8080 by operator
# Step2: Run testcase
cd submarine-cloud-v2

# Usage: ./hack/run_frontend_e2e.sh ${testcase}
# Example: 
./hack/run_frontend_e2e.sh notebookIT
```

### Screenshots (if appropriate)
<img width="728" alt="截圖 2021-06-14 上午2 19 57" src="https://user-images.githubusercontent.com/20109646/121817982-10ed4a00-ccb7-11eb-842f-61edb7c73c27.png">


### Questions:
* Do the license files need updating? No
* Are there breaking changes for older versions? No
* Does this need new documentation? No
