### PR TITLE
SUBMARINE-855. provide a handy submarine-server building script for developing

### DIFF
--- a/submarine-cloud-v2/hack/server-rapid-builder.sh
+++ b/submarine-cloud-v2/hack/server-rapid-builder.sh
@@ -1,29 +1,36 @@
 #!/usr/bin/env bash
 set -e
 
-export CURRENT_PATH=$(cd "${PWD}">/dev/null; pwd)
-export SUBMARINE_HOME=${CURRENT_PATH}/../../..
-NAMESPACE=$1
 
-
-[[ ! -f mvnw ]] && mvn -N io.takari:maven:0.7.7:wrapper -Dmaven=3.6.1
-eval $(minikube docker-env -u)
+if [ -L ${BASH_SOURCE-$0} ]; then
+  PWD=$(dirname $(readlink "${BASH_SOURCE-$0}"))
+else
+  PWD=$(dirname ${BASH_SOURCE-$0})
+fi
 
 export CURRENT_PATH=$(cd "${PWD}">/dev/null; pwd)
 export SUBMARINE_HOME=${CURRENT_PATH}/../..
+
+NAMESPACE=$1
+
+[[ ! -f mvnw ]] && mvn -N io.takari:maven:0.7.7:wrapper -Dmaven=3.6.1
+eval $(minikube docker-env -u)
 
 if [ ! -d "${SUBMARINE_HOME}/submarine-dist/target" ]; then
   mkdir "${SUBMARINE_HOME}/submarine-dist/target"
 fi
 
+# Build submarine-server module
 cd ${SUBMARINE_HOME}/submarine-server
 mvn clean package -DskipTests
+
+# Build assemble tar ball
 cd ${SUBMARINE_HOME}/submarine-dist
 mvn clean package -DskipTests
 
 [[ ! -f mvnw ]] && mvn -N io.takari:maven:0.7.7:wrapper -Dmaven=3.6.1
 eval $(minikube docker-env -u)
-eval $(minikube docker-env)
+
 ${SUBMARINE_HOME}/dev-support/docker-images/submarine/build.sh
 # Delete the deployment and the operator will create a new one using new image
 kubectl delete -n "$NAMESPACE" deployments submarine-server

--- a/submarine-cloud-v2/hack/server-rapid-builder.sh
+++ b/submarine-cloud-v2/hack/server-rapid-builder.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -e
+
+export CURRENT_PATH=$(cd "${PWD}">/dev/null; pwd)
+export SUBMARINE_HOME=${CURRENT_PATH}/../../..
+NAMESPACE=$1
+
+
+[[ ! -f mvnw ]] && mvn -N io.takari:maven:0.7.7:wrapper -Dmaven=3.6.1
+eval $(minikube docker-env -u)
+
+export CURRENT_PATH=$(cd "${PWD}">/dev/null; pwd)
+export SUBMARINE_HOME=${CURRENT_PATH}/../..
+
+if [ ! -d "${SUBMARINE_HOME}/submarine-dist/target" ]; then
+  mkdir "${SUBMARINE_HOME}/submarine-dist/target"
+fi
+
+cd ${SUBMARINE_HOME}/submarine-server
+mvn clean package -DskipTests
+cd ${SUBMARINE_HOME}/submarine-dist
+mvn clean package -DskipTests
+
+[[ ! -f mvnw ]] && mvn -N io.takari:maven:0.7.7:wrapper -Dmaven=3.6.1
+eval $(minikube docker-env -u)
+eval $(minikube docker-env)
+${SUBMARINE_HOME}/dev-support/docker-images/submarine/build.sh
+# Delete the deployment and the operator will create a new one using new image
+kubectl delete -n "$NAMESPACE" deployments submarine-server
+eval $(minikube docker-env -u)

--- a/submarine-cloud-v2/hack/server-rapid-builder.sh
+++ b/submarine-cloud-v2/hack/server-rapid-builder.sh
@@ -34,7 +34,6 @@ export SUBMARINE_HOME=${CURRENT_PATH}/../..
 NAMESPACE=$1
 
 [[ ! -f mvnw ]] && mvn -N io.takari:maven:0.7.7:wrapper -Dmaven=3.6.1
-eval $(minikube docker-env -u)
 
 if [ ! -d "${SUBMARINE_HOME}/submarine-dist/target" ]; then
   mkdir "${SUBMARINE_HOME}/submarine-dist/target"
@@ -42,14 +41,13 @@ fi
 
 # Build submarine-server module
 cd ${SUBMARINE_HOME}/submarine-server
-mvn clean package -DskipTests
+${SUBMARINE_HOME}/submarine-cloud-v2/hack/mvnw clean package -DskipTests
 
 # Build assemble tar ball
 cd ${SUBMARINE_HOME}/submarine-dist
-mvn clean package -DskipTests
+${SUBMARINE_HOME}/submarine-cloud-v2/hack/mvnw clean package -DskipTests
 
-[[ ! -f mvnw ]] && mvn -N io.takari:maven:0.7.7:wrapper -Dmaven=3.6.1
-eval $(minikube docker-env -u)
+eval $(minikube docker-env)
 
 ${SUBMARINE_HOME}/dev-support/docker-images/submarine/build.sh
 # Delete the deployment and the operator will create a new one using new image

--- a/submarine-cloud-v2/hack/server-rapid-builder.sh
+++ b/submarine-cloud-v2/hack/server-rapid-builder.sh
@@ -1,4 +1,24 @@
 #!/usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Please make sure you've already built whole package once before executing this script!
+
 set -e
 
 


### PR DESCRIPTION
### What is this PR for?
Just like I mentioned in Jira story, it's common for operator members to fix the code of submarine-server when they hit some unexpected error in testing. Our current building tool compiles the whole project each time even they are only made some minor change, it really takes time and slow down the progress. I made a handy script aim to improve the developing progress in these kind of cases. 

IMPORTANT: The developers have to make a whole project compiling once before using this script.
After we execute the script, it will enter the submarine-server directory and start to build the submarine-server module. The second step is moviong to  submarin-dist directory to build the assembly tar ball, and call the build script to build image in step three. In the end,  the script delete the submarine-server deployment in assigned namespace, and we expect the operator will launch another submarine-server deployment with the latest image.

### What type of PR is it?
Improvement

### Todos

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-855

### How should this be tested?
usage:  `./submarine-cloud-v2/hack/server-rapid-builder.sh <assigned-namespace>`
example:  ` ./submarine-cloud-v2/hack/server-rapid-builder.sh submarine-user-test`


### Screenshots (if appropriate)

Step1. set up the developing environment
<img width="1659" alt="pic1_setup_done" src="https://user-images.githubusercontent.com/5687317/124377299-ddae4180-dcdd-11eb-88e9-1331d47140e7.png">
Step2. create a notebook
<img width="1364" alt="pic2_create_notebook1" src="https://user-images.githubusercontent.com/5687317/124377301-e0109b80-dcdd-11eb-9eda-945242946678.png">
Step3. check the notebook is deployed in submarine-user-test domain
<img width="1401" alt="pic3_notebook1_on_k8s" src="https://user-images.githubusercontent.com/5687317/124377303-e1da5f00-dcdd-11eb-998b-dcdd07cec198.png">
Step4. we modified the server's code to force it to deploy notebook in default namespace
<img width="859" alt="pic4-modify-server-code" src="https://user-images.githubusercontent.com/5687317/124377305-e56de600-dcdd-11eb-85df-2c6f6ea83946.png">
Step5. execute server_rapid_builder 
<img width="776" alt="pic5_execute_rapid_builder" src="https://user-images.githubusercontent.com/5687317/124377307-e868d680-dcdd-11eb-98eb-9a24a9453a8d.png">
Step6. wait until the compiling process done
<img width="750" alt="pic6_compile_done" src="https://user-images.githubusercontent.com/5687317/124377311-ea329a00-dcdd-11eb-9b10-fac43a6f2638.png">
Step7. Create another notebook, and now we found out the pod is deployed in default namespace.
<img width="1420" alt="pic7-check-the-notebook-in-defaul-ns" src="https://user-images.githubusercontent.com/5687317/124377312-ec94f400-dcdd-11eb-80ef-8322ef19ea96.png">

### Questions:

* Do the license files need updating? Yes/No
* Are there breaking changes for older versions? Yes/No
* Does this need new documentation? Yes/No
