### PR TITLE
SUBMARINE-870. Replace &amp; with &

### DIFF
--- a/submarine-commons/commons-metastore/src/test/java/org/apache/submarine/commons/metastore/SubmarineMetaStoreTest.java
+++ b/submarine-commons/commons-metastore/src/test/java/org/apache/submarine/commons/metastore/SubmarineMetaStoreTest.java
@@ -55,8 +55,8 @@ public class SubmarineMetaStoreTest {
 
   static {
     submarineConf.setMetastoreJdbcUrl("jdbc:mysql://127.0.0.1:3306/metastore_test?" +
-        "useUnicode=true&amp;characterEncoding=UTF-8&amp;autoReconnect=true&amp;" +
-        "failOverReadOnly=false&amp;zeroDateTimeBehavior=convertToNull&amp;useSSL=false");
+        "useUnicode=true&characterEncoding=UTF-8&autoReconnect=true&" +
+        "failOverReadOnly=false&zeroDateTimeBehavior=convertToNull&useSSL=false");
     submarineConf.setMetastoreJdbcUserName("metastore_test");
     submarineConf.setMetastoreJdbcPassword("password_test");
   }
@@ -66,8 +66,8 @@ public class SubmarineMetaStoreTest {
     LOG.info("listTables >>> ");
 
     String url = "jdbc:mysql://127.0.0.1:3306/metastore_test?" +
-        "useUnicode=true&amp;characterEncoding=UTF-8&amp;autoReconnect=true&amp;" +
-        "failOverReadOnly=false&amp;zeroDateTimeBehavior=convertToNull&amp;useSSL=false";
+        "useUnicode=true&characterEncoding=UTF-8&autoReconnect=true&" +
+        "failOverReadOnly=false&zeroDateTimeBehavior=convertToNull&useSSL=false";
     String username = "metastore_test";
     String password = "password_test";
     boolean flag = false;

--- a/submarine-commons/commons-utils/src/main/java/org/apache/submarine/commons/utils/SubmarineConfVars.java
+++ b/submarine-commons/commons-utils/src/main/java/org/apache/submarine/commons/utils/SubmarineConfVars.java
@@ -53,13 +53,13 @@ public class SubmarineConfVars {
 
     JDBC_DRIVERCLASSNAME("jdbc.driverClassName", "com.mysql.jdbc.Driver"),
     JDBC_URL("jdbc.url", "jdbc:mysql://127.0.0.1:3306/submarine" +
-        "?useUnicode=true&amp;characterEncoding=UTF-8&amp;autoReconnect=true&amp;" +
-        "failOverReadOnly=false&amp;zeroDateTimeBehavior=convertToNull&amp;useSSL=false"),
+        "?useUnicode=true&characterEncoding=UTF-8&autoReconnect=true&" +
+        "failOverReadOnly=false&zeroDateTimeBehavior=convertToNull&useSSL=false"),
     JDBC_USERNAME("jdbc.username", "submarine"),
     JDBC_PASSWORD("jdbc.password", "password"),
     METASTORE_JDBC_URL("metastore.jdbc.url", "jdbc:mysql://127.0.0.1:3306/metastore" +
-        "?useUnicode=true&amp;characterEncoding=UTF-8&amp;autoReconnect=true&amp;" +
-        "failOverReadOnly=false&amp;zeroDateTimeBehavior=convertToNull&amp;useSSL=false"),
+        "?useUnicode=true&characterEncoding=UTF-8&autoReconnect=true&" +
+        "failOverReadOnly=false&zeroDateTimeBehavior=convertToNull&useSSL=false"),
     METASTORE_JDBC_USERNAME("metastore.jdbc.username", "metastore"),
     METASTORE_JDBC_PASSWORD("metastore.jdbc.password", "password"),
 

--- a/submarine-server/server-core/src/main/java/org/apache/submarine/server/database/utils/MyBatisUtil.java
+++ b/submarine-server/server-core/src/main/java/org/apache/submarine/server/database/utils/MyBatisUtil.java
@@ -97,8 +97,8 @@ public class MyBatisUtil {
     // Run the test unit using the test database
     SubmarineConfiguration conf = SubmarineConfiguration.getInstance();
     conf.setJdbcUrl("jdbc:mysql://127.0.0.1:3306/submarine_test?" +
-            "useUnicode=true&amp;characterEncoding=UTF-8&amp;autoReconnect=true&amp;" +
-            "failOverReadOnly=false&amp;zeroDateTimeBehavior=convertToNull&amp;useSSL=false");
+            "useUnicode=true&characterEncoding=UTF-8&autoReconnect=true&" +
+            "failOverReadOnly=false&zeroDateTimeBehavior=convertToNull&useSSL=false");
     conf.setJdbcUserName("submarine_test");
     conf.setJdbcPassword("password_test");
   }

--- a/submarine-server/server-core/src/test/java/org/apache/submarine/server/rest/EnvironmentRestApiTest.java
+++ b/submarine-server/server-core/src/test/java/org/apache/submarine/server/rest/EnvironmentRestApiTest.java
@@ -66,11 +66,11 @@ public class EnvironmentRestApiTest {
   public static void init() {
     SubmarineConfiguration submarineConf = SubmarineConfiguration.getInstance();
     submarineConf.setMetastoreJdbcUrl("jdbc:mysql://127.0.0.1:3306/submarine_test?" +
-        "useUnicode=true&amp;" +
-        "characterEncoding=UTF-8&amp;" +
-        "autoReconnect=true&amp;" +
-        "failOverReadOnly=false&amp;" +
-        "zeroDateTimeBehavior=convertToNull&amp;" +
+        "useUnicode=true&" +
+        "characterEncoding=UTF-8&" +
+        "autoReconnect=true&" +
+        "failOverReadOnly=false&" +
+        "zeroDateTimeBehavior=convertToNull&" +
         "useSSL=false");
     submarineConf.setMetastoreJdbcUserName("submarine_test");
     submarineConf.setMetastoreJdbcPassword("password_test");

--- a/submarine-server/server-core/src/test/java/org/apache/submarine/server/rest/ExperimentTemplateRestApiTest.java
+++ b/submarine-server/server-core/src/test/java/org/apache/submarine/server/rest/ExperimentTemplateRestApiTest.java
@@ -54,23 +54,23 @@ public class ExperimentTemplateRestApiTest {
   @BeforeClass
   public static void init() {
     SubmarineConfiguration submarineConf = SubmarineConfiguration.getInstance();
-    submarineConf.setMetastoreJdbcUrl("jdbc:mysql://127.0.0.1:3306/submarine_test?" + "useUnicode=true&amp;"
-        + "characterEncoding=UTF-8&amp;" + "autoReconnect=true&amp;" + "failOverReadOnly=false&amp;"
-        + "zeroDateTimeBehavior=convertToNull&amp;" + "useSSL=false");
+    submarineConf.setMetastoreJdbcUrl("jdbc:mysql://127.0.0.1:3306/submarine_test?" + "useUnicode=true&"
+        + "characterEncoding=UTF-8&" + "autoReconnect=true&" + "failOverReadOnly=false&"
+        + "zeroDateTimeBehavior=convertToNull&" + "useSSL=false");
     submarineConf.setMetastoreJdbcUserName("submarine_test");
     submarineConf.setMetastoreJdbcPassword("password_test");
-    experimentTemplateStoreApi = new ExperimentTemplateRestApi();  
+    experimentTemplateStoreApi = new ExperimentTemplateRestApi();
   }
 
   @Before
   public void createAndUpdateExperimentTemplate() {
     String body = loadContent(TPL_FILE);
     experimentTemplateSpec = gson.fromJson(body, ExperimentTemplateSpec.class);
-    
+
     // Create ExperimentTemplate
     Response createEnvResponse = experimentTemplateStoreApi.createExperimentTemplate(experimentTemplateSpec);
     assertEquals(Response.Status.OK.getStatusCode(), createEnvResponse.getStatus());
-    
+
     // Update ExperimentTemplate
     experimentTemplateSpec.setDescription("newdescription");
     Response updateTplResponse = experimentTemplateStoreApi.
@@ -80,7 +80,7 @@ public class ExperimentTemplateRestApiTest {
 
   @After
   public void deleteExperimentTemplate() {
-    
+
     String body = loadContent(TPL_FILE);
     experimentTemplateSpec = gson.fromJson(body, ExperimentTemplateSpec.class);
 

--- a/submarine-server/server-core/src/test/java/org/apache/submarine/server/rest/MetaStoreRestApiTest.java
+++ b/submarine-server/server-core/src/test/java/org/apache/submarine/server/rest/MetaStoreRestApiTest.java
@@ -48,11 +48,11 @@ public class MetaStoreRestApiTest {
   public static void init() {
     SubmarineConfiguration submarineConf = SubmarineConfiguration.getInstance();
     submarineConf.setMetastoreJdbcUrl("jdbc:mysql://127.0.0.1:3306/metastore_test?" +
-                                              "useUnicode=true&amp;" +
-                                              "characterEncoding=UTF-8&amp;" +
-                                              "autoReconnect=true&amp;" +
-                                              "failOverReadOnly=false&amp;" +
-                                              "zeroDateTimeBehavior=convertToNull&amp;" +
+                                              "useUnicode=true&" +
+                                              "characterEncoding=UTF-8&" +
+                                              "autoReconnect=true&" +
+                                              "failOverReadOnly=false&" +
+                                              "zeroDateTimeBehavior=convertToNull&" +
                                               "useSSL=false");
     submarineConf.setMetastoreJdbcUserName("metastore_test");
     submarineConf.setMetastoreJdbcPassword("password_test");


### PR DESCRIPTION
### What is this PR for?
Using the link with "jdbc:mysql://127.0.0.1:3306/metastore_test?useUnicode=true&amp;characterEncoding=UTF-8&amp;autoReconnect=true&amp;failOverReadOnly=false&amp;zeroDateTimeBehavior=convertToNull&amp;useSSL=false" will encounter the problem "Caused by: javax.net.ssl.SSLHandshakeException: No appropriate protocol (protocol is disabled or cipher suites are inappropriate)"; however, we have set the useSSL=false. This is the reason that &amp; is the ampersand for XML file but not for Java file.

### What type of PR is it?
[Test]

### Todos


### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-870

### How should this be tested?
run the MetaStoreRestApiTest or run the command "mvn test" under the submarine-server folder.

### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/38066413/123741582-e6b5a200-d8dc-11eb-9463-75a193ae4c31.png)

### Questions:
* Do the license files need updating? No
* Are there breaking changes for older versions? No
* Does this need new documentation? No
