### PR TITLE
SUBMARINE-871. Upgrade cglib for Ubuntu 20.04

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
     <commons-configuration.version>1.10</commons-configuration.version>
     <commons-httpclient.version>3.1</commons-httpclient.version>
 
-    <cglib.version>3.2.2</cglib.version>
+    <cglib.version>3.3.0</cglib.version>
     <mybatis.version>3.2.8</mybatis.version>
     <mysql-connector-java.version>5.1.41</mysql-connector-java.version>
     <grpc.version>1.25.0</grpc.version>

--- a/submarine-server/server-core/pom.xml
+++ b/submarine-server/server-core/pom.xml
@@ -36,6 +36,12 @@
       <groupId>org.apache.submarine</groupId>
       <artifactId>submarine-commons-cluster</artifactId>
       <version>${project.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.ow2.asm</groupId>
+          <artifactId>asm</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>
@@ -43,7 +49,7 @@
       <artifactId>submarine-server-api</artifactId>
       <version>${project.version}</version>
     </dependency>
-      <dependency>
+    <dependency>
       <groupId>io.swagger.core.v3</groupId>
       <artifactId>swagger-jaxrs2</artifactId>
       <version>${io.swagger.version}</version>
@@ -239,6 +245,10 @@
         <exclusion>
           <groupId>javax.servlet</groupId>
           <artifactId>servlet-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.ow2.asm</groupId>
+          <artifactId>asm</artifactId>
         </exclusion>
       </exclusions>
     </dependency>


### PR DESCRIPTION
### What is this PR for?
Running userSexDictAnnotationTest will add the DICT_SUFFIX in DictAnnotation class.
Using key with "@" will fail in cglib 3.2, but passing in cglib 3.3.
However, cglib is using asm 7.1, submarine-cluster and submarine-rpc are using asm 5.1. We should exclude the asm in both dependencies.

### What type of PR is it?
[Test]

### Todos


### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-871

### How should this be tested?
run the userSexDictAnnotationTest.

### Screenshots (if appropriate)

### Questions:
* Do the license files need updating? No
* Are there breaking changes for older versions? No
* Does this need new documentation? No
