### PR TITLE
SUBMARINE-874. Use the locally installed kind and kubectl

### DIFF
--- a/submarine-cloud/hack/lib.sh
+++ b/submarine-cloud/hack/lib.sh
@@ -47,16 +47,18 @@ function hack::ensure_kubectl() {
         return 0
     fi
 
-    orig_kubectl_bin="$KUBECTL_BIN"
-    if command -v kubectl > /dev/null; then
-        KUBECTL_BIN="$(command -v kubectl)"
-        if hack::verify_kubectl; then
-            ln -sf "$KUBECTL_BIN" "$orig_kubectl_bin"
-            KUBECTL_BIN="$orig_kubectl_bin"
-            echo $KUBECTL_BIN
-            return 0
-        fi
-    fi
+    # Use the locally installed kubectl(1.14.2).
+    # Because of the development, we are using a specific version of kubectl now.
+    # orig_kubectl_bin="$KUBECTL_BIN"
+    # if command -v kubectl > /dev/null; then
+    #     KUBECTL_BIN="$(command -v kubectl)"
+    #     if hack::verify_kubectl; then
+    #         ln -sf "$KUBECTL_BIN" "$orig_kubectl_bin"
+    #         KUBECTL_BIN="$orig_kubectl_bin"
+    #         echo $KUBECTL_BIN
+    #         return 0
+    #     fi
+    # fi
 
     echo "Installing kubectl v$KUBECTL_VERSION..."
     tmpfile=$(mktemp)
@@ -79,16 +81,18 @@ function hack::ensure_kind() {
         return 0
     fi
 
-    orig_kind_bin="$KIND_BIN"
-    if command -v kind > /dev/null; then
-        KIND_BIN="$(command -v kind)"
-        if hack::verify_kind; then
-            ln -sf "$KIND_BIN" "$orig_kind_bin"
-            KIND_BIN="$orig_kind_bin"
-            echo $KIND_BIN
-            return 0
-        fi
-    fi
+    # Use the locally installed kind(0.7.0).
+    # Because of the development, we are using a specific version of kubectl now.
+    # orig_kind_bin="$KIND_BIN"
+    # if command -v kind > /dev/null; then
+    #     KIND_BIN="$(command -v kind)"
+    #     if hack::verify_kind; then
+    #         ln -sf "$KIND_BIN" "$orig_kind_bin"
+    #         KIND_BIN="$orig_kind_bin"
+    #         echo $KIND_BIN
+    #         return 0
+    #     fi
+    # fi
 
     echo "Installing kind v$KIND_VERSION..."
     tmpfile=$(mktemp)


### PR DESCRIPTION
### What is this PR for?
This PR is a preparation of the integration test in GitHub Actions. Since there is the wrong version of kubectl and KinD installed in GitHub Actions, we should specify our own versions locally.

### What type of PR is it?
[Test]

### Todos

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-874

### How should this be tested?
See the test-k8s in Travis CI.

### Screenshots (if appropriate)

### Questions:
* Do the license files need updating? No
* Are there breaking changes for older versions? No
* Does this need new documentation? No
