### PR TITLE
SUBMARINE-882. fix datadictIT

### DIFF
--- a/submarine-test/test-e2e/src/test/java/org/apache/submarine/AbstractSubmarineIT.java
+++ b/submarine-test/test-e2e/src/test/java/org/apache/submarine/AbstractSubmarineIT.java
@@ -37,6 +37,7 @@ import org.openqa.selenium.support.ui.Wait;
 import org.openqa.selenium.support.ui.WebDriverWait;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.openqa.selenium.interactions.Actions;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -48,6 +49,7 @@ import java.util.concurrent.TimeUnit;
 
 abstract public class AbstractSubmarineIT {
   protected static WebDriver driver;
+  protected static Actions action;
 
   protected final static Logger LOG = LoggerFactory.getLogger(AbstractSubmarineIT.class);
   protected static final long MIN_IMPLICIT_WAIT = 5;

--- a/submarine-test/test-e2e/src/test/java/org/apache/submarine/AbstractSubmarineIT.java
+++ b/submarine-test/test-e2e/src/test/java/org/apache/submarine/AbstractSubmarineIT.java
@@ -126,6 +126,20 @@ abstract public class AbstractSubmarineIT {
     return button;
   }
 
+  protected WebElement Hover(final By locator, final long timeWait) {
+    waitToPresent(locator, timeWait);
+    WebElement item = buttonCheck(locator, timeWait);
+    action.moveToElement(item).build().perform();
+    return item;
+  }
+
+  protected WebElement HoverAndClick(final By locator, final long timeWait) {
+    waitToPresent(locator, timeWait);
+    WebElement item = buttonCheck(locator, timeWait);
+    action.moveToElement(item).click().build().perform();
+    return item;
+  }
+
   protected void takeScreenShot(final String path) {
     File scrFile1 = ((TakesScreenshot)driver).getScreenshotAs(OutputType.FILE);
     try {

--- a/submarine-test/test-e2e/src/test/java/org/apache/submarine/WebDriverManager.java
+++ b/submarine-test/test-e2e/src/test/java/org/apache/submarine/WebDriverManager.java
@@ -29,6 +29,7 @@ import org.openqa.selenium.support.ui.ExpectedCondition;
 import org.openqa.selenium.support.ui.WebDriverWait;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.openqa.selenium.Dimension;
 
 
 public class WebDriverManager {
@@ -111,8 +112,8 @@ public class WebDriverManager {
     if (loaded == false) {
       fail();
     }
-
-    driver.manage().window().maximize();
+    Dimension d = new Dimension(1920, 1080);
+    driver.manage().window().setSize(d);
     return driver;
   }
 

--- a/submarine-test/test-e2e/src/test/java/org/apache/submarine/integration/datadictIT.java
+++ b/submarine-test/test-e2e/src/test/java/org/apache/submarine/integration/datadictIT.java
@@ -51,9 +51,9 @@ public class datadictIT extends AbstractSubmarineIT {
   public void dataDictTest() throws Exception {
     DataDictPage dataDictPage = new DataDictPage();
     String URL = getURL("http://127.0.0.1", 8080);
-
     Sidebars sidebars = new Sidebars(URL);
     LoginPage loginPage = new LoginPage();
+    String dictCode, newItemCode, newItemName, newPostfix;
 
     // Login
     LOG.info("Login");
@@ -62,43 +62,143 @@ public class datadictIT extends AbstractSubmarineIT {
     // Start Routing & Navigation in data-dict
     LOG.info("Start Routing & Navigation in data-dict");
     sidebars.gotoDataDict();
-    WebDriverWait wait = new WebDriverWait( driver, 60);
-    wait.until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//span[@class='ant-breadcrumb-link ng-star-inserted']")));
 
     // Add button
     LOG.info("[TEST] Add button");
-    // Add --> Ok --> required feedback --> close
-    dataDictPage.addNothing();
+    // // 1. Add --> Ok --> required feedback --> close
+    // Add
+    Click(dataDictPage.addBtn, MAX_BROWSER_TIMEOUT_SEC);
+    // Ok
+    Click(dataDictPage.okBtn, MAX_BROWSER_TIMEOUT_SEC);
+    // check if the modal doesn't disappear
+    Assert.assertEquals(driver.findElements(By.xpath("//div[contains(text(), \"Add\")]")).size(), 1);
+    // Close
+    Click(dataDictPage.closeBtn, MAX_BROWSER_TIMEOUT_SEC);
+    // check if the model disappear
+    Assert.assertEquals(driver.findElements(By.xpath("//div[contains(text(), \"Add\")]")).size(), 0);
 
-    // Add --> set input --> close
-    dataDictPage.addNewDict("test new dict code", "test new dict name", "test new dict description", true);
+    // 2. Add --> set input --> close
+    // Add
+    Click(dataDictPage.addBtn, MAX_BROWSER_TIMEOUT_SEC);
+    // Set input
+    SendKeys(dataDictPage.dictCodeInput, MAX_BROWSER_TIMEOUT_SEC, "test new dict code");
+    SendKeys(dataDictPage.dictNameInput, MAX_BROWSER_TIMEOUT_SEC, "test new dict name");
+    SendKeys(dataDictPage.dictDescription, MAX_BROWSER_TIMEOUT_SEC, "test new dict description");
+    // close
+    Click(dataDictPage.closeBtn, MAX_BROWSER_TIMEOUT_SEC);
+    // check there is no new dict
+    Assert.assertEquals(driver.findElements(By.xpath("//td[@id='dataDictCodetest new dict code']")).size(), 0);
 
-    // Add --> set input --> ok --> new dict
-    dataDictPage.addNewDict("test new dict code", "test new dict name", "test new dict description", false);
-
+    // 3. Add --> set input --> ok --> new dict
+    // dataDictPage.addNewDict("test new dict code", "test new dict name", "test new dict description", false);
+    // Add
+    Click(dataDictPage.addBtn, MAX_BROWSER_TIMEOUT_SEC);
+    // Set input
+    SendKeys(dataDictPage.dictCodeInput, MAX_BROWSER_TIMEOUT_SEC, "test new dict code");
+    SendKeys(dataDictPage.dictNameInput, MAX_BROWSER_TIMEOUT_SEC, "test new dict name");
+    SendKeys(dataDictPage.dictDescription, MAX_BROWSER_TIMEOUT_SEC, "test new dict description");
+    // Ok
+    Click(dataDictPage.okBtn, MAX_BROWSER_TIMEOUT_SEC);
+    // check there is new dict
+    Assert.assertEquals(driver.findElements(By.xpath("//td[@id='dataDictCodetest new dict code']")).size(), 1);
 
     // Configuration button
     LOG.info("[TEST] PROJECT_TYPE Configuration button");
 
-    // old dict --> More --> Configuration --> Add --> set input --> OK
-    dataDictPage.addItem("PROJECT_TYPE","qqq", "www", false);
+    // 3. old dict --> More --> Configuration --> Add --> set input --> OK
+    dictCode = "PROJECT_TYPE";
+    newItemCode = "qqq";
+    newItemName = "www";
+    // More
+    waitToPresent(dataDictPage.moreBtn(dictCode), MAX_BROWSER_TIMEOUT_SEC);
+    Click(dataDictPage.moreBtn(dictCode), MAX_BROWSER_TIMEOUT_SEC);
+    // Configuration
+    waitToPresent(dataDictPage.configBtn(dictCode), MAX_BROWSER_TIMEOUT_SEC);
+    Click(dataDictPage.configBtn(dictCode), MAX_BROWSER_TIMEOUT_SEC);
+    // Add Item
+    waitToPresent(dataDictPage.itemAddBtn(dictCode), MAX_BROWSER_TIMEOUT_SEC);
+    Click(dataDictPage.itemAddBtn(dictCode), MAX_BROWSER_TIMEOUT_SEC);
+    // Set Input
+    Click(dataDictPage.statusDropDown, MAX_BROWSER_TIMEOUT_SEC);
+    Click(dataDictPage.statusUnavailable, MAX_BROWSER_TIMEOUT_SEC);
+    SendKeys(dataDictPage.itemCodeInput(dictCode), MAX_BROWSER_TIMEOUT_SEC, newItemCode);
+    SendKeys(dataDictPage.itemNameInput(dictCode), MAX_BROWSER_TIMEOUT_SEC, newItemName);
+    Click(dataDictPage.addActionBtn, MAX_BROWSER_TIMEOUT_SEC);
+    // Ok
+    Click(dataDictPage.okBtn, MAX_BROWSER_TIMEOUT_SEC);
 
+    // check if add successful
+    Click(dataDictPage.moreBtn(dictCode), MAX_BROWSER_TIMEOUT_SEC);
+    waitToPresent(dataDictPage.configBtn(dictCode), MAX_BROWSER_TIMEOUT_SEC);
+    Click(dataDictPage.configBtn(dictCode), MAX_BROWSER_TIMEOUT_SEC);
+    Assert.assertEquals(driver.findElements(By.xpath(String.format("//td[contains(text(), \"%s\")]", newItemCode))).size(), 1);
+    Click(dataDictPage.okBtn, MAX_BROWSER_TIMEOUT_SEC);
 
     // Edit button
     LOG.info("[TEST] Edit button");
 
-    // Edit dict --> Update --> OK --> More --> Configuration
-    dataDictPage.editDict("PROJECT_VISIBILITY", "123");
+    // 4. Edit dict --> Update --> OK --> More --> Configuration --> OK
+    dictCode = "PROJECT_VISIBILITY";
+    newPostfix = "123";
+    // Edit
+    waitToPresent(dataDictPage.editBtn(dictCode), MAX_BROWSER_TIMEOUT_SEC);
+    Click(dataDictPage.editBtn(dictCode), MAX_BROWSER_TIMEOUT_SEC);
+    // Update
+    SendKeys(dataDictPage.dictCodeInput, MAX_BROWSER_TIMEOUT_SEC, newPostfix);
+    // Ok
+    Click(dataDictPage.okBtn, MAX_BROWSER_TIMEOUT_SEC);
+    // More
+    Click(dataDictPage.moreBtn(dictCode.concat(newPostfix)), MAX_BROWSER_TIMEOUT_SEC);
+    // Configuration
+    waitToPresent(dataDictPage.configBtn(dictCode.concat(newPostfix)), MAX_BROWSER_TIMEOUT_SEC);
+    Click(dataDictPage.configBtn(dictCode.concat(newPostfix)), MAX_BROWSER_TIMEOUT_SEC);
+    // Ok
+    Click(dataDictPage.okBtn, MAX_BROWSER_TIMEOUT_SEC);
 
     LOG.info("[TEST] test new dict code Configuration button");
 
-    // new dict --> More --> Configuration --> Add --> set input --> OK
-    dataDictPage.addItem("test new dict code", "aaa", "bbb", true);
+    // 5. new dict --> More --> Configuration --> Add --> set input --> OK
+    dictCode = "test new dict code";
+    newItemCode = "aaa";
+    newItemName = "bbb";
+    // More
+    waitToPresent(dataDictPage.moreBtn(dictCode), MAX_BROWSER_TIMEOUT_SEC);
+    Click(dataDictPage.moreBtn(dictCode), MAX_BROWSER_TIMEOUT_SEC);
+    // Configuration
+    waitToPresent(dataDictPage.configBtn(dictCode), MAX_BROWSER_TIMEOUT_SEC);
+    Click(dataDictPage.configBtn(dictCode), MAX_BROWSER_TIMEOUT_SEC);
+    // Add Item
+    waitToPresent(dataDictPage.itemAddBtn(dictCode), MAX_BROWSER_TIMEOUT_SEC);
+    Click(dataDictPage.itemAddBtn(dictCode), MAX_BROWSER_TIMEOUT_SEC);
+    // Set Input
+    Click(dataDictPage.statusDropDown, MAX_BROWSER_TIMEOUT_SEC);
+    Click(dataDictPage.statusAvailable, MAX_BROWSER_TIMEOUT_SEC);
+    SendKeys(dataDictPage.itemCodeInput(dictCode), MAX_BROWSER_TIMEOUT_SEC, newItemCode);
+    SendKeys(dataDictPage.itemNameInput(dictCode), MAX_BROWSER_TIMEOUT_SEC, newItemName);
+    Click(dataDictPage.addActionBtn, MAX_BROWSER_TIMEOUT_SEC);
+    // Ok
+    Click(dataDictPage.okBtn, MAX_BROWSER_TIMEOUT_SEC);
+
+    // check if add successful
+    Click(dataDictPage.moreBtn(dictCode), MAX_BROWSER_TIMEOUT_SEC);
+    waitToPresent(dataDictPage.configBtn(dictCode), MAX_BROWSER_TIMEOUT_SEC);
+    Click(dataDictPage.configBtn(dictCode), MAX_BROWSER_TIMEOUT_SEC);
+    Assert.assertEquals(driver.findElements(By.xpath(String.format("//td[contains(text(), \"%s\")]", newItemCode))).size(), 1);
+    Click(dataDictPage.okBtn, MAX_BROWSER_TIMEOUT_SEC);
 
     // Delete button
     LOG.info("[TEST] Delete button");
 
-    // More --> Delete
-    dataDictPage.deleteDict("SYS_USER_SEX");
+    // 6. More --> Delete
+    dictCode = "SYS_USER_SEX";
+    // More
+    waitToPresent(dataDictPage.moreBtn(dictCode), MAX_BROWSER_TIMEOUT_SEC);
+    Click(dataDictPage.moreBtn(dictCode), MAX_BROWSER_TIMEOUT_SEC);
+    // Delete
+    Click(dataDictPage.deleteBtn(dictCode), MAX_BROWSER_TIMEOUT_SEC);
+    waitToPresent(dataDictPage.okDeleteBtn, MAX_BROWSER_TIMEOUT_SEC);
+    Click(dataDictPage.okDeleteBtn, MAX_BROWSER_TIMEOUT_SEC);
+    // check if delete successfully
+    Assert.assertEquals(driver.findElements(By.xpath(String.format("//td[@id='dataDictCode%s']", dictCode))).size(), 0);
   }
 }

--- a/submarine-test/test-e2e/src/test/java/org/apache/submarine/integration/datadictIT.java
+++ b/submarine-test/test-e2e/src/test/java/org/apache/submarine/integration/datadictIT.java
@@ -32,6 +32,7 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.openqa.selenium.interactions.Actions;
+import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.Keys;
 
 
@@ -165,7 +166,10 @@ public class datadictIT extends AbstractSubmarineIT {
     dictCode = "test new dict code";
     newItemCode = "aaa";
     newItemName = "bbb";
+
     // More
+    ((JavascriptExecutor) driver).executeScript("arguments[0].scrollIntoView(true);", driver.findElement(dataDictPage.moreBtn(dictCode)));
+    waitToPresent(dataDictPage.moreBtn(dictCode), MAX_BROWSER_TIMEOUT_SEC);
     action.moveToElement(driver.findElement(dataDictPage.moreBtn(dictCode))).build().perform();
     // Configuration
     waitToPresent(dataDictPage.configBtn(dictCode), MAX_BROWSER_TIMEOUT_SEC);

--- a/submarine-test/test-e2e/src/test/java/org/apache/submarine/integration/datadictIT.java
+++ b/submarine-test/test-e2e/src/test/java/org/apache/submarine/integration/datadictIT.java
@@ -168,7 +168,6 @@ public class datadictIT extends AbstractSubmarineIT {
     newItemName = "bbb";
 
     // More
-    ((JavascriptExecutor) driver).executeScript("arguments[0].scrollIntoView(true);", driver.findElement(dataDictPage.moreBtn(dictCode)));
     waitToPresent(dataDictPage.moreBtn(dictCode), MAX_BROWSER_TIMEOUT_SEC);
     action.moveToElement(driver.findElement(dataDictPage.moreBtn(dictCode))).build().perform();
     // Configuration

--- a/submarine-test/test-e2e/src/test/java/org/apache/submarine/integration/datadictIT.java
+++ b/submarine-test/test-e2e/src/test/java/org/apache/submarine/integration/datadictIT.java
@@ -20,6 +20,7 @@ package org.apache.submarine.integration;
 import org.apache.submarine.AbstractSubmarineIT;
 import org.apache.submarine.integration.pages.LoginPage;
 import org.apache.submarine.integration.components.Sidebars;
+import org.apache.submarine.integration.pages.DataDictPage;
 import org.apache.submarine.WebDriverManager;
 import org.openqa.selenium.By;
 import org.openqa.selenium.support.ui.ExpectedConditions;
@@ -29,6 +30,7 @@ import org.slf4j.LoggerFactory;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
 
 public class datadictIT extends AbstractSubmarineIT {
 
@@ -45,8 +47,9 @@ public class datadictIT extends AbstractSubmarineIT {
     driver.quit();
   }
 
-  // @Test TODO(kevin85421): Due to the undeterministic behavior of travis, I decide to comment it.
+  @Test //TODO(kevin85421): Due to the undeterministic behavior of travis, I decide to comment it.
   public void dataDictTest() throws Exception {
+    DataDictPage dataDictPage = new DataDictPage(driver);
     String URL = getURL("http://127.0.0.1", 8080);
 
     Sidebars sidebars = new Sidebars(URL);
@@ -55,101 +58,47 @@ public class datadictIT extends AbstractSubmarineIT {
     // Login
     LOG.info("Login");
     loginPage.Login();
-    
+
     // Start Routing & Navigation in data-dict
     LOG.info("Start Routing & Navigation in data-dict");
     sidebars.gotoDataDict();
     WebDriverWait wait = new WebDriverWait( driver, 60);
     wait.until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//span[@class='ant-breadcrumb-link ng-star-inserted']")));
-    Assert.assertEquals(driver.getCurrentUrl(), URL.concat("/workbench/manager/dataDict"));
 
     // Add button
     LOG.info("[TEST] Add button");
-    // Add --> Ok --> required feedback
-    pollingWait(By.cssSelector("form > nz-form-item:nth-child(3) > nz-form-control > div > span > button.ant-btn.ant-btn-default"), MAX_BROWSER_TIMEOUT_SEC).click();
-    Assert.assertEquals( driver.findElements(By.xpath("//div[contains(text(), \"Add\")]")).size(), 1);
-    pollingWait(By.cssSelector("button[class='ant-btn ng-star-inserted ant-btn-primary']"), MAX_BROWSER_TIMEOUT_SEC).click();
-    Assert.assertEquals( driver.findElements(By.xpath("//div[contains(text(), \"Add\")]")).size(), 1);
-    // Add --> Close
-    pollingWait(By.cssSelector("button[class='ant-btn ng-star-inserted ant-btn-default']"), MAX_BROWSER_TIMEOUT_SEC).click();
-    Assert.assertEquals( driver.findElements(By.xpath("//div[contains(text(), \"Add\")]")).size(), 0);
+    // Add --> Ok --> required feedback --> close
+    dataDictPage.addNothing();
+
     // Add --> set input --> close
-    pollingWait(By.cssSelector("form > nz-form-item:nth-child(3) > nz-form-control > div > span > button.ant-btn.ant-btn-default"), MAX_BROWSER_TIMEOUT_SEC).click();
-    pollingWait(By.xpath("//input[@id='inputNewDictCode']"), MAX_BROWSER_TIMEOUT_SEC).sendKeys("test new dict code");
-    pollingWait(By.xpath("//input[@id='inputNewDictName']"), MAX_BROWSER_TIMEOUT_SEC).sendKeys("test new dict name");
-    pollingWait(By.xpath("//input[@id='inputNewDictDescription']"), MAX_BROWSER_TIMEOUT_SEC).sendKeys("test new dict description");
-    pollingWait(By.cssSelector("button[class='ant-btn ng-star-inserted ant-btn-default']"), MAX_BROWSER_TIMEOUT_SEC).click();
-    Assert.assertEquals( driver.findElements(By.xpath("//td[@id='dataDictCodetest new dict code']")).size(), 0);
+    dataDictPage.addNewDict("test new dict code", "test new dict name", "test new dict description", true);
+
     // Add --> set input --> ok --> new dict
-    pollingWait(By.cssSelector("form > nz-form-item:nth-child(3) > nz-form-control > div > span > button.ant-btn.ant-btn-default"), MAX_BROWSER_TIMEOUT_SEC).click();
-    pollingWait(By.xpath("//input[@id='inputNewDictCode']"), MAX_BROWSER_TIMEOUT_SEC).sendKeys("test new dict code");
-    pollingWait(By.xpath("//input[@id='inputNewDictName']"), MAX_BROWSER_TIMEOUT_SEC).sendKeys("test new dict name");
-    pollingWait(By.xpath("//input[@id='inputNewDictDescription']"), MAX_BROWSER_TIMEOUT_SEC).sendKeys("test new dict description");
-    pollingWait(By.cssSelector("button[class='ant-btn ng-star-inserted ant-btn-primary']"), MAX_BROWSER_TIMEOUT_SEC).click();
-    Assert.assertEquals( driver.findElements(By.xpath("//td[@id='dataDictCodetest new dict code']")).size(), 1);
+    dataDictPage.addNewDict("test new dict code", "test new dict name", "test new dict description", false);
+
 
     // Configuration button
     LOG.info("[TEST] PROJECT_TYPE Configuration button");
+
     // old dict --> More --> Configuration --> Add --> set input --> OK
-    wait.until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//a[@id='dataDictMorePROJECT_TYPE']")));
-    pollingWait(By.xpath("//a[@id='dataDictMorePROJECT_TYPE']"), MAX_BROWSER_TIMEOUT_SEC).click();
-    pollingWait(By.xpath("//li[@id='dataDictConfigurationPROJECT_TYPE']"), MAX_BROWSER_TIMEOUT_SEC).click();
-    pollingWait(By.xpath("//button[@id='dataDictItemAddPROJECT_TYPE']"), MAX_BROWSER_TIMEOUT_SEC).click();
-    pollingWait(By.xpath("//span[@class='ant-cascader-picker-label']"), MAX_BROWSER_TIMEOUT_SEC).click();
-    pollingWait(By.xpath("//li[@title='unavailable']"), MAX_BROWSER_TIMEOUT_SEC).click();
-    pollingWait(By.xpath("//input[@id='newItemCodePROJECT_TYPE']"), MAX_BROWSER_TIMEOUT_SEC).sendKeys("qqq");
-    pollingWait(By.xpath("//input[@id='newItemNamePROJECT_TYPE']"), MAX_BROWSER_TIMEOUT_SEC).sendKeys("www");
-    pollingWait(By.xpath("//button[@class='ant-btn ng-star-inserted ant-btn-default ant-btn-sm']"), MAX_BROWSER_TIMEOUT_SEC).click();
-    Assert.assertEquals( driver.findElements(By.xpath("//td[contains(text(), \"qqq\")]")).size(), 1);
-    pollingWait(By.xpath("//button[@class='ant-btn ng-star-inserted ant-btn-primary']"), MAX_BROWSER_TIMEOUT_SEC).click();
-    // Check old dict
-    pollingWait(By.xpath("//a[@id='dataDictMorePROJECT_TYPE']"), MAX_BROWSER_TIMEOUT_SEC).click();
-    pollingWait(By.xpath("//li[@id='dataDictConfigurationPROJECT_TYPE']"), MAX_BROWSER_TIMEOUT_SEC).click();
-    Assert.assertEquals( driver.findElements(By.xpath("//td[contains(text(), \"qqq\")]")).size(), 1);
-    pollingWait(By.xpath("//button[@class='ant-btn ng-star-inserted ant-btn-primary']"), MAX_BROWSER_TIMEOUT_SEC).click();
+    dataDictPage.addItem("PROJECT_TYPE","qqq", "www", false);
+
 
     // Edit button
     LOG.info("[TEST] Edit button");
+
     // Edit dict --> Update --> OK --> More --> Configuration
-    wait.until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//a[@id='dataDictEditPROJECT_VISIBILITY']")));
-    pollingWait(By.xpath("//a[@id='dataDictEditPROJECT_VISIBILITY']"), MAX_BROWSER_TIMEOUT_SEC).click();
-    pollingWait(By.xpath("//input[@id='inputNewDictCode']"), MAX_BROWSER_TIMEOUT_SEC).sendKeys("123");
-    pollingWait(By.cssSelector("button[class='ant-btn ng-star-inserted ant-btn-primary']"), MAX_BROWSER_TIMEOUT_SEC).click();
-    Assert.assertEquals( driver.findElements(By.xpath("//td[@id='dataDictCodePROJECT_VISIBILITY123']")).size(), 1);
-    pollingWait(By.xpath("//a[@id='dataDictMorePROJECT_VISIBILITY123']"), MAX_BROWSER_TIMEOUT_SEC).click();
-    pollingWait(By.xpath("//li[@id='dataDictConfigurationPROJECT_VISIBILITY123']"), MAX_BROWSER_TIMEOUT_SEC).click();
-    Assert.assertEquals( driver.findElements(By.xpath("//td[contains(text(), \"PROJECT_VISIBILITY_PRIVATE\")]")).size(), 1);
-    Assert.assertEquals( driver.findElements(By.xpath("//td[contains(text(), \"PROJECT_VISIBILITY_TEAM\")]")).size(), 1);
-    Assert.assertEquals( driver.findElements(By.xpath("//td[contains(text(), \"PROJECT_VISIBILITY_PUBLIC\")]")).size(), 1);
-    pollingWait(By.xpath("//button[@class='ant-btn ng-star-inserted ant-btn-primary']"), MAX_BROWSER_TIMEOUT_SEC).click();
+    dataDictPage.editDict("PROJECT_VISIBILITY", "123");
 
     LOG.info("[TEST] test new dict code Configuration button");
+
     // new dict --> More --> Configuration --> Add --> set input --> OK
-    wait.until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//a[@id='dataDictMoretest new dict code']")));
-    pollingWait(By.xpath("//a[@id='dataDictMoretest new dict code']"), MAX_BROWSER_TIMEOUT_SEC).click();
-    pollingWait(By.xpath("//li[@id='dataDictConfigurationtest new dict code']"), MAX_BROWSER_TIMEOUT_SEC).click();
-    pollingWait(By.xpath("//button[@id='dataDictItemAddtest new dict code']"), MAX_BROWSER_TIMEOUT_SEC).click();
-    pollingWait(By.xpath("//span[@class='ant-cascader-picker-label']"), MAX_BROWSER_TIMEOUT_SEC).click();
-    pollingWait(By.xpath("//li[@title='available']"), MAX_BROWSER_TIMEOUT_SEC).click();
-    pollingWait(By.xpath("//input[@id='newItemCodetest new dict code']"), MAX_BROWSER_TIMEOUT_SEC).sendKeys("aaa");
-    pollingWait(By.xpath("//input[@id='newItemNametest new dict code']"), MAX_BROWSER_TIMEOUT_SEC).sendKeys("bbb");
-    pollingWait(By.xpath("//button[@class='ant-btn ng-star-inserted ant-btn-default ant-btn-sm']"), MAX_BROWSER_TIMEOUT_SEC).click();
-    Assert.assertEquals( driver.findElements(By.xpath("//td[contains(text(), \"aaa\")]")).size(), 1);
-    pollingWait(By.xpath("//button[@class='ant-btn ng-star-inserted ant-btn-primary']"), MAX_BROWSER_TIMEOUT_SEC).click();
-    // Check new dict
-    pollingWait(By.xpath("//a[@id='dataDictMoretest new dict code']"), MAX_BROWSER_TIMEOUT_SEC).click();
-    pollingWait(By.xpath("//li[@id='dataDictConfigurationtest new dict code']"), MAX_BROWSER_TIMEOUT_SEC).click();
-    Assert.assertEquals( driver.findElements(By.xpath("//td[contains(text(), \"aaa\")]")).size(), 1);
-    pollingWait(By.xpath("//button[@class='ant-btn ng-star-inserted ant-btn-primary']"), MAX_BROWSER_TIMEOUT_SEC).click();
+    dataDictPage.addItem("test new dict code", "aaa", "bbb", true);
 
     // Delete button
     LOG.info("[TEST] Delete button");
+
     // More --> Delete
-    Assert.assertEquals( driver.findElements(By.xpath("//td[@id='dataDictCodeSYS_USER_SEX']")).size(), 1);
-    wait.until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//a[@id='dataDictMoreSYS_USER_SEX']")));
-    pollingWait(By.xpath("//a[@id='dataDictMoreSYS_USER_SEX']"), MAX_BROWSER_TIMEOUT_SEC).click();
-    pollingWait(By.xpath("//li[@id='dataDictDeleteSYS_USER_SEX']"), MAX_BROWSER_TIMEOUT_SEC).click();
-    pollingWait(By.xpath("//span[text()='Ok']/ancestor::button[@ng-reflect-nz-type='primary']"), MAX_BROWSER_TIMEOUT_SEC).click();
-    Assert.assertEquals( driver.findElements(By.xpath("//td[@id='dataDictCodeSYS_USER_SEX']")).size(), 0);
+    dataDictPage.deleteDict("SYS_USER_SEX");
   }
 }

--- a/submarine-test/test-e2e/src/test/java/org/apache/submarine/integration/datadictIT.java
+++ b/submarine-test/test-e2e/src/test/java/org/apache/submarine/integration/datadictIT.java
@@ -47,7 +47,7 @@ public class datadictIT extends AbstractSubmarineIT {
     driver.quit();
   }
 
-  @Test //TODO(kevin85421): Due to the undeterministic behavior of travis, I decide to comment it.
+  @Test
   public void dataDictTest() throws Exception {
     DataDictPage dataDictPage = new DataDictPage();
     String URL = getURL("http://127.0.0.1", 8080);

--- a/submarine-test/test-e2e/src/test/java/org/apache/submarine/integration/datadictIT.java
+++ b/submarine-test/test-e2e/src/test/java/org/apache/submarine/integration/datadictIT.java
@@ -49,7 +49,7 @@ public class datadictIT extends AbstractSubmarineIT {
 
   @Test //TODO(kevin85421): Due to the undeterministic behavior of travis, I decide to comment it.
   public void dataDictTest() throws Exception {
-    DataDictPage dataDictPage = new DataDictPage(driver);
+    DataDictPage dataDictPage = new DataDictPage();
     String URL = getURL("http://127.0.0.1", 8080);
 
     Sidebars sidebars = new Sidebars(URL);

--- a/submarine-test/test-e2e/src/test/java/org/apache/submarine/integration/datadictIT.java
+++ b/submarine-test/test-e2e/src/test/java/org/apache/submarine/integration/datadictIT.java
@@ -32,6 +32,7 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.openqa.selenium.interactions.Actions;
+import org.openqa.selenium.Keys;
 
 
 public class datadictIT extends AbstractSubmarineIT {
@@ -114,10 +115,10 @@ public class datadictIT extends AbstractSubmarineIT {
     newItemCode = "qqq";
     newItemName = "www";
     // More
-    action.moveToElement(driver.findElement(dataDictPage.moreBtn(dictCode))).perform();
+    action.moveToElement(driver.findElement(dataDictPage.moreBtn(dictCode))).build().perform();
     // Configuration
     waitToPresent(dataDictPage.configBtn(dictCode), MAX_BROWSER_TIMEOUT_SEC);
-    Click(dataDictPage.configBtn(dictCode), MAX_BROWSER_TIMEOUT_SEC);
+    action.moveToElement(driver.findElement(dataDictPage.configBtn(dictCode))).click().build().perform();
     // Add Item
     waitToPresent(dataDictPage.itemAddBtn(dictCode), MAX_BROWSER_TIMEOUT_SEC);
     Click(dataDictPage.itemAddBtn(dictCode), MAX_BROWSER_TIMEOUT_SEC);
@@ -131,9 +132,9 @@ public class datadictIT extends AbstractSubmarineIT {
     Click(dataDictPage.okBtn, MAX_BROWSER_TIMEOUT_SEC);
 
     // check if add successful
-    action.moveToElement(driver.findElement(dataDictPage.moreBtn(dictCode))).perform();
+    action.moveToElement(driver.findElement(dataDictPage.moreBtn(dictCode))).build().perform();
     waitToPresent(dataDictPage.configBtn(dictCode), MAX_BROWSER_TIMEOUT_SEC);
-    Click(dataDictPage.configBtn(dictCode), MAX_BROWSER_TIMEOUT_SEC);
+    action.moveToElement(driver.findElement(dataDictPage.configBtn(dictCode))).click().build().perform();
     Assert.assertEquals(driver.findElements(By.xpath(String.format("//td[contains(text(), \"%s\")]", newItemCode))).size(), 1);
     Click(dataDictPage.okBtn, MAX_BROWSER_TIMEOUT_SEC);
 
@@ -151,10 +152,10 @@ public class datadictIT extends AbstractSubmarineIT {
     // Ok
     Click(dataDictPage.okBtn, MAX_BROWSER_TIMEOUT_SEC);
     // More
-    action.moveToElement(driver.findElement(dataDictPage.moreBtn(dictCode.concat(newPostfix)))).perform();
+    action.moveToElement(driver.findElement(dataDictPage.moreBtn(dictCode.concat(newPostfix)))).build().perform();
     // Configuration
     waitToPresent(dataDictPage.configBtn(dictCode.concat(newPostfix)), MAX_BROWSER_TIMEOUT_SEC);
-    Click(dataDictPage.configBtn(dictCode.concat(newPostfix)), MAX_BROWSER_TIMEOUT_SEC);
+    action.moveToElement(driver.findElement(dataDictPage.configBtn(dictCode.concat(newPostfix)))).click().build().perform();
     // Ok
     Click(dataDictPage.okBtn, MAX_BROWSER_TIMEOUT_SEC);
 
@@ -165,10 +166,10 @@ public class datadictIT extends AbstractSubmarineIT {
     newItemCode = "aaa";
     newItemName = "bbb";
     // More
-    action.moveToElement(driver.findElement(dataDictPage.moreBtn(dictCode))).perform();
+    action.moveToElement(driver.findElement(dataDictPage.moreBtn(dictCode))).build().perform();
     // Configuration
     waitToPresent(dataDictPage.configBtn(dictCode), MAX_BROWSER_TIMEOUT_SEC);
-    Click(dataDictPage.configBtn(dictCode), MAX_BROWSER_TIMEOUT_SEC);
+    action.moveToElement(driver.findElement(dataDictPage.configBtn(dictCode))).click().build().perform();
     // Add Item
     waitToPresent(dataDictPage.itemAddBtn(dictCode), MAX_BROWSER_TIMEOUT_SEC);
     Click(dataDictPage.itemAddBtn(dictCode), MAX_BROWSER_TIMEOUT_SEC);
@@ -184,7 +185,7 @@ public class datadictIT extends AbstractSubmarineIT {
     // check if add successful
     action.moveToElement(driver.findElement(dataDictPage.moreBtn(dictCode))).perform();
     waitToPresent(dataDictPage.configBtn(dictCode), MAX_BROWSER_TIMEOUT_SEC);
-    Click(dataDictPage.configBtn(dictCode), MAX_BROWSER_TIMEOUT_SEC);
+    action.moveToElement(driver.findElement(dataDictPage.configBtn(dictCode))).click().build().perform();
     Assert.assertEquals(driver.findElements(By.xpath(String.format("//td[contains(text(), \"%s\")]", newItemCode))).size(), 1);
     Click(dataDictPage.okBtn, MAX_BROWSER_TIMEOUT_SEC);
 
@@ -197,7 +198,7 @@ public class datadictIT extends AbstractSubmarineIT {
     action.moveToElement(driver.findElement(dataDictPage.moreBtn(dictCode))).perform();
     // Delete
     waitToPresent(dataDictPage.deleteBtn(dictCode), MAX_BROWSER_TIMEOUT_SEC);
-    Click(dataDictPage.deleteBtn(dictCode), MAX_BROWSER_TIMEOUT_SEC);
+    action.moveToElement(driver.findElement(dataDictPage.deleteBtn(dictCode))).click().build().perform();
     waitToPresent(dataDictPage.okDeleteBtn, MAX_BROWSER_TIMEOUT_SEC);
     Click(dataDictPage.okDeleteBtn, MAX_BROWSER_TIMEOUT_SEC);
     // check if delete successfully

--- a/submarine-test/test-e2e/src/test/java/org/apache/submarine/integration/datadictIT.java
+++ b/submarine-test/test-e2e/src/test/java/org/apache/submarine/integration/datadictIT.java
@@ -116,10 +116,9 @@ public class datadictIT extends AbstractSubmarineIT {
     newItemCode = "qqq";
     newItemName = "www";
     // More
-    action.moveToElement(driver.findElement(dataDictPage.moreBtn(dictCode))).build().perform();
+    Hover(dataDictPage.moreBtn(dictCode), MAX_BROWSER_TIMEOUT_SEC);
     // Configuration
-    waitToPresent(dataDictPage.configBtn(dictCode), MAX_BROWSER_TIMEOUT_SEC);
-    action.moveToElement(driver.findElement(dataDictPage.configBtn(dictCode))).click().build().perform();
+    HoverAndClick(dataDictPage.configBtn(dictCode), MAX_BROWSER_TIMEOUT_SEC);
     // Add Item
     waitToPresent(dataDictPage.itemAddBtn(dictCode), MAX_BROWSER_TIMEOUT_SEC);
     Click(dataDictPage.itemAddBtn(dictCode), MAX_BROWSER_TIMEOUT_SEC);
@@ -133,9 +132,8 @@ public class datadictIT extends AbstractSubmarineIT {
     Click(dataDictPage.okBtn, MAX_BROWSER_TIMEOUT_SEC);
 
     // check if add successful
-    action.moveToElement(driver.findElement(dataDictPage.moreBtn(dictCode))).build().perform();
-    waitToPresent(dataDictPage.configBtn(dictCode), MAX_BROWSER_TIMEOUT_SEC);
-    action.moveToElement(driver.findElement(dataDictPage.configBtn(dictCode))).click().build().perform();
+    Hover(dataDictPage.moreBtn(dictCode), MAX_BROWSER_TIMEOUT_SEC);
+    HoverAndClick(dataDictPage.configBtn(dictCode), MAX_BROWSER_TIMEOUT_SEC);
     Assert.assertEquals(driver.findElements(By.xpath(String.format("//td[contains(text(), \"%s\")]", newItemCode))).size(), 1);
     Click(dataDictPage.okBtn, MAX_BROWSER_TIMEOUT_SEC);
 
@@ -153,10 +151,10 @@ public class datadictIT extends AbstractSubmarineIT {
     // Ok
     Click(dataDictPage.okBtn, MAX_BROWSER_TIMEOUT_SEC);
     // More
-    action.moveToElement(driver.findElement(dataDictPage.moreBtn(dictCode.concat(newPostfix)))).build().perform();
+    Hover(dataDictPage.moreBtn(dictCode.concat(newPostfix)), MAX_BROWSER_TIMEOUT_SEC);
     // Configuration
-    waitToPresent(dataDictPage.configBtn(dictCode.concat(newPostfix)), MAX_BROWSER_TIMEOUT_SEC);
-    action.moveToElement(driver.findElement(dataDictPage.configBtn(dictCode.concat(newPostfix)))).click().build().perform();
+    HoverAndClick(dataDictPage.configBtn(dictCode.concat(newPostfix)), MAX_BROWSER_TIMEOUT_SEC);
+
     // Ok
     Click(dataDictPage.okBtn, MAX_BROWSER_TIMEOUT_SEC);
 
@@ -168,11 +166,9 @@ public class datadictIT extends AbstractSubmarineIT {
     newItemName = "bbb";
 
     // More
-    waitToPresent(dataDictPage.moreBtn(dictCode), MAX_BROWSER_TIMEOUT_SEC);
-    action.moveToElement(driver.findElement(dataDictPage.moreBtn(dictCode))).build().perform();
+    Hover(dataDictPage.moreBtn(dictCode), MAX_BROWSER_TIMEOUT_SEC);
     // Configuration
-    waitToPresent(dataDictPage.configBtn(dictCode), MAX_BROWSER_TIMEOUT_SEC);
-    action.moveToElement(driver.findElement(dataDictPage.configBtn(dictCode))).click().build().perform();
+    HoverAndClick(dataDictPage.configBtn(dictCode), MAX_BROWSER_TIMEOUT_SEC);
     // Add Item
     waitToPresent(dataDictPage.itemAddBtn(dictCode), MAX_BROWSER_TIMEOUT_SEC);
     Click(dataDictPage.itemAddBtn(dictCode), MAX_BROWSER_TIMEOUT_SEC);
@@ -186,9 +182,8 @@ public class datadictIT extends AbstractSubmarineIT {
     Click(dataDictPage.okBtn, MAX_BROWSER_TIMEOUT_SEC);
 
     // check if add successful
-    action.moveToElement(driver.findElement(dataDictPage.moreBtn(dictCode))).perform();
-    waitToPresent(dataDictPage.configBtn(dictCode), MAX_BROWSER_TIMEOUT_SEC);
-    action.moveToElement(driver.findElement(dataDictPage.configBtn(dictCode))).click().build().perform();
+    Hover(dataDictPage.moreBtn(dictCode), MAX_BROWSER_TIMEOUT_SEC);
+    HoverAndClick(dataDictPage.configBtn(dictCode), MAX_BROWSER_TIMEOUT_SEC);
     Assert.assertEquals(driver.findElements(By.xpath(String.format("//td[contains(text(), \"%s\")]", newItemCode))).size(), 1);
     Click(dataDictPage.okBtn, MAX_BROWSER_TIMEOUT_SEC);
 
@@ -198,10 +193,9 @@ public class datadictIT extends AbstractSubmarineIT {
     // 6. More --> Delete
     dictCode = "SYS_USER_SEX";
     // More
-    action.moveToElement(driver.findElement(dataDictPage.moreBtn(dictCode))).perform();
+    Hover(dataDictPage.moreBtn(dictCode), MAX_BROWSER_TIMEOUT_SEC);
     // Delete
-    waitToPresent(dataDictPage.deleteBtn(dictCode), MAX_BROWSER_TIMEOUT_SEC);
-    action.moveToElement(driver.findElement(dataDictPage.deleteBtn(dictCode))).click().build().perform();
+    HoverAndClick(dataDictPage.deleteBtn(dictCode), MAX_BROWSER_TIMEOUT_SEC);
     waitToPresent(dataDictPage.okDeleteBtn, MAX_BROWSER_TIMEOUT_SEC);
     Click(dataDictPage.okDeleteBtn, MAX_BROWSER_TIMEOUT_SEC);
     // check if delete successfully

--- a/submarine-test/test-e2e/src/test/java/org/apache/submarine/integration/datadictIT.java
+++ b/submarine-test/test-e2e/src/test/java/org/apache/submarine/integration/datadictIT.java
@@ -31,15 +31,19 @@ import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
+import org.openqa.selenium.interactions.Actions;
+
 
 public class datadictIT extends AbstractSubmarineIT {
 
   public final static Logger LOG = LoggerFactory.getLogger(datadictIT.class);
 
+
   @BeforeClass
   public static void startUp(){
     LOG.info("[Testcase]: datadictIT");
     driver =  WebDriverManager.getWebDriver();
+    action = new Actions(driver);
   }
 
   @AfterClass
@@ -110,8 +114,7 @@ public class datadictIT extends AbstractSubmarineIT {
     newItemCode = "qqq";
     newItemName = "www";
     // More
-    waitToPresent(dataDictPage.moreBtn(dictCode), MAX_BROWSER_TIMEOUT_SEC);
-    Click(dataDictPage.moreBtn(dictCode), MAX_BROWSER_TIMEOUT_SEC);
+    action.moveToElement(driver.findElement(dataDictPage.moreBtn(dictCode))).perform();
     // Configuration
     waitToPresent(dataDictPage.configBtn(dictCode), MAX_BROWSER_TIMEOUT_SEC);
     Click(dataDictPage.configBtn(dictCode), MAX_BROWSER_TIMEOUT_SEC);
@@ -128,7 +131,7 @@ public class datadictIT extends AbstractSubmarineIT {
     Click(dataDictPage.okBtn, MAX_BROWSER_TIMEOUT_SEC);
 
     // check if add successful
-    Click(dataDictPage.moreBtn(dictCode), MAX_BROWSER_TIMEOUT_SEC);
+    action.moveToElement(driver.findElement(dataDictPage.moreBtn(dictCode))).perform();
     waitToPresent(dataDictPage.configBtn(dictCode), MAX_BROWSER_TIMEOUT_SEC);
     Click(dataDictPage.configBtn(dictCode), MAX_BROWSER_TIMEOUT_SEC);
     Assert.assertEquals(driver.findElements(By.xpath(String.format("//td[contains(text(), \"%s\")]", newItemCode))).size(), 1);
@@ -148,7 +151,7 @@ public class datadictIT extends AbstractSubmarineIT {
     // Ok
     Click(dataDictPage.okBtn, MAX_BROWSER_TIMEOUT_SEC);
     // More
-    Click(dataDictPage.moreBtn(dictCode.concat(newPostfix)), MAX_BROWSER_TIMEOUT_SEC);
+    action.moveToElement(driver.findElement(dataDictPage.moreBtn(dictCode.concat(newPostfix)))).perform();
     // Configuration
     waitToPresent(dataDictPage.configBtn(dictCode.concat(newPostfix)), MAX_BROWSER_TIMEOUT_SEC);
     Click(dataDictPage.configBtn(dictCode.concat(newPostfix)), MAX_BROWSER_TIMEOUT_SEC);
@@ -162,8 +165,7 @@ public class datadictIT extends AbstractSubmarineIT {
     newItemCode = "aaa";
     newItemName = "bbb";
     // More
-    waitToPresent(dataDictPage.moreBtn(dictCode), MAX_BROWSER_TIMEOUT_SEC);
-    Click(dataDictPage.moreBtn(dictCode), MAX_BROWSER_TIMEOUT_SEC);
+    action.moveToElement(driver.findElement(dataDictPage.moreBtn(dictCode))).perform();
     // Configuration
     waitToPresent(dataDictPage.configBtn(dictCode), MAX_BROWSER_TIMEOUT_SEC);
     Click(dataDictPage.configBtn(dictCode), MAX_BROWSER_TIMEOUT_SEC);
@@ -180,7 +182,7 @@ public class datadictIT extends AbstractSubmarineIT {
     Click(dataDictPage.okBtn, MAX_BROWSER_TIMEOUT_SEC);
 
     // check if add successful
-    Click(dataDictPage.moreBtn(dictCode), MAX_BROWSER_TIMEOUT_SEC);
+    action.moveToElement(driver.findElement(dataDictPage.moreBtn(dictCode))).perform();
     waitToPresent(dataDictPage.configBtn(dictCode), MAX_BROWSER_TIMEOUT_SEC);
     Click(dataDictPage.configBtn(dictCode), MAX_BROWSER_TIMEOUT_SEC);
     Assert.assertEquals(driver.findElements(By.xpath(String.format("//td[contains(text(), \"%s\")]", newItemCode))).size(), 1);
@@ -192,9 +194,9 @@ public class datadictIT extends AbstractSubmarineIT {
     // 6. More --> Delete
     dictCode = "SYS_USER_SEX";
     // More
-    waitToPresent(dataDictPage.moreBtn(dictCode), MAX_BROWSER_TIMEOUT_SEC);
-    Click(dataDictPage.moreBtn(dictCode), MAX_BROWSER_TIMEOUT_SEC);
+    action.moveToElement(driver.findElement(dataDictPage.moreBtn(dictCode))).perform();
     // Delete
+    waitToPresent(dataDictPage.deleteBtn(dictCode), MAX_BROWSER_TIMEOUT_SEC);
     Click(dataDictPage.deleteBtn(dictCode), MAX_BROWSER_TIMEOUT_SEC);
     waitToPresent(dataDictPage.okDeleteBtn, MAX_BROWSER_TIMEOUT_SEC);
     Click(dataDictPage.okDeleteBtn, MAX_BROWSER_TIMEOUT_SEC);

--- a/submarine-test/test-e2e/src/test/java/org/apache/submarine/integration/pages/DataDictPage.java
+++ b/submarine-test/test-e2e/src/test/java/org/apache/submarine/integration/pages/DataDictPage.java
@@ -1,0 +1,188 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.submarine.integration.pages;
+
+import org.apache.submarine.AbstractSubmarineIT;
+import org.testng.Assert;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.interactions.Actions;
+import org.openqa.selenium.support.FindBy;
+import org.openqa.selenium.support.PageFactory;
+import org.openqa.selenium.support.pagefactory.AjaxElementLocatorFactory;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.Select;
+import org.openqa.selenium.support.ui.WebDriverWait;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DataDictPage extends AbstractSubmarineIT {
+
+    private By addBtn = By.cssSelector("form > nz-form-item:nth-child(3) > nz-form-control > div > span > button.ant-btn.ant-btn-default");
+
+    private By okBtn = By.cssSelector("button[class='ant-btn ng-star-inserted ant-btn-primary']");
+
+    private By okDeleteBtn = By.xpath("//span[text()='Ok']/ancestor::button[@ng-reflect-nz-type='primary']");
+
+    private By closeBtn = By.cssSelector("button[class='ant-btn ng-star-inserted ant-btn-default']");
+
+    private By dictCodeInput = By.xpath("//input[@id='inputNewDictCode']");
+
+    private By dictNameInput = By.xpath("//input[@id='inputNewDictName']");
+
+    private By dictDescription = By.xpath("//input[@id='inputNewDictDescription']");
+
+    // for configuration jump out modal
+    private By statusDropDown = By.xpath("//span[@class='ant-cascader-picker-label']");
+
+    private By statusAvailable = By.xpath("//li[@title='available']");
+
+    private By statusUnavailable = By.xpath("//li[@title='unavailable']");
+
+    private By addActionBtn = By.xpath("//button[@class='ant-btn ng-star-inserted ant-btn-default ant-btn-sm']");
+
+    public DataDictPage(WebDriver driver){
+
+    }
+
+    public By moreBtn(String dict_code) {
+        String xpath = String.format("//a[@id='dataDictMore%s']", dict_code);
+        return By.xpath(xpath);
+    }
+
+    public By deleteBtn(String dict_code) {
+        String xpath = String.format("//li[@id='dataDictDelete%s']", dict_code);
+        return By.xpath(xpath);
+    }
+
+    public By configBtn(String dict_code) {
+        String xpath = String.format("//li[@id='dataDictConfiguration%s']", dict_code);
+        return By.xpath(xpath);
+    }
+
+    public By editBtn(String dict_code) {
+        String xpath = String.format("//a[@id='dataDictEdit%s']", dict_code);
+        return By.xpath(xpath);
+    }
+
+    public By itemAddBtn(String dict_code) {
+        String xpath = String.format("//button[@id='dataDictItemAdd%s']", dict_code);
+        return By.xpath(xpath);
+    }
+
+    public By itemCodeInput(String dict_code) {
+        String xpath = String.format("//input[@id='newItemCode%s']", dict_code);
+        return By.xpath(xpath);
+    }
+
+    public By itemNameInput(String dict_code) {
+        String xpath = String.format("//input[@id='newItemName%s']", dict_code);
+        return By.xpath(xpath);
+    }
+
+    public void addNothing(){
+        // Add --> Ok --> required feedback
+        By checkEmpty = By.xpath("//div[contains(text(), \"Add\")]");
+        Click(addBtn, MAX_BROWSER_TIMEOUT_SEC);
+        Assert.assertEquals(driver.findElements(checkEmpty).size(), 1);
+        Click(okBtn, MAX_BROWSER_TIMEOUT_SEC);
+        Assert.assertEquals(driver.findElements(checkEmpty).size(), 1);
+
+        // Add --> Close
+        Click(closeBtn, MAX_BROWSER_TIMEOUT_SEC);
+        Assert.assertEquals(driver.findElements(checkEmpty).size(), 0);
+    }
+
+    // if isDry means it wouldn't really add it.
+    public void addNewDict(String newDictCode, String newDictName, String newDictDescription, boolean isDry) {
+        String toCheck = String.format("//td[@id='dataDictCode%s']", newDictCode);
+        Click(addBtn, MAX_BROWSER_TIMEOUT_SEC);
+        SendKeys(dictCodeInput, MAX_BROWSER_TIMEOUT_SEC, newDictCode);
+        SendKeys(dictNameInput, MAX_BROWSER_TIMEOUT_SEC, newDictName);
+        SendKeys(dictDescription, MAX_BROWSER_TIMEOUT_SEC, newDictDescription);
+        if (isDry) {
+            Click(closeBtn, MAX_BROWSER_TIMEOUT_SEC);
+            Assert.assertEquals(driver.findElements(By.xpath(toCheck)).size(), 0);
+        }else {
+            Click(okBtn, MAX_BROWSER_TIMEOUT_SEC);
+            Assert.assertEquals(driver.findElements(By.xpath(toCheck)).size(), 1);
+        }
+    }
+
+    public void addItem(String dictCode, String newItemCode, String newItemName, boolean isAvailable) {
+        String toCheck = String.format("//td[contains(text(), \"%s\")]", newItemCode);
+        waitToPresent(moreBtn(dictCode), MAX_BROWSER_TIMEOUT_SEC);
+        Click(moreBtn(dictCode), MAX_BROWSER_TIMEOUT_SEC);
+        waitToPresent(configBtn(dictCode), MAX_BROWSER_TIMEOUT_SEC);
+        Click(configBtn(dictCode), MAX_BROWSER_TIMEOUT_SEC);
+        waitToPresent(itemAddBtn(dictCode), MAX_BROWSER_TIMEOUT_SEC);
+        Click(itemAddBtn(dictCode), MAX_BROWSER_TIMEOUT_SEC);
+        Click(statusDropDown, MAX_BROWSER_TIMEOUT_SEC);
+        waitToPresent(statusAvailable, MAX_BROWSER_TIMEOUT_SEC);
+        if(isAvailable) {
+            Click(statusAvailable, MAX_BROWSER_TIMEOUT_SEC);
+        }else {
+            Click(statusUnavailable, MAX_BROWSER_TIMEOUT_SEC);
+        }
+        SendKeys(itemCodeInput(dictCode), MAX_BROWSER_TIMEOUT_SEC, newItemCode);
+        SendKeys(itemNameInput(dictCode), MAX_BROWSER_TIMEOUT_SEC, newItemName);
+        Click(addActionBtn, MAX_BROWSER_TIMEOUT_SEC);
+        Assert.assertEquals(driver.findElements(By.xpath(toCheck)).size(), 1);
+        Click(okBtn, MAX_BROWSER_TIMEOUT_SEC);
+        // check if add successful
+        Click(moreBtn(dictCode), MAX_BROWSER_TIMEOUT_SEC);
+        waitToPresent(configBtn(dictCode), MAX_BROWSER_TIMEOUT_SEC);
+        Click(configBtn(dictCode), MAX_BROWSER_TIMEOUT_SEC);
+        Assert.assertEquals(driver.findElements(By.xpath(toCheck)).size(), 1);
+        Click(okBtn, MAX_BROWSER_TIMEOUT_SEC);
+    }
+
+    public void editDict(String dictCode, String newPostfix) {
+        String toCheck = String.format("//td[@id='dataDictCode%s%s']", dictCode, newPostfix);
+        String checkPrivate = String.format("//td[contains(text(), \"%s_PRIVATE\")]", dictCode);
+        String checkTeam = String.format("//td[contains(text(), \"%s_TEAM\")]", dictCode);
+        String checkPublic = String.format("//td[contains(text(), \"%s_PUBLIC\")]", dictCode);
+
+        waitToPresent(editBtn(dictCode), MAX_BROWSER_TIMEOUT_SEC);
+        Click(editBtn(dictCode), MAX_BROWSER_TIMEOUT_SEC);
+        SendKeys(dictCodeInput, MAX_BROWSER_TIMEOUT_SEC, newPostfix);
+        Click(okBtn, MAX_BROWSER_TIMEOUT_SEC);
+        Assert.assertEquals(driver.findElements(By.xpath(toCheck)).size(), 1);
+        // after edit
+        Click(moreBtn(dictCode.concat(newPostfix)), MAX_BROWSER_TIMEOUT_SEC);
+        waitToPresent(configBtn(dictCode.concat(newPostfix)), MAX_BROWSER_TIMEOUT_SEC);
+        Click(configBtn(dictCode.concat(newPostfix)), MAX_BROWSER_TIMEOUT_SEC);
+        Assert.assertEquals(driver.findElements(By.xpath(checkPrivate)).size(), 1);
+        Assert.assertEquals(driver.findElements(By.xpath(checkTeam)).size(), 1);
+        Assert.assertEquals(driver.findElements(By.xpath(checkPublic)).size(), 1);
+        Click(okBtn, MAX_BROWSER_TIMEOUT_SEC);
+    }
+
+    public void deleteDict(String dictCode) {
+        String toCheck = String.format("//td[@id='dataDictCode%s']", dictCode);
+        Assert.assertEquals(driver.findElements(By.xpath(toCheck)).size(), 1);
+        waitToPresent(moreBtn(dictCode), MAX_BROWSER_TIMEOUT_SEC);
+        Click(moreBtn(dictCode), MAX_BROWSER_TIMEOUT_SEC);
+        Click(deleteBtn(dictCode), MAX_BROWSER_TIMEOUT_SEC);
+        waitToPresent(okDeleteBtn, MAX_BROWSER_TIMEOUT_SEC);
+        Click(okDeleteBtn, MAX_BROWSER_TIMEOUT_SEC);
+        Assert.assertEquals(driver.findElements(By.xpath(toCheck)).size(), 0);
+    }
+
+}

--- a/submarine-test/test-e2e/src/test/java/org/apache/submarine/integration/pages/DataDictPage.java
+++ b/submarine-test/test-e2e/src/test/java/org/apache/submarine/integration/pages/DataDictPage.java
@@ -34,29 +34,29 @@ import org.slf4j.LoggerFactory;
 
 public class DataDictPage extends AbstractSubmarineIT {
 
-    private By addBtn = By.cssSelector("form > nz-form-item:nth-child(3) > nz-form-control > div > span > button.ant-btn.ant-btn-default");
+    public By addBtn = By.cssSelector("form > nz-form-item:nth-child(3) > nz-form-control > div > span > button.ant-btn.ant-btn-default");
 
-    private By okBtn = By.cssSelector("button[class='ant-btn ng-star-inserted ant-btn-primary']");
+    public By okBtn = By.cssSelector("button[class='ant-btn ng-star-inserted ant-btn-primary']");
 
-    private By okDeleteBtn = By.xpath("//span[text()='Ok']/ancestor::button[@ng-reflect-nz-type='primary']");
+    public By okDeleteBtn = By.xpath("//span[text()='Ok']/ancestor::button[@ng-reflect-nz-type='primary']");
 
-    private By closeBtn = By.cssSelector("button[class='ant-btn ng-star-inserted ant-btn-default']");
+    public By closeBtn = By.cssSelector("button[class='ant-btn ng-star-inserted ant-btn-default']");
 
-    private By dictCodeInput = By.xpath("//input[@id='inputNewDictCode']");
+    public By dictCodeInput = By.xpath("//input[@id='inputNewDictCode']");
 
-    private By dictNameInput = By.xpath("//input[@id='inputNewDictName']");
+    public By dictNameInput = By.xpath("//input[@id='inputNewDictName']");
 
-    private By dictDescription = By.xpath("//input[@id='inputNewDictDescription']");
+    public By dictDescription = By.xpath("//input[@id='inputNewDictDescription']");
 
     // for configuration jump out modal
-    private By statusDropDown = By.xpath("//span[@class='ant-cascader-picker-label']");
+    public By statusDropDown = By.xpath("//span[@class='ant-cascader-picker-label']");
 
-    private By statusAvailable = By.xpath("//li[@title='available']");
+    public By statusAvailable = By.xpath("//li[@title='available']");
 
-    private By statusUnavailable = By.xpath("//li[@title='unavailable']");
+    public By statusUnavailable = By.xpath("//li[@title='unavailable']");
 
-    private By addActionBtn = By.xpath("//button[@class='ant-btn ng-star-inserted ant-btn-default ant-btn-sm']");
-    
+    public By addActionBtn = By.xpath("//button[@class='ant-btn ng-star-inserted ant-btn-default ant-btn-sm']");
+
     public By moreBtn(String dict_code) {
         String xpath = String.format("//a[@id='dataDictMore%s']", dict_code);
         return By.xpath(xpath);
@@ -90,95 +90,6 @@ public class DataDictPage extends AbstractSubmarineIT {
     public By itemNameInput(String dict_code) {
         String xpath = String.format("//input[@id='newItemName%s']", dict_code);
         return By.xpath(xpath);
-    }
-
-    public void addNothing(){
-        // Add --> Ok --> required feedback
-        By checkEmpty = By.xpath("//div[contains(text(), \"Add\")]");
-        Click(addBtn, MAX_BROWSER_TIMEOUT_SEC);
-        Assert.assertEquals(driver.findElements(checkEmpty).size(), 1);
-        Click(okBtn, MAX_BROWSER_TIMEOUT_SEC);
-        Assert.assertEquals(driver.findElements(checkEmpty).size(), 1);
-
-        // Add --> Close
-        Click(closeBtn, MAX_BROWSER_TIMEOUT_SEC);
-        Assert.assertEquals(driver.findElements(checkEmpty).size(), 0);
-    }
-
-    // if isDry means it wouldn't really add it.
-    public void addNewDict(String newDictCode, String newDictName, String newDictDescription, boolean isDry) {
-        String toCheck = String.format("//td[@id='dataDictCode%s']", newDictCode);
-        Click(addBtn, MAX_BROWSER_TIMEOUT_SEC);
-        SendKeys(dictCodeInput, MAX_BROWSER_TIMEOUT_SEC, newDictCode);
-        SendKeys(dictNameInput, MAX_BROWSER_TIMEOUT_SEC, newDictName);
-        SendKeys(dictDescription, MAX_BROWSER_TIMEOUT_SEC, newDictDescription);
-        if (isDry) {
-            Click(closeBtn, MAX_BROWSER_TIMEOUT_SEC);
-            Assert.assertEquals(driver.findElements(By.xpath(toCheck)).size(), 0);
-        }else {
-            Click(okBtn, MAX_BROWSER_TIMEOUT_SEC);
-            Assert.assertEquals(driver.findElements(By.xpath(toCheck)).size(), 1);
-        }
-    }
-
-    public void addItem(String dictCode, String newItemCode, String newItemName, boolean isAvailable) {
-        String toCheck = String.format("//td[contains(text(), \"%s\")]", newItemCode);
-        waitToPresent(moreBtn(dictCode), MAX_BROWSER_TIMEOUT_SEC);
-        Click(moreBtn(dictCode), MAX_BROWSER_TIMEOUT_SEC);
-        waitToPresent(configBtn(dictCode), MAX_BROWSER_TIMEOUT_SEC);
-        Click(configBtn(dictCode), MAX_BROWSER_TIMEOUT_SEC);
-        waitToPresent(itemAddBtn(dictCode), MAX_BROWSER_TIMEOUT_SEC);
-        Click(itemAddBtn(dictCode), MAX_BROWSER_TIMEOUT_SEC);
-        Click(statusDropDown, MAX_BROWSER_TIMEOUT_SEC);
-        waitToPresent(statusAvailable, MAX_BROWSER_TIMEOUT_SEC);
-        if(isAvailable) {
-            Click(statusAvailable, MAX_BROWSER_TIMEOUT_SEC);
-        }else {
-            Click(statusUnavailable, MAX_BROWSER_TIMEOUT_SEC);
-        }
-        SendKeys(itemCodeInput(dictCode), MAX_BROWSER_TIMEOUT_SEC, newItemCode);
-        SendKeys(itemNameInput(dictCode), MAX_BROWSER_TIMEOUT_SEC, newItemName);
-        Click(addActionBtn, MAX_BROWSER_TIMEOUT_SEC);
-        Assert.assertEquals(driver.findElements(By.xpath(toCheck)).size(), 1);
-        Click(okBtn, MAX_BROWSER_TIMEOUT_SEC);
-        // check if add successful
-        Click(moreBtn(dictCode), MAX_BROWSER_TIMEOUT_SEC);
-        waitToPresent(configBtn(dictCode), MAX_BROWSER_TIMEOUT_SEC);
-        Click(configBtn(dictCode), MAX_BROWSER_TIMEOUT_SEC);
-        Assert.assertEquals(driver.findElements(By.xpath(toCheck)).size(), 1);
-        Click(okBtn, MAX_BROWSER_TIMEOUT_SEC);
-    }
-
-    public void editDict(String dictCode, String newPostfix) {
-        String toCheck = String.format("//td[@id='dataDictCode%s%s']", dictCode, newPostfix);
-        String checkPrivate = String.format("//td[contains(text(), \"%s_PRIVATE\")]", dictCode);
-        String checkTeam = String.format("//td[contains(text(), \"%s_TEAM\")]", dictCode);
-        String checkPublic = String.format("//td[contains(text(), \"%s_PUBLIC\")]", dictCode);
-
-        waitToPresent(editBtn(dictCode), MAX_BROWSER_TIMEOUT_SEC);
-        Click(editBtn(dictCode), MAX_BROWSER_TIMEOUT_SEC);
-        SendKeys(dictCodeInput, MAX_BROWSER_TIMEOUT_SEC, newPostfix);
-        Click(okBtn, MAX_BROWSER_TIMEOUT_SEC);
-        Assert.assertEquals(driver.findElements(By.xpath(toCheck)).size(), 1);
-        // after edit
-        Click(moreBtn(dictCode.concat(newPostfix)), MAX_BROWSER_TIMEOUT_SEC);
-        waitToPresent(configBtn(dictCode.concat(newPostfix)), MAX_BROWSER_TIMEOUT_SEC);
-        Click(configBtn(dictCode.concat(newPostfix)), MAX_BROWSER_TIMEOUT_SEC);
-        Assert.assertEquals(driver.findElements(By.xpath(checkPrivate)).size(), 1);
-        Assert.assertEquals(driver.findElements(By.xpath(checkTeam)).size(), 1);
-        Assert.assertEquals(driver.findElements(By.xpath(checkPublic)).size(), 1);
-        Click(okBtn, MAX_BROWSER_TIMEOUT_SEC);
-    }
-
-    public void deleteDict(String dictCode) {
-        String toCheck = String.format("//td[@id='dataDictCode%s']", dictCode);
-        Assert.assertEquals(driver.findElements(By.xpath(toCheck)).size(), 1);
-        waitToPresent(moreBtn(dictCode), MAX_BROWSER_TIMEOUT_SEC);
-        Click(moreBtn(dictCode), MAX_BROWSER_TIMEOUT_SEC);
-        Click(deleteBtn(dictCode), MAX_BROWSER_TIMEOUT_SEC);
-        waitToPresent(okDeleteBtn, MAX_BROWSER_TIMEOUT_SEC);
-        Click(okDeleteBtn, MAX_BROWSER_TIMEOUT_SEC);
-        Assert.assertEquals(driver.findElements(By.xpath(toCheck)).size(), 0);
     }
 
 }

--- a/submarine-test/test-e2e/src/test/java/org/apache/submarine/integration/pages/DataDictPage.java
+++ b/submarine-test/test-e2e/src/test/java/org/apache/submarine/integration/pages/DataDictPage.java
@@ -56,11 +56,7 @@ public class DataDictPage extends AbstractSubmarineIT {
     private By statusUnavailable = By.xpath("//li[@title='unavailable']");
 
     private By addActionBtn = By.xpath("//button[@class='ant-btn ng-star-inserted ant-btn-default ant-btn-sm']");
-
-    public DataDictPage(WebDriver driver){
-
-    }
-
+    
     public By moreBtn(String dict_code) {
         String xpath = String.format("//a[@id='dataDictMore%s']", dict_code);
         return By.xpath(xpath);


### PR DESCRIPTION
### What is this PR for?
In travis.ci, this IT will have undeterministic behavior, it is because of the original way to realize the waiting is fluent wait, but it lacks of expected condition.
The other reason of unstable behavior of this test is because of the wrong interaction with components.

https://user-images.githubusercontent.com/55401762/124241557-6e561780-db4e-11eb-8ab4-53a04ffc583e.mp4

As you can see, this drop-down list need to be hovered. But this IT clicked it. This might be the source of unstable.
So it need to be modify with the functions that use explicit wait in AbstractSubmarineIT.
Also found that the window need to set larger to prevent element from disappearing in viewpoint, which makes headless driver can not interact.
Note: the default of size of headless window maximize is (600, 800), when driver hover the target out of this area, it will cause MoveTargetOutOfBounds exception.

### What type of PR is it?
[Bug Fix | Refactoring]

### Todos

### What is the Jira issue?

https://issues.apache.org/jira/projects/SUBMARINE/issues/SUBMARINE-882

### How should this be tested?
```bash
# Step1: Run Submarine workbench on 127.0.0.1:8080 by operator
# Step2: Run testcase
cd submarine-cloud-v2

# Usage: ./hack/run_frontend_e2e.sh ${testcase}
# Example: 
./hack/run_frontend_e2e.sh datadictIT
```
### Screenshots (if appropriate)

https://user-images.githubusercontent.com/55401762/124000807-8c186500-da06-11eb-8289-faf054a85650.mp4

### Questions:
* Do the license files need updating? No
* Are there breaking changes for older versions? No
* Does this need new documentation? No
