### PR TITLE
SUBMARINE-885. Fix KinD error and remove docker layer cache

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -52,7 +52,6 @@ jobs:
         run: |
           mvn --version
           java -version
-
       - name: Create the kind config
         run: |
           cat <<EOF > ./kind-config-kind.yaml
@@ -75,11 +74,9 @@ jobs:
               hostPort: 443
               protocol: TCP
           EOF
-      - uses: container-tools/kind-action@v1
-        with:
-          version: "v0.9.0"
-          node_image: kindest/node:v1.15.11
-          config: ./kind-config-kind.yaml
+      - name: Create kind cluster
+        run: |
+          kind create cluster --config ./kind-config-kind.yaml --wait 3m --image kindest/node:v1.15.12
       - name: Show K8s cluster information
         run: |
           kubectl cluster-info
@@ -87,13 +84,6 @@ jobs:
           kubectl get pods -n kube-system
           echo "current-context:" $(kubectl config current-context)
           echo "environment-kubeconfig:" ${KUBECONFIG}
-
-      # Cache docker layer
-      - name: Cache docker layer
-        uses: satackey/action-docker-layer-caching@v0.0.11
-        # Ignore the failure of a step and avoid terminating the job.
-        continue-on-error: true
-
       # Cache maven (for submarine server)
       - uses: actions/cache@v1
         with:
@@ -146,3 +136,9 @@ jobs:
         run: |
           cd submarine-sdk/pysubmarine
           pytest --cov=submarine -vs -m "e2e"
+      - name: Failure status
+        run: |
+          kubectl get pods
+          kubectl -n default get events --sort-by='{.lastTimestamp}'
+          kubectl describe nodes
+        if: ${{ failure() }}


### PR DESCRIPTION
### What is this PR for?
There are setting bugs that make the python-sdk test fails.  Use the official KinD to install the submarine and remove the docker layer cache which is not available in this repo.

### What type of PR is it?
[Bug Fix]

### Todos

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-885

### How should this be tested?
See the GitHub Actions.

### Screenshots (if appropriate)

### Questions:
* Do the license files need updating? No
* Are there breaking changes for older versions? No
* Does this need new documentation? No
