### PR TITLE
SUBMARINE-886. Underscore character is invalid for experiment name

### DIFF
--- a/submarine-workbench/workbench-web/src/app/pages/workbench/experiment/experiment-home/experiment-form/experiment-customized-form/experiment-customized-form.component.html
+++ b/submarine-workbench/workbench-web/src/app/pages/workbench/experiment/experiment-home/experiment-form/experiment-customized-form/experiment-customized-form.component.html
@@ -41,6 +41,9 @@
             formControlName="experimentName"
             placeholder="mnist-example"
           />
+          <div class="alert-message" *ngIf="experiment.get('experimentName').hasError('pattern')">
+            Invalid characters exist!
+          </div>
         </div>
         <div class="single-field-group">
           <label for="description">Description</label>

--- a/submarine-workbench/workbench-web/src/app/pages/workbench/experiment/experiment-home/experiment-form/experiment-customized-form/experiment-customized-form.component.html
+++ b/submarine-workbench/workbench-web/src/app/pages/workbench/experiment/experiment-home/experiment-form/experiment-customized-form/experiment-customized-form.component.html
@@ -42,7 +42,7 @@
             placeholder="mnist-example"
           />
           <div class="alert-message" *ngIf="experiment.get('experimentName').hasError('pattern')">
-            Invalid characters exist!
+            Only letters(a-z), numbers(0-9), and hyphens(-) are allowed.
           </div>
         </div>
         <div class="single-field-group">

--- a/submarine-workbench/workbench-web/src/app/pages/workbench/experiment/experiment-home/experiment-form/experiment-customized-form/experiment-customized-form.component.ts
+++ b/submarine-workbench/workbench-web/src/app/pages/workbench/experiment/experiment-home/experiment-form/experiment-customized-form/experiment-customized-form.component.ts
@@ -88,7 +88,7 @@ export class ExperimentCustomizedFormComponent implements OnInit, OnDestroy {
 
   ngOnInit() {
     this.experiment = new FormGroup({
-      experimentName: new FormControl(null, Validators.required),
+      experimentName: new FormControl(null, [Validators.pattern('[a-zA-Z0-9\-]*'), Validators.required]),
       description: new FormControl(null, [Validators.required]),
       namespace: new FormControl(this.defaultNameSpace, [Validators.required]),
       cmd: new FormControl('', [Validators.required]),


### PR DESCRIPTION
### What is this PR for?
* Underscore character is invalid for experiment name, and it will cause Kubernetes Java API to throw an exception "io.kubernetes.client.ApiException" with the error message "Unprocessable Entity" as shown in the attachment figure. In addition, no POD related to the experiment will be created, and users cannot get any error notification from the workbench.
<img width="915" alt="截圖 2021-07-01 下午12 25 43" src="https://user-images.githubusercontent.com/20109646/124086289-7c8b3180-da83-11eb-9932-9cc7bb15bbc4.png">

* In this PR, the valid characters for experiment name only include "a-z", "A-Z", "0-9", and "-". Hence, the ApiException can be avoided.

### What type of PR is it?
[Bug Fix]

### Todos


### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-886

### How should this be tested?
* Workbench -> New Experiment -> Define your experiment -> Enter experiment name

### Screenshots (if appropriate)
<img width="997" alt="截圖 2021-07-01 下午3 44 00" src="https://user-images.githubusercontent.com/20109646/124087097-47331380-da84-11eb-96e8-a316edf87285.png">
<img width="994" alt="截圖 2021-07-01 下午3 44 16" src="https://user-images.githubusercontent.com/20109646/124087103-48fcd700-da84-11eb-9f93-48feda1ca600.png">
<img width="994" alt="截圖 2021-07-01 下午3 45 04" src="https://user-images.githubusercontent.com/20109646/124087119-4bf7c780-da84-11eb-8a4b-809fc2cd4111.png">
<img width="986" alt="截圖 2021-07-01 下午3 44 40" src="https://user-images.githubusercontent.com/20109646/124087123-4dc18b00-da84-11eb-8d38-d7abd0e242c5.png">


### Questions:
* Do the license files need updating? No
* Are there breaking changes for older versions? No
* Does this need new documentation? No
