### PR TITLE
SUBMARINE-884. Fix mllfow backend url with new mysql url.

### DIFF
--- a/dev-support/database/init-database.sh
+++ b/dev-support/database/init-database.sh
@@ -39,7 +39,6 @@ mysql -e "CREATE USER IF NOT EXISTS 'metastore'@'%' IDENTIFIED BY 'password';"
 mysql -e "GRANT ALL PRIVILEGES ON *.* TO 'metastore'@'%';"
 mysql -e "use metastore; source ./metastore.sql; show tables;"
 
-mysql -e "CREATE DATABASE IF NOT EXISTS mlflow;"
+mysql -e "CREATE DATABASE IF NOT EXISTS mlflowdb;"
 mysql -e "CREATE USER IF NOT EXISTS 'mlflow'@'%' IDENTIFIED BY 'password';"
 mysql -e "GRANT ALL PRIVILEGES ON *.* TO 'mlflow'@'%';"
-mysql -e "use mlflow; source ./mlflow.sql; show tables;"

--- a/dev-support/docker-images/database/startup.sh
+++ b/dev-support/docker-images/database/startup.sh
@@ -31,8 +31,7 @@ CREATE DATABASE metastore;
 CREATE USER 'metastore'@'%' IDENTIFIED BY 'password';
 GRANT ALL PRIVILEGES ON * . * TO 'metastore'@'%';
 use metastore; source /tmp/database/metastore.sql;
-CREATE DATABASE mlflow;
+CREATE DATABASE mlflowdb;
 CREATE USER 'mlflow'@'%' IDENTIFIED BY 'password';
 GRANT ALL PRIVILEGES ON * . * TO 'mlflow'@'%';
-use mlflow; source /tmp/database/mlflow.sql;
 EOF

--- a/dev-support/docker-images/mlflow/Dockerfile
+++ b/dev-support/docker-images/mlflow/Dockerfile
@@ -15,11 +15,9 @@
 
 FROM python:3.7.0-slim
 
-RUN pip install mlflow
+RUN apt-get update && apt-get -y install --no-install-recommends default-libmysqlclient-dev libpq-dev build-essential wget
 
-RUN apt-get update && apt-get -y install --no-install-recommends default-libmysqlclient-dev libpq-dev build-essential sqlite3 wget
-
-RUN pip install mlflow==1.15.0 sqlalchemy==1.4.11 boto3==1.17.58
+RUN pip install mlflow==1.15.0 sqlalchemy==1.4.11 boto3==1.17.58 pymysql==0.9.3
 
 COPY start.sh /usr/local/bin
 
@@ -30,7 +28,7 @@ RUN wget https://dl.min.io/client/mc/release/linux-amd64/mc && chmod +x mc
 ENV MLFLOW_S3_ENDPOINT_URL http://submarine-minio-service:9000
 ENV AWS_ACCESS_KEY_ID submarine_minio
 ENV AWS_SECRET_ACCESS_KEY submarine_minio
-ENV BACKEND_URI mysql+pymysql://mlflow:password@localhost:3306/mlflow
+ENV BACKEND_URI mysql+pymysql://mlflow:password@submarine-database:3306/mlflowdb
 
 EXPOSE 5000
 

--- a/dev-support/docker-images/mlflow/start.sh
+++ b/dev-support/docker-images/mlflow/start.sh
@@ -33,11 +33,9 @@ check_minio_mlflow_bucket_exists() {
 MLFLOW_S3_ENDPOINT_URL="http://submarine-minio-service:9000"
 AWS_ACCESS_KEY_ID="submarine_minio"
 AWS_SECRET_ACCESS_KEY="submarine_minio"
-BACKEND_URI="mysql+pymysql://mlflow:password@localhost:3306/mlflow"
+BACKEND_URI="mysql+pymysql://mlflow:password@submarine-database:3306/mlflowdb"
 DEFAULT_ARTIFACT_ROOT="s3://mlflow"
 STATIC_PREFIX="/mlflow"
-
-/bin/bash -c "sqlite3 store.db"
 
 /bin/bash -c "sleep 60; ./mc config host add minio ${MLFLOW_S3_ENDPOINT_URL} ${AWS_ACCESS_KEY_ID} ${AWS_SECRET_ACCESS_KEY}"
 

--- a/dev-support/docker-images/mlflow/start.sh
+++ b/dev-support/docker-images/mlflow/start.sh
@@ -33,7 +33,7 @@ check_minio_mlflow_bucket_exists() {
 MLFLOW_S3_ENDPOINT_URL="http://submarine-minio-service:9000"
 AWS_ACCESS_KEY_ID="submarine_minio"
 AWS_SECRET_ACCESS_KEY="submarine_minio"
-BACKEND_URI="sqlite:///store.db"
+BACKEND_URI="mysql+pymysql://mlflow:password@localhost:3306/mlflow"
 DEFAULT_ARTIFACT_ROOT="s3://mlflow"
 STATIC_PREFIX="/mlflow"
 

--- a/dev-support/mini-submarine/conf/setup-mysql.sh
+++ b/dev-support/mini-submarine/conf/setup-mysql.sh
@@ -37,7 +37,6 @@ mysql -e "CREATE USER 'metastore'@'%' IDENTIFIED BY 'password';"
 mysql -e "GRANT ALL PRIVILEGES ON * . * TO 'metastore'@'%';"
 mysql -e "use metastore; source /home/yarn/database/metastore.sql;"
 
-mysql -e "CREATE DATABASE mlflow;"
+mysql -e "CREATE DATABASE mlflowdb;"
 mysql -e "CREATE USER 'mlflow'@'%' IDENTIFIED BY 'password';"
 mysql -e "GRANT ALL PRIVILEGES ON * . * TO 'mlflow'@'%';"
-mysql -e "use mlflow; source /home/yarn/database/mlflow.sql;"


### PR DESCRIPTION
### What is this PR for?
Backend url in docker-images/mlflow/start.sh is missed to replace with new mysql url. 
Delete unused package in Dockerfile.

### What type of PR is it?
Bug Fix

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-884

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* Do the license files need updating? No
* Are there breaking changes for older versions? No
* Does this need new documentation? No
