### PR TITLE
SUBMARINE-903. Submarine operator created tensorboard is inconsistent with helm-charts template

### DIFF
--- a/submarine-cloud-v2/pkg/controller/submarine_tensorboard.go
+++ b/submarine-cloud-v2/pkg/controller/submarine_tensorboard.go
@@ -139,6 +139,14 @@ func newSubmarineTensorboardDeployment(submarine *v1alpha1.Submarine) *appsv1.De
 									SubPath:   tensorboardName,
 								},
 							},
+							ReadinessProbe: &corev1.Probe{
+								Handler: corev1.Handler {
+									TCPSocket: &corev1.TCPSocketAction {
+										Port: intstr.FromInt(6006),
+									},
+								},
+								PeriodSeconds: 10,
+							},
 						},
 					},
 					Volumes: []corev1.Volume{


### PR DESCRIPTION
### What is this PR for?

Submarine operator should create tensorboard with settings same as submarine-tensorboard.yaml, but found different at  readinessProbe.

### What type of PR is it?
[Bug Fix]

### Todos

### What is the Jira issue?

https://issues.apache.org/jira/browse/SUBMARINE-903

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* Do the license files need updating? No
* Are there breaking changes for older versions? No
* Does this need new documentation? No
