### PR TITLE
SUBMARINE-905. Change status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 ![Colored_logo_with_text](website/docs/assets/color_logo_with_text.png)
 
-[![Build Status](https://travis-ci.org/apache/submarine.svg?branch=master)](https://travis-ci.org/apache/submarine) [![License](https://img.shields.io/badge/license-Apache%202-4EB1BA.svg)](https://www.apache.org/licenses/LICENSE-2.0.html) [![PyPI version](https://badge.fury.io/py/apache-submarine.svg)](https://badge.fury.io/py/apache-submarine)
+![Submarine workflow](https://github.com/apache/submarine/actions/workflows/master.yml/badge.svg?branch=master) ![python-sdk workflow](https://github.com/apache/submarine/actions/workflows/python.yml/badge.svg?branch=master) [![License](https://img.shields.io/badge/license-Apache%202-4EB1BA.svg)](https://www.apache.org/licenses/LICENSE-2.0.html) [![PyPI version](https://badge.fury.io/py/apache-submarine.svg)](https://badge.fury.io/py/apache-submarine)
 
 </div>
 


### PR DESCRIPTION
### What is this PR for?
Replace Travis CI status badge with GitHub Actions status badge

### What type of PR is it?
[CI/CD]

### Todos

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-905

### How should this be tested?

### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/38066413/124563569-bc328e80-de72-11eb-96ab-403e014743b2.png)

### Questions:
* Do the license files need updating? No
* Are there breaking changes for older versions? No
* Does this need new documentation? No
