### PR TITLE
SUBMARINE-865. Clean up deleted experiment in mlflow

### DIFF
--- a/submarine-server/server-core/pom.xml
+++ b/submarine-server/server-core/pom.xml
@@ -474,6 +474,13 @@
         </exclusion>
       </exclusions>
     </dependency>
+
+    <dependency>
+      <groupId>org.mlflow</groupId>
+      <artifactId>mlflow-client</artifactId>
+      <version>1.18.0</version>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/submarine-server/server-core/src/main/java/org/apache/submarine/server/rest/ExperimentRestApi.java
+++ b/submarine-server/server-core/src/main/java/org/apache/submarine/server/rest/ExperimentRestApi.java
@@ -31,7 +31,6 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.util.List;
-import java.util.Optional;
 
 import com.google.common.annotations.VisibleForTesting;
 
@@ -52,7 +51,6 @@ import org.apache.submarine.server.api.experiment.ExperimentLog;
 import org.apache.submarine.server.api.experimenttemplate.ExperimentTemplateSubmit;
 import org.apache.submarine.server.api.spec.ExperimentSpec;
 import org.apache.submarine.server.response.JsonResponse;
-import org.mlflow.tracking.MlflowClient;
 
 /**
  * Experiment Service REST API v1
@@ -61,8 +59,6 @@ import org.mlflow.tracking.MlflowClient;
 @Produces({MediaType.APPLICATION_JSON + "; " + RestConstants.CHARSET_UTF8})
 public class ExperimentRestApi {
   private ExperimentManager experimentManager = ExperimentManager.getInstance();
-  private Optional<org.mlflow.api.proto.Service.Experiment> MlflowExperimentOptional;
-  private org.mlflow.api.proto.Service.Experiment MlflowExperiment;
 
   @VisibleForTesting
   public void setExperimentManager(ExperimentManager experimentManager) {
@@ -226,12 +222,6 @@ public class ExperimentRestApi {
     } catch (SubmarineRuntimeException e) {
       return parseExperimentServiceException(e);
     }
-    MlflowClient mlflowClient = new MlflowClient("http://submarine-mlflow-service:5000");
-    MlflowExperimentOptional = mlflowClient.getExperimentByName(id);
-    MlflowExperiment = MlflowExperimentOptional.get();
-    String mlflowId = MlflowExperiment.getExperimentId();
-    
-    mlflowClient.deleteExperiment(mlflowId);
     return new JsonResponse.Builder<Experiment>(Response.Status.OK).success(true)
           .result(experiment).build();
   }

--- a/submarine-server/server-core/src/main/java/org/apache/submarine/server/rest/ExperimentRestApi.java
+++ b/submarine-server/server-core/src/main/java/org/apache/submarine/server/rest/ExperimentRestApi.java
@@ -31,6 +31,7 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.util.List;
+import java.util.Optional;
 
 import com.google.common.annotations.VisibleForTesting;
 
@@ -60,6 +61,8 @@ import org.mlflow.tracking.MlflowClient;
 @Produces({MediaType.APPLICATION_JSON + "; " + RestConstants.CHARSET_UTF8})
 public class ExperimentRestApi {
   private ExperimentManager experimentManager = ExperimentManager.getInstance();
+  private Optional<org.mlflow.api.proto.Service.Experiment> MlflowExperimentOptional;
+  private org.mlflow.api.proto.Service.Experiment MlflowExperiment;
 
   @VisibleForTesting
   public void setExperimentManager(ExperimentManager experimentManager) {
@@ -223,10 +226,14 @@ public class ExperimentRestApi {
     } catch (SubmarineRuntimeException e) {
       return parseExperimentServiceException(e);
     }
-    MlflowClient mlflowclient = MlflowClient("http://submarine-mlflow-service:5000");
-    mlflowclient.deleteExperiment(id);
+    MlflowClient mlflowClient = new MlflowClient("http://submarine-mlflow-service:5000");
+    MlflowExperimentOptional = mlflowClient.getExperimentByName(id);
+    MlflowExperiment = MlflowExperimentOptional.get();
+    String mlflowId = MlflowExperiment.getExperimentId();
+    
+    mlflowClient.deleteExperiment(mlflowId);
     return new JsonResponse.Builder<Experiment>(Response.Status.OK).success(true)
-            .result(experiment).build();
+          .result(experiment).build();
   }
 
   @GET


### PR DESCRIPTION
### What is this PR for?
When delete an experiment through web GUI, the mlflow param and metric that the same experiment creates are not deleted. We need to delete the resources concurrently by calling mlflow java API.

### What type of PR is it?
Improvement

### Todos

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-865

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* Do the license files need updating? No
* Are there breaking changes for older versions? No
* Does this need new documentation? No
