### PR TITLE
SUBMARINE-909. Add API to get the serve pod's status.

### DIFF
--- a/submarine-server/server-api/src/main/java/org/apache/submarine/server/api/Submitter.java
+++ b/submarine-server/server-api/src/main/java/org/apache/submarine/server/api/Submitter.java
@@ -142,6 +142,14 @@ public interface Submitter {
   ServeResponse deleteServe(ServeRequest spec) throws SubmarineRuntimeException;
 
   /**
+   * Get ServePod ready status with modelName and modelVersion
+   * @param name
+   * @return object
+   * @throws SubmarineRuntimeException running error
+   */
+  ServeResponse checkServePodReady(String name) throws SubmarineRuntimeException;
+
+  /**
    * Get tensorboard meta data
    * @param
    * @return object

--- a/submarine-server/server-api/src/main/java/org/apache/submarine/server/api/experiment/ServeResponse.java
+++ b/submarine-server/server-api/src/main/java/org/apache/submarine/server/api/experiment/ServeResponse.java
@@ -21,6 +21,7 @@ package org.apache.submarine.server.api.experiment;
 
 public class ServeResponse {
   public String url;
+  public String ready;
 
   public String getUrl() {
     return this.url;
@@ -30,8 +31,17 @@ public class ServeResponse {
     this.url = url;
   }
 
+  public String getReady() { return this.ready; }
+
+  public void setReady(String ready) { this.ready = ready; }
+
   public ServeResponse url(String url) {
     setUrl(url);
+    return this;
+  }
+
+  public ServeResponse ready(String ready){
+    setReady(ready);
     return this;
   }
 }

--- a/submarine-server/server-core/src/main/java/org/apache/submarine/server/experiment/ExperimentManager.java
+++ b/submarine-server/server-core/src/main/java/org/apache/submarine/server/experiment/ExperimentManager.java
@@ -335,6 +335,17 @@ public class ExperimentManager {
     return serve;
   }
 
+  /**
+   * Get ServePod ready status with modelName and modelVersion
+   *
+   * @param name
+   * @return object
+   * @throws SubmarineRuntimeException the service error
+   */
+  public ServeResponse checkServePodReady(String name) throws SubmarineRuntimeException {
+    ServeResponse serve = submitter.checkServePodReady(name);
+    return serve;
+  }
 
   private void checkSpec(ExperimentSpec spec) throws SubmarineRuntimeException {
     if (spec == null) {

--- a/submarine-server/server-core/src/main/java/org/apache/submarine/server/rest/ExperimentRestApi.java
+++ b/submarine-server/server-core/src/main/java/org/apache/submarine/server/rest/ExperimentRestApi.java
@@ -352,6 +352,25 @@ public class ExperimentRestApi {
     }
   }
 
+  @GET
+  @Path("/serve")
+  @Operation(summary = "Get a serve ready status",
+      tags = {"serve"},
+      responses = {
+          @ApiResponse(description = "successful operation", content = @Content(
+              schema = @Schema(implementation = JsonResponse.class)))})
+  public Response checkServePodReady(@QueryParam("modelName") String modelName,
+                              @QueryParam("modelVersion") String modelVersion) {
+    try {
+      ServeResponse serve = experimentManager.checkServePodReady(modelName + "-"
+          + modelVersion + "-pod");
+      return new JsonResponse.Builder<ServeResponse>(Response.Status.OK).success(true)
+          .result(serve).build();
+    } catch (SubmarineRuntimeException e) {
+      return parseExperimentServiceException(e);
+    }
+  }
+
   private Response parseExperimentServiceException(SubmarineRuntimeException e) {
     return new JsonResponse.Builder<String>(e.getCode())
       .message(e.getMessage().equals("Conflict") ? "Duplicated experiment name" : e.getMessage()).build();


### PR DESCRIPTION
### What is this PR for?
Add http API to get the serve pod's ready status.

### What type of PR is it?
Improvement

### Todos
* [ ] - Add serve id

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-909

### How should this be tested?

### Screenshots (if appropriate)
![Screenshot from 2021-07-07 17-23-29](https://user-images.githubusercontent.com/54139205/124736863-00dd2900-df4a-11eb-8ef5-22b5a6ac322c.png)

### Questions:
* Do the license files need updating? No
* Are there breaking changes for older versions? No
* Does this need new documentation? No
