### PR TITLE
SUBMARINE-851. Dirty notebook status is persisted in DB when notebook operation is failed

### DIFF
--- a/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/K8sSubmitter.java
+++ b/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/K8sSubmitter.java
@@ -703,7 +703,7 @@ public class K8sSubmitter implements Submitter {
     return spec;
   }
 
-  private void rollbackCreationNotebook(String pvName) {
+  private void rollbackCreationPV(String pvName) {
     try {
       deletePersistentVolume(pvName);
     } catch (ApiException e) {
@@ -712,7 +712,7 @@ public class K8sSubmitter implements Submitter {
     }
   }
 
-  private void rollbackCreationNotebook(String pvName, String pvcName, String namespace) {
+  private void rollbackCreationPVC(String pvName, String pvcName, String namespace) {
     try {
       deletePersistentVolumeClaim(pvcName, namespace);
     } catch (ApiException e) {

--- a/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/K8sSubmitter.java
+++ b/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/K8sSubmitter.java
@@ -392,7 +392,7 @@ public class K8sSubmitter implements Submitter {
     } catch (ApiException e) {
       LOG.error("K8s submitter: Create persistent volume claim for Notebook object failed by " +
           e.getMessage(), e);
-      rollbackCreationNotebook(pvName);
+      rollbackCreationPV(pvName);
       throw new SubmarineRuntimeException(e.getCode(), "K8s submitter: Create persistent volume claim for " +
           "Notebook object failed by " + e.getMessage());
     }
@@ -412,11 +412,11 @@ public class K8sSubmitter implements Submitter {
 
     } catch (JsonSyntaxException e) {
       LOG.error("K8s submitter: parse response object failed by " + e.getMessage(), e);
-      rollbackCreationNotebook(pvName, pvcName, namespace);
+      rollbackCreationPVC(pvName, pvcName, namespace);
       throw new SubmarineRuntimeException(500, "K8s Submitter parse upstream response failed.");
     } catch (ApiException e) {
       LOG.error("K8s submitter: parse Notebook object failed by " + e.getMessage(), e);
-      rollbackCreationNotebook(pvName, pvcName, namespace);
+      rollbackCreationPVC(pvName, pvcName, namespace);
       throw new SubmarineRuntimeException(e.getCode(), "K8s submitter: parse Notebook object failed by " +
           e.getMessage());
     }


### PR DESCRIPTION
### What is this PR for?
Maintain atomicity while creating notebook.

### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-851

### How should this be tested?
Try to get error in notebook creation, and then create a new notebook with same name.

### Screenshots (if appropriate)

### Questions:
* Do the license files need updating? No
* Are there breaking changes for older versions? No
* Does this need new documentation? No
