### PR TITLE
SUBMARINE-914. Github Action compiles Docker images twice

### DIFF
--- a/submarine-test/test-k8s/pom.xml
+++ b/submarine-test/test-k8s/pom.xml
@@ -143,6 +143,10 @@
           <argLine>-Xmx2g -Xms1g -Dfile.encoding=UTF-8</argLine>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-antrun-plugin</artifactId>
+      </plugin>
     </plugins>
   </build>
 

--- a/submarine-test/test-k8s/pom.xml
+++ b/submarine-test/test-k8s/pom.xml
@@ -143,41 +143,6 @@
           <argLine>-Xmx2g -Xms1g -Dfile.encoding=UTF-8</argLine>
         </configuration>
       </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-antrun-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>start-integration-ks8-test</id>
-            <phase>pre-integration-test</phase>
-            <configuration>
-              <target unless="skipTests">
-                <exec executable="./integration-test.sh" dir="${submarine.cloud.path}" spawn="false">
-                  <arg value="--start"/>
-                  <arg value="--update"/>
-                </exec>
-              </target>
-            </configuration>
-            <goals>
-              <goal>run</goal>
-            </goals>
-          </execution>
-          <execution>
-            <id>stop-integration-ks8-test</id>
-            <phase>post-integration-test</phase>
-            <configuration>
-              <target unless="skipTests">
-                <exec executable="./integration-test.sh" dir="${submarine.cloud.path}" spawn="false">
-                  <arg value="--stop"/>
-                </exec>
-              </target>
-            </configuration>
-            <goals>
-              <goal>run</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
### What is this PR for?
Github Action compiles Docker images twice.

1st: "Build image locally"
https://github.com/apache/submarine/blob/master/.github/workflows/master.yml#L158

2nd: "Test"
https://github.com/apache/submarine/blob/master/.github/workflows/master.yml#L170

Because of the [pom.xml](https://github.com/apache/submarine/blob/master/submarine-test/test-k8s/pom.xml#L155), the script "integration-test.sh" with the argument "--update"
will compile all images again.

### What type of PR is it?
[Improvement]

### Todos


### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-914#

### How should this be tested?
* Github Action: check if all test cases in "submarine-k8s" are executed as expected.

### Screenshots (if appropriate)
<img width="1395" alt="截圖 2021-07-08 下午6 13 06" src="https://user-images.githubusercontent.com/20109646/124906336-8c71bb00-e019-11eb-83ef-874c1932f3fe.png">


### Questions:
* Do the license files need updating? No
* Are there breaking changes for older versions? No
* Does this need new documentation? No
