### PR TITLE
SUBMARINE-943. add [tags] into experimentSpec and add a searchExperimentByTag function

### DIFF
--- a/submarine-server/server-api/src/main/java/org/apache/submarine/server/api/spec/ExperimentMeta.java
+++ b/submarine-server/server-api/src/main/java/org/apache/submarine/server/api/spec/ExperimentMeta.java
@@ -142,7 +142,7 @@ public class ExperimentMeta {
     this.tags = tags;
   }
 
-/**
+  /**
    * The {@link ExperimentMeta#framework} should be one of the below supported framework name.
    */
   public enum SupportedMLFramework {

--- a/submarine-server/server-api/src/main/java/org/apache/submarine/server/api/spec/ExperimentMeta.java
+++ b/submarine-server/server-api/src/main/java/org/apache/submarine/server/api/spec/ExperimentMeta.java
@@ -19,6 +19,9 @@
 
 package org.apache.submarine.server.api.spec;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -33,7 +36,8 @@ public class ExperimentMeta {
   private String namespace;
   private String framework;
   private String cmd;
-  private Map<String, String> envVars;
+  private Map<String, String> envVars = new HashMap<>();
+  private List<String> tags = new ArrayList<>();
 
   public ExperimentMeta() {
 
@@ -126,6 +130,19 @@ public class ExperimentMeta {
   }
 
   /**
+   * The default tag list for task. If the @{@link ExperimentTaskSpec#getEnvVars()} not specified
+   * replaced with it.
+   * @return tags
+   */
+  public List<String> getTags() {
+    return tags;
+  }
+
+  public void setTags(List<String> tags) {
+    this.tags = tags;
+  }
+
+/**
    * The {@link ExperimentMeta#framework} should be one of the below supported framework name.
    */
   public enum SupportedMLFramework {
@@ -161,6 +178,7 @@ public class ExperimentMeta {
       ", framework='" + framework + '\'' +
       ", cmd='" + cmd + '\'' +
       ", envVars=" + envVars +
+      ", tags=" + tags +
       '}';
   }
 }

--- a/submarine-server/server-core/src/main/java/org/apache/submarine/server/experiment/ExperimentManager.java
+++ b/submarine-server/server-core/src/main/java/org/apache/submarine/server/experiment/ExperimentManager.java
@@ -214,9 +214,9 @@ public class ExperimentManager {
             experiment.rebuild(foundExperiment);
             experimentList.add(experiment);
             break;
-            }
           }
         }
+      }
     }
     LOG.info("List experiment: {}", experimentList.size());
     return experimentList;

--- a/submarine-server/server-core/src/main/java/org/apache/submarine/server/experiment/ExperimentManager.java
+++ b/submarine-server/server-core/src/main/java/org/apache/submarine/server/experiment/ExperimentManager.java
@@ -20,7 +20,6 @@
 package org.apache.submarine.server.experiment;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
@@ -210,14 +209,14 @@ public class ExperimentManager {
         experiment.rebuild(foundExperiment);
         experimentList.add(experiment);
       } else {
-          for (String tag: experiment.getSpec().getMeta().getTags()) {
-              if (tag.equalsIgnoreCase(searchTag)) {
-                  experiment.rebuild(foundExperiment);
-                  experimentList.add(experiment);
-                  break;
-              }
+        for (String tag: experiment.getSpec().getMeta().getTags()) {
+          if (tag.equalsIgnoreCase(searchTag)) {
+            experiment.rebuild(foundExperiment);
+            experimentList.add(experiment);
+            break;
+            }
           }
-      }
+        }
     }
     LOG.info("List experiment: {}", experimentList.size());
     return experimentList;

--- a/submarine-server/server-core/src/main/java/org/apache/submarine/server/experiment/ExperimentManager.java
+++ b/submarine-server/server-core/src/main/java/org/apache/submarine/server/experiment/ExperimentManager.java
@@ -191,7 +191,7 @@ public class ExperimentManager {
    * @return list
    * @throws SubmarineRuntimeException the service error
    */
-  public List<Experiment> listExperimentsByTag(String tag) throws SubmarineRuntimeException {
+  public List<Experiment> listExperimentsByTag(String searchTag) throws SubmarineRuntimeException {
     List<Experiment> experimentList = new ArrayList<>();
     List<ExperimentEntity> entities = experimentService.selectAll();
 
@@ -206,9 +206,17 @@ public class ExperimentManager {
         continue;
       }
       LOG.info("Found experiment: {}", foundExperiment.getSpec().getMeta().getTags());
-      if (tag == null || experiment.getSpec().getMeta().getTags().contains(tag)) {
+      if (searchTag == null) {
         experiment.rebuild(foundExperiment);
         experimentList.add(experiment);
+      } else {
+          for (String tag: experiment.getSpec().getMeta().getTags()) {
+              if (tag.equalsIgnoreCase(searchTag)) {
+                  experiment.rebuild(foundExperiment);
+                  experimentList.add(experiment);
+                  break;
+              }
+          }
       }
     }
     LOG.info("List experiment: {}", experimentList.size());

--- a/submarine-server/server-core/src/test/java/org/apache/submarine/server/experiment/ExperimentManagerTest.java
+++ b/submarine-server/server-core/src/test/java/org/apache/submarine/server/experiment/ExperimentManagerTest.java
@@ -269,7 +269,10 @@ public class ExperimentManagerTest {
         actual.getSpec().getEnvironment().getImage())
     ;
 
-    assertEquals(expected.getSpec().getMeta().getTags().toString(), actual.getSpec().getMeta().getTags().toString());
+    assertEquals(
+            expected.getSpec().getMeta().getTags().toString(),
+            actual.getSpec().getMeta().getTags().toString())
+    ;
   }
 
   private Object buildFromJsonFile(Object obj, String filePath) throws SubmarineException {

--- a/submarine-server/server-core/src/test/java/org/apache/submarine/server/experiment/ExperimentManagerTest.java
+++ b/submarine-server/server-core/src/test/java/org/apache/submarine/server/experiment/ExperimentManagerTest.java
@@ -41,6 +41,8 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
@@ -103,6 +105,37 @@ public class ExperimentManagerTest {
     Experiment actualExperiment = spyExperimentManager.createExperiment(spec);
 
     verifyResult(expectedExperiment, actualExperiment);
+  }
+
+  @Test
+  public void testFinaExperimentByTag() {
+
+    ExperimentId experimentId1 = new ExperimentId();
+    experimentId1.setServerTimestamp(System.currentTimeMillis());
+    experimentId1.setId(1);
+
+    Experiment experiment1 = new Experiment();
+    experiment1.setSpec(spec);
+    experiment1.setExperimentId(experimentId1);
+    experiment1.rebuild(result);
+
+    ExperimentId experimentId2 = new ExperimentId();
+    experimentId2.setServerTimestamp(System.currentTimeMillis());
+    experimentId2.setId(2);
+
+    ExperimentEntity entity1 = new ExperimentEntity();
+    entity1.setId(experiment1.getExperimentId().toString());
+    entity1.setExperimentSpec(new GsonBuilder().disableHtmlEscaping().create().toJson(experiment1.getSpec()));
+
+    doReturn(Arrays.asList(entity1)).when(mockService).selectAll();
+
+    when(mockSubmitter.findExperiment(any(ExperimentSpec.class))).thenReturn(experiment1);
+
+    ExperimentManager spyExperimentManager = spy(experimentManager);
+    List<Experiment> foundExperiments = spyExperimentManager.listExperimentsByTag("stable");
+    assertEquals(1, foundExperiments.size());
+    List<Experiment> foundExperiments2 = spyExperimentManager.listExperimentsByTag("test");
+    assertEquals(0, foundExperiments2.size());
   }
 
   @Test
@@ -235,6 +268,8 @@ public class ExperimentManagerTest {
         expected.getSpec().getEnvironment().getImage(),
         actual.getSpec().getEnvironment().getImage())
     ;
+
+    assertEquals(expected.getSpec().getMeta().getTags().toString(), actual.getSpec().getMeta().getTags().toString());
   }
 
   private Object buildFromJsonFile(Object obj, String filePath) throws SubmarineException {

--- a/submarine-server/server-core/src/test/java/org/apache/submarine/server/experiment/ExperimentManagerTest.java
+++ b/submarine-server/server-core/src/test/java/org/apache/submarine/server/experiment/ExperimentManagerTest.java
@@ -110,6 +110,7 @@ public class ExperimentManagerTest {
   @Test
   public void testFinaExperimentByTag() {
 
+    // Build two experiment objects, only experiment1 has tags
     ExperimentId experimentId1 = new ExperimentId();
     experimentId1.setServerTimestamp(System.currentTimeMillis());
     experimentId1.setId(1);
@@ -132,8 +133,10 @@ public class ExperimentManagerTest {
     when(mockSubmitter.findExperiment(any(ExperimentSpec.class))).thenReturn(experiment1);
 
     ExperimentManager spyExperimentManager = spy(experimentManager);
+    // only the experiment1 object should be found with giving tag stable
     List<Experiment> foundExperiments = spyExperimentManager.listExperimentsByTag("stable");
     assertEquals(1, foundExperiments.size());
+    // no object should be found when we're searching with tag "test"
     List<Experiment> foundExperiments2 = spyExperimentManager.listExperimentsByTag("test");
     assertEquals(0, foundExperiments2.size());
   }

--- a/submarine-server/server-core/src/test/resources/experiment/spec.json
+++ b/submarine-server/server-core/src/test/resources/experiment/spec.json
@@ -6,7 +6,10 @@
     "cmd": "python /var/tf_mnist/mnist_with_summaries.py --log_dir=/train/log --learning_rate=0.01 --batch_size=150",
     "envVars": {
       "ENV_1": "ENV1"
-    }
+    },
+    "tags": [
+      "default", "stable"
+    ]
   },
   "environment": {
     "image": "apache/submarine:tf-mnist-with-summaries-1.0"


### PR DESCRIPTION
### What is this PR for?
We would like to allow users could define the tag on experiment by themself, and the tags should be also an useful field when they try to find experiment precisely, so I add a tags property into ExperimentSpec POJO and add a findExperimentByTag function.

### What type of PR is it?
Improvement

### Todos
add the new fields in front-end pages.

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-943

### How should this be tested?
The unit test has also been modified and added.

### Screenshots (if appropriate)
N/A
### Questions:
* Do the license files need updating? No
* Are there breaking changes for older versions? No
* Does this need new documentation? No
