### PR TITLE
SUBMARINE-944. Bump io:commons-io to 2.11

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -232,7 +232,7 @@ commons-configuration:commons-configuration:1.6
 commons-configuration:commons-configuration:1.1
 commons-daemon:commons-daemon:1.0.13
 commons-digester:commons-digester:1.8
-commons-io:commons-io:2.4
+commons-io:commons-io:2.11
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.1.3
 commons-logging:commons-logging:1.1.1

--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -232,7 +232,7 @@ commons-configuration:commons-configuration:1.6
 commons-configuration:commons-configuration:1.1
 commons-daemon:commons-daemon:1.0.13
 commons-digester:commons-digester:1.8
-commons-io:commons-io:2.11
+commons-io:commons-io:2.11.0
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.1.3
 commons-logging:commons-logging:1.1.1

--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@
     <httpclient.version>4.5.2</httpclient.version>
     <commons-lang.version>2.6</commons-lang.version>
     <commons-lang3.version>3.4</commons-lang3.version>
-    <commons-io.version>2.5</commons-io.version>
+    <commons-io.version>2.11</commons-io.version>
     <commons-codec.version>1.5</commons-codec.version>
     <junit.version>4.12</junit.version>
     <selenium.version>3.8.1</selenium.version>

--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@
     <httpclient.version>4.5.2</httpclient.version>
     <commons-lang.version>2.6</commons-lang.version>
     <commons-lang3.version>3.4</commons-lang3.version>
-    <commons-io.version>2.11</commons-io.version>
+    <commons-io.version>2.11.0</commons-io.version>
     <commons-codec.version>1.5</commons-codec.version>
     <junit.version>4.12</junit.version>
     <selenium.version>3.8.1</selenium.version>


### PR DESCRIPTION
### What is this PR for?
<!-- A few sentences describing the overall goals of the pull request's commits.
First time? Check out the contributing guide - https://submarine.apache.org/contribution/contributions.html
-->
CVE-2021-29425
Vulnerable versions: < 2.7
Patched version: 2.7
In Apache Commons IO before 2.7, When invoking the method FileNameUtils.normalize with an improper input string, like "//../foo", or "\..\foo", the result would be the same value, thus possibly providing access to files in the parent directory, but not further above (thus "limited" path traversal), if the calling code would use the result to construct a path value.
https://github.com/apache/submarine/security/dependabot/pom.xml/commons-io:commons-io/open 

### What type of PR is it?
[Improvement]

### Todos
No

### What is the Jira issue?
<!-- * Open an issue on Jira https://issues.apache.org/jira/browse/SUBMARINE/
* Put link here, and add [SUBMARINE-*Jira number*] in PR title, eg. `SUBMARINE-23. PR title`
-->
https://issues.apache.org/jira/browse/SUBMARINE-944
### How should this be tested?
<!--
* First time? Setup Travis CI as described on https://submarine.apache.org/contribution/contributions.html#continuous-integration
* Strongly recommended: add automated unit tests for any new or changed behavior
* Outline any manual steps to test the PR here.
-->
Pass the CIs
### Screenshots (if appropriate)

### Questions:
* Do the license files need updating? No
* Are there breaking changes for older versions? No
* Does this need new documentation? No
