### PR TITLE
SUBMARINE-947. Deploy website must be limited to apache submarine repository

### DIFF
--- a/.github/workflows/deploy_website.yml
+++ b/.github/workflows/deploy_website.yml
@@ -15,6 +15,9 @@
 
 name: Deploy Submarine documentation
 
+# Trigger the workflow on push or pull request
+on: [push, pull_request]
+
 jobs:
   checks-website:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy_website.yml
+++ b/.github/workflows/deploy_website.yml
@@ -15,16 +15,8 @@
 
 name: Deploy Submarine documentation
 
-# Trigger the workflow on master branch push and pull request
-on:
-  pull_request:
-    branches: [master]
-  push:
-    branches: [master]
-
 jobs:
   checks-website:
-    if: github.event_name != 'push'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -43,7 +35,7 @@ jobs:
           fi
           npm run build
   deploy-website:
-    if: github.event_name != 'pull_request'
+    if: github.repository == 'apache/submarine' && github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
### What is this PR for?
1. Check website job should be enabled to run on Pull Requests.
2. Deploy website job must only run on the apache submarine repository and the master branch.

### What type of PR is it?
[Improvement]

### Todos

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-947

### How should this be tested?


### Screenshots (if appropriate)

### Questions:
* Do the license files need updating? No
* Are there breaking changes for older versions? No
* Does this need new documentation? No
