### PR TITLE
SUBMARINE-911. Fix the bug about deleting notebook

### DIFF
--- a/dev-support/database/submarine.sql
+++ b/dev-support/database/submarine.sql
@@ -251,6 +251,20 @@ CREATE TABLE `experiment` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 -- ----------------------------
+-- Table structure for notebook
+-- ----------------------------
+DROP TABLE IF EXISTS `notebook`;
+CREATE TABLE `notebook` (
+  `id` varchar(64) NOT NULL COMMENT 'Id of the notebook',
+  `notebook_spec` text NOT NULL COMMENT 'Spec of the notebook',
+  `create_by` varchar(32) DEFAULT NULL COMMENT 'create user',
+  `create_time` datetime DEFAULT NULL COMMENT 'create time',
+  `update_by` varchar(32) DEFAULT NULL COMMENT 'last update user',
+  `update_time` datetime DEFAULT NULL COMMENT 'last update time',
+   PRIMARY KEY `id` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+-- ----------------------------
 -- Table structure for metric
 -- ----------------------------
 DROP TABLE IF EXISTS `metrics`;

--- a/submarine-server/server-core/src/main/java/org/apache/submarine/server/notebook/NotebookManager.java
+++ b/submarine-server/server-core/src/main/java/org/apache/submarine/server/notebook/NotebookManager.java
@@ -153,7 +153,7 @@ public class NotebookManager {
     Notebook notebook = notebookService.select(id);
     if (notebook == null) {
       throw new SubmarineRuntimeException(Response.Status.NOT_FOUND.getStatusCode(),
-          "Not found notebook");
+          "Notebook not found.");
     }
     Notebook foundNotebook = submitter.findNotebook(notebook.getSpec());
     foundNotebook.rebuild(notebook);
@@ -203,7 +203,7 @@ public class NotebookManager {
     NotebookId notebookId = NotebookId.fromString(id);
     if (notebookId == null) {
       throw new SubmarineRuntimeException(Response.Status.NOT_FOUND.getStatusCode(),
-          "Not found notebook server.");
+          "Notebook not found.");
     }
   }
 

--- a/submarine-server/server-core/src/main/java/org/apache/submarine/server/notebook/NotebookManager.java
+++ b/submarine-server/server-core/src/main/java/org/apache/submarine/server/notebook/NotebookManager.java
@@ -151,6 +151,10 @@ public class NotebookManager {
     checkNotebookId(id);
 
     Notebook notebook = notebookService.select(id);
+    if (notebook == null) {
+      throw new SubmarineRuntimeException(Response.Status.NOT_FOUND.getStatusCode(),
+          "Not found notebook");
+    }
     Notebook foundNotebook = submitter.findNotebook(notebook.getSpec());
     foundNotebook.rebuild(notebook);
 

--- a/submarine-server/server-core/src/main/java/org/apache/submarine/server/notebook/database/NotebookEntity.java
+++ b/submarine-server/server-core/src/main/java/org/apache/submarine/server/notebook/database/NotebookEntity.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.submarine.server.notebook.database;
+
+import org.apache.submarine.server.database.entity.BaseEntity;
+
+public class NotebookEntity extends BaseEntity {
+  /*
+    Take id (inherited from BaseEntity) as the primary key for notebook table
+  */
+  private String notebookSpec;
+
+  public NotebookEntity() {
+  }
+
+  public String getNotebookSpec() {
+    return notebookSpec;
+  }
+
+  public void setNotebookSpec(String notebookSpec) {
+    this.notebookSpec = notebookSpec;
+  }
+
+  @Override
+  public String toString() {
+    return "NotebookEntity{" +
+        "notebookSpec='" + notebookSpec + '\'' +
+        ", id='" + id + '\'' +
+        ", createBy='" + createBy + '\'' +
+        ", createTime=" + createTime +
+        ", updateBy='" + updateBy + '\'' +
+        ", updateTime=" + updateTime +
+        '}';
+  }
+}

--- a/submarine-server/server-core/src/main/java/org/apache/submarine/server/notebook/database/NotebookMapper.java
+++ b/submarine-server/server-core/src/main/java/org/apache/submarine/server/notebook/database/NotebookMapper.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.submarine.server.notebook.database;
+
+import java.util.List;
+
+public interface NotebookMapper {
+  List<NotebookEntity> selectAll();
+
+  NotebookEntity select(String id);
+
+  int insert(NotebookEntity notebook);
+
+  int update(NotebookEntity notebook);
+
+  int delete(String id);
+}

--- a/submarine-server/server-core/src/main/java/org/apache/submarine/server/notebook/database/NotebookService.java
+++ b/submarine-server/server-core/src/main/java/org/apache/submarine/server/notebook/database/NotebookService.java
@@ -1,0 +1,153 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.submarine.server.notebook.database;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import java.util.ArrayList;
+import org.apache.ibatis.session.SqlSession;
+import org.apache.submarine.commons.utils.exception.SubmarineRuntimeException;
+import org.apache.submarine.server.api.notebook.Notebook;
+import org.apache.submarine.server.api.notebook.NotebookId;
+import org.apache.submarine.server.api.spec.NotebookSpec;
+import org.apache.submarine.server.database.utils.MyBatisUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+public class NotebookService {
+
+  private static final Logger LOG = LoggerFactory.getLogger(NotebookService.class);
+
+  public List<Notebook> selectAll() throws SubmarineRuntimeException {
+    LOG.info("Notebook selectAll");
+    List<NotebookEntity> entities;
+    List<Notebook> notebooks = new ArrayList<>();
+    try (SqlSession sqlSession = MyBatisUtil.getSqlSession()) {
+      NotebookMapper mapper = sqlSession.getMapper(NotebookMapper.class);
+      entities = mapper.selectAll();
+      sqlSession.commit();
+    } catch (Exception e) {
+      LOG.error(e.getMessage(), e);
+      throw new SubmarineRuntimeException("Unable to get notebook entities from database");
+    }
+    for (NotebookEntity entity : entities) {
+      notebooks.add(buildNotebookFromEntity(entity));
+    }
+    return notebooks;
+  }
+
+  public Notebook select(String id) throws SubmarineRuntimeException {
+    LOG.info("Notebook select " + id);
+    NotebookEntity entity;
+    Notebook notebook;
+    try (SqlSession sqlSession = MyBatisUtil.getSqlSession()) {
+      NotebookMapper mapper = sqlSession.getMapper(NotebookMapper.class);
+      entity = mapper.select(id);
+      sqlSession.commit();
+    } catch (Exception e) {
+      LOG.error(e.getMessage(), e);
+      throw new SubmarineRuntimeException("Unable to get notebook entity from database");
+    }
+    notebook = buildNotebookFromEntity(entity);
+    return notebook;
+  }
+
+  public boolean insert(Notebook notebook) throws SubmarineRuntimeException {
+    LOG.info("Notebook insert");
+    LOG.debug(notebook.toString());
+    NotebookEntity entity = buildEntityFromNotebook(notebook);
+    try (SqlSession sqlSession = MyBatisUtil.getSqlSession()) {
+      NotebookMapper mapper = sqlSession.getMapper(NotebookMapper.class);
+      mapper.insert(entity);
+      sqlSession.commit();
+    } catch (Exception e) {
+      LOG.error(e.getMessage(), e);
+      throw new SubmarineRuntimeException("Unable to insert notebook entity to database");
+    }
+    return true;
+  }
+
+  public boolean update(Notebook notebook) throws SubmarineRuntimeException {
+    LOG.info("Notebook update");
+    NotebookEntity entity = buildEntityFromNotebook(notebook);
+    try (SqlSession sqlSession = MyBatisUtil.getSqlSession()) {
+      NotebookMapper mapper = sqlSession.getMapper(NotebookMapper.class);
+      mapper.update(entity);
+      sqlSession.commit();
+    } catch (Exception e) {
+      LOG.error(e.getMessage(), e);
+      throw new SubmarineRuntimeException("Unable to update notebook entity in database");
+    }
+    return true;
+  }
+
+  public boolean delete(String id) throws SubmarineRuntimeException {
+    LOG.info("Notebook delete " + id);
+
+    try (SqlSession sqlSession = MyBatisUtil.getSqlSession()) {
+      NotebookMapper mapper = sqlSession.getMapper(NotebookMapper.class);
+      mapper.delete(id);
+      sqlSession.commit();
+    } catch (Exception e) {
+      LOG.error(e.getMessage(), e);
+      throw new SubmarineRuntimeException("Unable to delete notebook entity from database");
+    }
+    return true;
+  }
+
+  /**
+   * Create a NotebookEntity instance from experiment
+   *
+   * @param notebook
+   * @return NotebookEntity
+   */
+  private NotebookEntity buildEntityFromNotebook(Notebook notebook) {
+    NotebookEntity entity = new NotebookEntity();
+    try {
+      entity.setId(notebook.getNotebookId().toString());
+      entity.setNotebookSpec(new GsonBuilder().disableHtmlEscaping().create().toJson(notebook.getSpec()));
+    } catch (Exception e) {
+      LOG.error(e.getMessage(), e);
+      throw new SubmarineRuntimeException("Unable to build entity from notebook");
+    }
+    return entity;
+  }
+
+  /**
+   * Create a new notebook instance from entity
+   *
+   * @param entity
+   * @return Notebook
+   */
+  private Notebook buildNotebookFromEntity(NotebookEntity entity) {
+    Notebook notebook = new Notebook();
+    try {
+      notebook.setNotebookId(NotebookId.fromString(entity.getId()));
+      notebook.setSpec(new Gson().fromJson(entity.getNotebookSpec(), NotebookSpec.class));
+      notebook.setName(notebook.getSpec().getMeta().getName());
+    } catch (Exception e) {
+      LOG.error(e.getMessage(), e);
+      throw new SubmarineRuntimeException("Unable to build notebook from entity");
+    }
+    return notebook;
+  }
+}

--- a/submarine-server/server-core/src/main/java/org/apache/submarine/server/notebook/database/NotebookService.java
+++ b/submarine-server/server-core/src/main/java/org/apache/submarine/server/notebook/database/NotebookService.java
@@ -67,7 +67,7 @@ public class NotebookService {
       LOG.error(e.getMessage(), e);
       throw new SubmarineRuntimeException("Unable to get notebook entity from database");
     }
-    if(entity != null) {
+    if (entity != null) {
       notebook = buildNotebookFromEntity(entity);
       return notebook;
     }

--- a/submarine-server/server-core/src/main/java/org/apache/submarine/server/notebook/database/NotebookService.java
+++ b/submarine-server/server-core/src/main/java/org/apache/submarine/server/notebook/database/NotebookService.java
@@ -67,8 +67,11 @@ public class NotebookService {
       LOG.error(e.getMessage(), e);
       throw new SubmarineRuntimeException("Unable to get notebook entity from database");
     }
-    notebook = buildNotebookFromEntity(entity);
-    return notebook;
+    if(entity != null) {
+      notebook = buildNotebookFromEntity(entity);
+      return notebook;
+    }
+    return null;
   }
 
   public boolean insert(Notebook notebook) throws SubmarineRuntimeException {

--- a/submarine-server/server-core/src/main/resources/mybatis-config.xml
+++ b/submarine-server/server-core/src/main/resources/mybatis-config.xml
@@ -69,5 +69,6 @@
     <mapper resource='org/apache/submarine/database/mappers/EnvironmentMapper.xml'/>
     <mapper resource='org/apache/submarine/database/mappers/ExperimentTemplateMapper.xml'/>
     <mapper resource='org/apache/submarine/database/mappers/ExperimentMapper.xml'/>
+    <mapper resource='org/apache/submarine/database/mappers/NotebookMapper.xml'/>
   </mappers>
 </configuration>

--- a/submarine-server/server-core/src/main/resources/org/apache/submarine/database/mappers/NotebookMapper.xml
+++ b/submarine-server/server-core/src/main/resources/org/apache/submarine/database/mappers/NotebookMapper.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="org.apache.submarine.server.notebook.database.NotebookMapper">
+  <resultMap id="BaseEntityResultMap" type="org.apache.submarine.server.database.entity.BaseEntity">
+    <id property="id" column="id"/>
+    <result column="create_by" property="createBy"/>
+    <result column="create_time" property="createTime"/>
+    <result column="update_by" property="updateBy"/>
+    <result column="update_time" property="updateTime"/>
+  </resultMap>
+
+  <resultMap id="NotebookEntityResultMap" type="org.apache.submarine.server.notebook.database.NotebookEntity" extends="BaseEntityResultMap">
+    <result column="notebook_spec" jdbcType="VARCHAR" property="notebookSpec" />
+  </resultMap>
+
+  <sql id="Base_Column_List">
+    id, notebook_spec, create_by, create_time, update_by, update_time
+  </sql>
+
+  <select id="selectAll" parameterType="java.lang.String" resultMap="NotebookEntityResultMap">
+    select
+    <include refid="Base_Column_List" />
+    from notebook
+  </select>
+
+  <select id="select" parameterType="java.lang.String" resultMap="NotebookEntityResultMap">
+    select
+    <include refid="Base_Column_List" />
+    from notebook
+    where id = #{id,jdbcType=VARCHAR}
+  </select>
+
+  <delete id="delete" parameterType="java.lang.String">
+    delete from notebook
+    where id = #{id,jdbcType=VARCHAR}
+  </delete>
+
+  <insert id="insert" parameterType="org.apache.submarine.server.notebook.database.NotebookEntity">
+    insert into notebook (id, notebook_spec, create_by, create_time, update_by, update_time)
+    values (#{id,jdbcType=VARCHAR}, #{notebookSpec,jdbcType=VARCHAR},
+            #{createBy,jdbcType=VARCHAR}, now(), #{updateBy,jdbcType=VARCHAR}, now())
+  </insert>
+
+  <update id="update" parameterType="org.apache.submarine.server.notebook.database.NotebookEntity">
+    update notebook
+    <set>
+      <if test="notebookSpec != null">
+        notebook_spec = #{notebookSpec,jdbcType=VARCHAR},
+      </if>
+      update_time = now()
+    </set>
+    where id = #{id,jdbcType=VARCHAR}
+  </update>
+
+</mapper>


### PR DESCRIPTION
### What is this PR for?

Store notebook data to database.
Those data used to be saved in cache. The notebook pod have persistent volume to retain them which make the pod still working even if the server restart for some reason. But in this case, we will lose control of the pod on workbench because we don't have the data of these notebooks.

### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-911

### How should this be tested?
<!--
* First time? Setup Travis CI as described on https://submarine.apache.org/contribution/contributions.html#continuous-integration
* Strongly recommended: add automated unit tests for any new or changed behavior
* Outline any manual steps to test the PR here.
-->
### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/30621230/126822877-41f0cb23-3fbc-4e2b-86ff-ad5b41781e6d.png)

### Questions:
* Do the license files need updating? No
* Are there breaking changes for older versions? No
* Does this need new documentation? No
