### PR TITLE
SUBMARINE-956. Change submarine CRD groupName to "submarine.apache.org"

### DIFF
--- a/submarine-cloud-v2/artifacts/examples/example-submarine.yaml
+++ b/submarine-cloud-v2/artifacts/examples/example-submarine.yaml
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-apiVersion: submarine.k8s.io/v1alpha1
+apiVersion: submarine.apache.org/v1alpha1
 kind: Submarine
 metadata:
   name: example-submarine

--- a/submarine-cloud-v2/helm-charts/submarine-operator/crds/crd.yaml
+++ b/submarine-cloud-v2/helm-charts/submarine-operator/crds/crd.yaml
@@ -18,9 +18,9 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: submarines.submarine.k8s.io
+  name: submarines.submarine.apache.org
 spec:
-  group: submarine.k8s.io
+  group: submarine.apache.org
   version: v1alpha1
   names:
     kind: Submarine

--- a/submarine-cloud-v2/helm-charts/submarine-operator/templates/rbac.yaml
+++ b/submarine-cloud-v2/helm-charts/submarine-operator/templates/rbac.yaml
@@ -21,7 +21,7 @@ metadata:
   name: submarine-operator
 rules:
   - apiGroups:
-      - submarine.k8s.io
+      - submarine.apache.org
     resources:
       - submarines
     verbs:

--- a/submarine-cloud-v2/pkg/apis/submarine/v1alpha1/doc.go
+++ b/submarine-cloud-v2/pkg/apis/submarine/v1alpha1/doc.go
@@ -15,6 +15,6 @@
  * limitations under the License.
  */
 // +k8s:deepcopy-gen=package
-// +groupName=submarine.k8s.io
+// +groupName=submarine.apache.org
 
 package v1alpha1

--- a/submarine-cloud-v2/pkg/apis/submarine/v1alpha1/register.go
+++ b/submarine-cloud-v2/pkg/apis/submarine/v1alpha1/register.go
@@ -24,7 +24,7 @@ import (
 )
 
 const (
-	GroupName    = "submarine.k8s.io"
+	GroupName    = "submarine.apache.org"
 	GroupVersion = "v1alpha1"
 )
 

--- a/submarine-cloud-v2/pkg/client/clientset/versioned/typed/submarine/v1alpha1/fake/fake_submarine.go
+++ b/submarine-cloud-v2/pkg/client/clientset/versioned/typed/submarine/v1alpha1/fake/fake_submarine.go
@@ -37,9 +37,9 @@ type FakeSubmarines struct {
 	ns   string
 }
 
-var submarinesResource = schema.GroupVersionResource{Group: "submarine.k8s.io", Version: "v1alpha1", Resource: "submarines"}
+var submarinesResource = schema.GroupVersionResource{Group: "submarine.apache.org", Version: "v1alpha1", Resource: "submarines"}
 
-var submarinesKind = schema.GroupVersionKind{Group: "submarine.k8s.io", Version: "v1alpha1", Kind: "Submarine"}
+var submarinesKind = schema.GroupVersionKind{Group: "submarine.apache.org", Version: "v1alpha1", Kind: "Submarine"}
 
 // Get takes name of the submarine, and returns the corresponding submarine object, and an error if there is any.
 func (c *FakeSubmarines) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1alpha1.Submarine, err error) {

--- a/submarine-cloud-v2/pkg/client/clientset/versioned/typed/submarine/v1alpha1/submarine_client.go
+++ b/submarine-cloud-v2/pkg/client/clientset/versioned/typed/submarine/v1alpha1/submarine_client.go
@@ -30,7 +30,7 @@ type SubmarineV1alpha1Interface interface {
 	SubmarinesGetter
 }
 
-// SubmarineV1alpha1Client is used to interact with features provided by the submarine.k8s.io group.
+// SubmarineV1alpha1Client is used to interact with features provided by the submarine.apache.org group.
 type SubmarineV1alpha1Client struct {
 	restClient rest.Interface
 }

--- a/submarine-cloud-v2/pkg/client/informers/externalversions/generic.go
+++ b/submarine-cloud-v2/pkg/client/informers/externalversions/generic.go
@@ -53,7 +53,7 @@ func (f *genericInformer) Lister() cache.GenericLister {
 // TODO extend this to unknown resources with a client pool
 func (f *sharedInformerFactory) ForResource(resource schema.GroupVersionResource) (GenericInformer, error) {
 	switch resource {
-	// Group=submarine.k8s.io, Version=v1alpha1
+	// Group=submarine.apache.org, Version=v1alpha1
 	case v1alpha1.SchemeGroupVersion.WithResource("submarines"):
 		return &genericInformer{resource: resource.GroupResource(), informer: f.Submarine().V1alpha1().Submarines().Informer()}, nil
 


### PR DESCRIPTION
### What is this PR for?
Currently, the CRD groupName of submarines is "submarine.k8s.io", we should change it to "submarine.apache.org"

### What type of PR is it?
[Bug Fix]

### Todos

### What is the Jira issue?
https://issues.apache.org/jira/projects/SUBMARINE/issues/SUBMARINE-956

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* Do the license files need updating? No
* Are there breaking changes for older versions? No
* Does this need new documentation? No
