### PR TITLE
SUBMARINE-955. Add Limit on Experiment Name

### DIFF
--- a/submarine-workbench/workbench-web/src/app/pages/workbench/experiment/experiment-home/experiment-form/experiment-customized-form/experiment-customized-form.component.html
+++ b/submarine-workbench/workbench-web/src/app/pages/workbench/experiment/experiment-home/experiment-form/experiment-customized-form/experiment-customized-form.component.html
@@ -42,7 +42,7 @@
             placeholder="mnist-example"
           />
           <div class="alert-message" *ngIf="experiment.get('experimentName').hasError('pattern')">
-            Only letters(a-z), numbers(0-9), and hyphens(-)(but cannot start with them) are allowed.
+            Only letters(a-z), numbers(0-9), and hyphens are allowed, but you can't start with hyphens.
           </div>
         </div>
         <div class="single-field-group">

--- a/submarine-workbench/workbench-web/src/app/pages/workbench/experiment/experiment-home/experiment-form/experiment-customized-form/experiment-customized-form.component.html
+++ b/submarine-workbench/workbench-web/src/app/pages/workbench/experiment/experiment-home/experiment-form/experiment-customized-form/experiment-customized-form.component.html
@@ -42,7 +42,7 @@
             placeholder="mnist-example"
           />
           <div class="alert-message" *ngIf="experiment.get('experimentName').hasError('pattern')">
-            Only letters(a-z), numbers(0-9), and hyphens(-) are allowed.
+            Only letters(a-z), numbers(0-9), and hyphens(-)(but cannot start with them) are allowed.
           </div>
         </div>
         <div class="single-field-group">

--- a/submarine-workbench/workbench-web/src/app/pages/workbench/experiment/experiment-home/experiment-form/experiment-customized-form/experiment-customized-form.component.ts
+++ b/submarine-workbench/workbench-web/src/app/pages/workbench/experiment/experiment-home/experiment-form/experiment-customized-form/experiment-customized-form.component.ts
@@ -88,7 +88,7 @@ export class ExperimentCustomizedFormComponent implements OnInit, OnDestroy {
 
   ngOnInit() {
     this.experiment = new FormGroup({
-      experimentName: new FormControl(null, [Validators.pattern('[a-zA-Z0-9]+[a-zA-Z0-9\-]*'), Validators.required]),
+      experimentName: new FormControl(null, [Validators.pattern('[a-zA-Z0-9][a-zA-Z0-9\-]*'), Validators.required]),
       description: new FormControl(null, [Validators.required]),
       namespace: new FormControl(this.defaultNameSpace, [Validators.required]),
       cmd: new FormControl('', [Validators.required]),

--- a/submarine-workbench/workbench-web/src/app/pages/workbench/experiment/experiment-home/experiment-form/experiment-customized-form/experiment-customized-form.component.ts
+++ b/submarine-workbench/workbench-web/src/app/pages/workbench/experiment/experiment-home/experiment-form/experiment-customized-form/experiment-customized-form.component.ts
@@ -88,7 +88,7 @@ export class ExperimentCustomizedFormComponent implements OnInit, OnDestroy {
 
   ngOnInit() {
     this.experiment = new FormGroup({
-      experimentName: new FormControl(null, [Validators.pattern('[a-zA-Z0-9\-]*'), Validators.required]),
+      experimentName: new FormControl(null, [Validators.pattern('[a-zA-Z0-9]+[a-zA-Z0-9\-]*'), Validators.required]),
       description: new FormControl(null, [Validators.required]),
       namespace: new FormControl(this.defaultNameSpace, [Validators.required]),
       cmd: new FormControl('', [Validators.required]),

--- a/submarine-workbench/workbench-web/src/app/pages/workbench/experiment/experiment-home/experiment-form/experiment-predefined-form/experiment-predefined-form.component.html
+++ b/submarine-workbench/workbench-web/src/app/pages/workbench/experiment/experiment-home/experiment-form/experiment-predefined-form/experiment-predefined-form.component.html
@@ -36,8 +36,14 @@
     <h4 nz-typography>Configurable Parameters</h4>
     <nz-form-item *ngFor="let item of paramList">
       <nz-form-label [nzSpan]="5" [nzRequired]="item.required" [nzFor]="item.name">{{ item.name }}</nz-form-label>
-      <nz-form-control [nzSpan]="12" nzErrorTip="Please provide the value!">
+      <nz-form-control [nzSpan]="12" nzErrorTip="Please provide the value!" *ngIf="item.name != 'experiment_name'">
         <input type="text" nz-input [id]="item.name" [formControlName]="item.name" />
+      </nz-form-control>
+      <nz-form-control [nzSpan]="12" *ngIf="item.name == 'experiment_name'">
+        <input type="text" nz-input [id]="item.name" [formControlName]="item.name" />
+        <div class="alert-message" *ngIf="predefinedForm.get('params').get(item.name).hasError('pattern')">
+          Only letters(a-z), numbers(0-9), and hyphens(-)(but cannot start with them) are allowed.
+        </div>
       </nz-form-control>
     </nz-form-item>
   </div>

--- a/submarine-workbench/workbench-web/src/app/pages/workbench/experiment/experiment-home/experiment-form/experiment-predefined-form/experiment-predefined-form.component.html
+++ b/submarine-workbench/workbench-web/src/app/pages/workbench/experiment/experiment-home/experiment-form/experiment-predefined-form/experiment-predefined-form.component.html
@@ -42,7 +42,7 @@
       <nz-form-control [nzSpan]="12" *ngIf="item.name == 'experiment_name'">
         <input type="text" nz-input [id]="item.name" [formControlName]="item.name" />
         <div class="alert-message" *ngIf="predefinedForm.get('params').get(item.name).hasError('pattern')">
-          Only letters(a-z), numbers(0-9), and hyphens(-)(but cannot start with them) are allowed.
+          Only letters(a-z), numbers(0-9), and hyphens are allowed, but you can't start with hyphens.
         </div>
       </nz-form-control>
     </nz-form-item>

--- a/submarine-workbench/workbench-web/src/app/pages/workbench/experiment/experiment-home/experiment-form/experiment-predefined-form/experiment-predefined-form.component.scss
+++ b/submarine-workbench/workbench-web/src/app/pages/workbench/experiment/experiment-home/experiment-form/experiment-predefined-form/experiment-predefined-form.component.scss
@@ -16,3 +16,9 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
+ .alert-message {
+    color: red;
+    margin-top: .3rem;
+    line-height: normal;
+   }

--- a/submarine-workbench/workbench-web/src/app/pages/workbench/experiment/experiment-home/experiment-form/experiment-predefined-form/experiment-predefined-form.component.scss
+++ b/submarine-workbench/workbench-web/src/app/pages/workbench/experiment/experiment-home/experiment-form/experiment-predefined-form/experiment-predefined-form.component.scss
@@ -21,4 +21,4 @@
     color: red;
     margin-top: .3rem;
     line-height: normal;
-   }
+}

--- a/submarine-workbench/workbench-web/src/app/pages/workbench/experiment/experiment-home/experiment-form/experiment-predefined-form/experiment-predefined-form.component.ts
+++ b/submarine-workbench/workbench-web/src/app/pages/workbench/experiment/experiment-home/experiment-form/experiment-predefined-form/experiment-predefined-form.component.ts
@@ -151,8 +151,11 @@ export class ExperimentPredefinedFormComponent implements OnInit, OnDestroy {
     let controls = {};
     for (let item of this.templates[this.currentOption].templateParams) {
       controls[item.name] = [item.value];
-      if (item.required === 'true') controls[item.name].push([Validators.required]);
+      if (item.required === 'true') {
+        if(item.name !== 'experiment_name') controls[item.name].push([Validators.required]);
+        else controls[item.name].push([Validators.required, Validators.pattern('[a-zA-Z0-9]+[a-zA-Z0-9\-]*')]);
     }
+  }
     const new_param_group = this.fb.group(controls);
     this.predefinedForm.setControl('params', new_param_group);
   }

--- a/submarine-workbench/workbench-web/src/app/pages/workbench/experiment/experiment-home/experiment-form/experiment-predefined-form/experiment-predefined-form.component.ts
+++ b/submarine-workbench/workbench-web/src/app/pages/workbench/experiment/experiment-home/experiment-form/experiment-predefined-form/experiment-predefined-form.component.ts
@@ -153,9 +153,9 @@ export class ExperimentPredefinedFormComponent implements OnInit, OnDestroy {
       controls[item.name] = [item.value];
       if (item.required === 'true') {
         if(item.name !== 'experiment_name') controls[item.name].push([Validators.required]);
-        else controls[item.name].push([Validators.required, Validators.pattern('[a-zA-Z0-9]+[a-zA-Z0-9\-]*')]);
+        else controls[item.name].push([Validators.required, Validators.pattern('[a-zA-Z0-9][a-zA-Z0-9\-]*')]);
+      }
     }
-  }
     const new_param_group = this.fb.group(controls);
     this.predefinedForm.setControl('params', new_param_group);
   }


### PR DESCRIPTION
### What is this PR for?

[Former PR](https://issues.apache.org/jira/browse/SUBMARINE-886) has some edge case.
Like:
* \-
* --invalid

Valid cases are like:
* valid-one
* valid1

So I change the pattern for validating experiment name to filter these cases.
And I also add this pattern to experiment name of predefine template.

### What type of PR is it?
[Bug Fix]

### Todos

None

### What is the Jira issue?

https://issues.apache.org/jira/projects/SUBMARINE/issues/SUBMARINE-955

### How should this be tested?

Open the workbench and type invalid experiment name.

### Screenshots (if appropriate)

invalid name on custom experiment
![2021-08-01 14-47-13 的螢幕擷圖](https://user-images.githubusercontent.com/55401762/127762058-e73ad41d-546b-4b45-960a-5d15b646d2cc.png)
invalid name on predefine experiment
![2021-08-01 14-47-34 的螢幕擷圖](https://user-images.githubusercontent.com/55401762/127762063-1510f983-a388-4472-89c4-7b7451cbaab5.png)
valid name on custom experiment
![2021-08-01 14-48-07 的螢幕擷圖](https://user-images.githubusercontent.com/55401762/127762066-2816e348-3202-43ce-b541-41ab4c85ca1b.png)
valid name on predefine experiment
![2021-08-01 14-47-52 的螢幕擷圖](https://user-images.githubusercontent.com/55401762/127762067-eda0d8c6-cb71-426c-a8af-6f446e9bffa8.png)


### Questions:
* Do the license files need updating? No
* Are there breaking changes for older versions? No
* Does this need new documentation? No
