### PR TITLE
SUBMARINE-961. Experiment Tag at Predefined Experiment

### DIFF
--- a/submarine-workbench/workbench-web/src/app/pages/workbench/experiment/experiment-home/experiment-form/experiment-customized-form/experiment-customized-form.component.ts
+++ b/submarine-workbench/workbench-web/src/app/pages/workbench/experiment/experiment-home/experiment-form/experiment-customized-form/experiment-customized-form.component.ts
@@ -328,7 +328,8 @@ export class ExperimentCustomizedFormComponent implements OnInit, OnDestroy {
       tags: this.tags.value,
       framework: this.framework === 'Standalone' ? 'Tensorflow' : this.framework,
       cmd: this.cmd.value,
-      envVars: {}
+      envVars: {},
+      tags: []
     };
     for (const env of this.envs.controls) {
       if (env.get('key').value) {

--- a/submarine-workbench/workbench-web/src/app/pages/workbench/experiment/experiment-home/experiment-form/experiment-customized-form/experiment-customized-form.component.ts
+++ b/submarine-workbench/workbench-web/src/app/pages/workbench/experiment/experiment-home/experiment-form/experiment-customized-form/experiment-customized-form.component.ts
@@ -329,7 +329,6 @@ export class ExperimentCustomizedFormComponent implements OnInit, OnDestroy {
       framework: this.framework === 'Standalone' ? 'Tensorflow' : this.framework,
       cmd: this.cmd.value,
       envVars: {},
-      tags: []
     };
     for (const env of this.envs.controls) {
       if (env.get('key').value) {

--- a/submarine-workbench/workbench-web/src/app/pages/workbench/experiment/experiment-home/experiment-form/experiment-predefined-form/experiment-predefined-form.component.html
+++ b/submarine-workbench/workbench-web/src/app/pages/workbench/experiment/experiment-home/experiment-form/experiment-predefined-form/experiment-predefined-form.component.html
@@ -65,6 +65,9 @@
       <nz-descriptions-item nzTitle="Environment Variables" [nzSpan]="2">
         {{ templates[currentOption].experimentVars }}
       </nz-descriptions-item>
+      <nz-descriptions-item nzTitle="Tags">
+        <nz-tag *ngFor="let tag of templates[currentOption].experimentTags">{{tag}}</nz-tag>
+      </nz-descriptions-item>
     </nz-descriptions>
   </nz-form-item>
 </form>

--- a/submarine-workbench/workbench-web/src/app/pages/workbench/experiment/experiment-home/experiment-form/experiment-predefined-form/experiment-predefined-form.component.ts
+++ b/submarine-workbench/workbench-web/src/app/pages/workbench/experiment/experiment-home/experiment-form/experiment-predefined-form/experiment-predefined-form.component.ts
@@ -37,6 +37,7 @@ interface ParsedTemplate {
   experimentCommand: string;
   experimentImage: string;
   experimentVars: string;
+  experimentTags: string[];
 }
 
 interface TemplateTable {
@@ -132,6 +133,7 @@ export class ExperimentPredefinedFormComponent implements OnInit, OnDestroy {
         experimentCommand: item.experimentTemplateSpec.experimentSpec.meta.cmd,
         experimentImage: item.experimentTemplateSpec.experimentSpec.environment.image,
         experimentVars: JSON.stringify(item.experimentTemplateSpec.experimentSpec.meta.envVars),
+        experimentTags: item.experimentTemplateSpec.experimentSpec.meta.tags,
       };
       templates[item.experimentTemplateSpec.name] = template;
     }

--- a/submarine-workbench/workbench-web/src/app/pages/workbench/template/template-home/template-form/template-form.component.html
+++ b/submarine-workbench/workbench-web/src/app/pages/workbench/template/template-home/template-form/template-form.component.html
@@ -175,6 +175,27 @@
             ></textarea>
           </nz-form-control>
         </nz-form-item>
+        <nz-form-item>
+          <nz-form-label [nzSm]="6" [nzXs]="24" nzRequired nzFor="tags">Tags</nz-form-label>
+          <nz-form-control [nzSm]="14" [nzXs]="24" nzErrorTip="Please input tags for this template!">
+            <!-- <textarea
+              nz-input
+              [nzAutosize]="{ minRows: 1, maxRows: 4 }"
+              name="cmd"
+              formControlName="cmd"
+              id="cmd"
+              placeholder="Command for this template."
+            ></textarea> -->
+            <nz-select
+            formControlName="tags"
+            nzMode="tags"
+            [nzTokenSeparators]="[',']"
+            nzPlaceHolder="AutoEncoder"
+            >
+            <nz-option *ngFor="let option of listOfOption" [nzLabel]="option.label" [nzValue]="option.value"></nz-option>
+          </nz-select>
+          </nz-form-control>
+        </nz-form-item>
         <div formArrayName="envVars">
           <ng-container *ngFor="let env of envVars.controls; index as i">
             <nz-form-item>

--- a/submarine-workbench/workbench-web/src/app/pages/workbench/template/template-home/template-form/template-form.component.html
+++ b/submarine-workbench/workbench-web/src/app/pages/workbench/template/template-home/template-form/template-form.component.html
@@ -178,14 +178,6 @@
         <nz-form-item>
           <nz-form-label [nzSm]="6" [nzXs]="24" nzRequired nzFor="tags">Tags</nz-form-label>
           <nz-form-control [nzSm]="14" [nzXs]="24" nzErrorTip="Please input tags for this template!">
-            <!-- <textarea
-              nz-input
-              [nzAutosize]="{ minRows: 1, maxRows: 4 }"
-              name="cmd"
-              formControlName="cmd"
-              id="cmd"
-              placeholder="Command for this template."
-            ></textarea> -->
             <nz-select
             formControlName="tags"
             nzMode="tags"

--- a/submarine-workbench/workbench-web/src/app/pages/workbench/template/template-home/template-form/template-form.component.ts
+++ b/submarine-workbench/workbench-web/src/app/pages/workbench/template/template-home/template-form/template-form.component.ts
@@ -47,6 +47,8 @@ export class TemplateFormComponent implements OnInit {
   currentSpecPage = 1;
   PAGESIZE = 5;
 
+  listOfOption: Array<{ label: string; value: string }> = [];
+
   // Constants
   TF_SPECNAMES = ['Master', 'Worker', 'Ps'];
   PYTORCH_SPECNAMES = ['Master', 'Worker'];
@@ -63,6 +65,9 @@ export class TemplateFormComponent implements OnInit {
   ) {}
 
   ngOnInit() {
+    //TODO: get tags from server
+    this.listOfOption = []; 
+
     this.templateForm = this.fb.group({
       templateName: [null, Validators.required],
       description: [null, Validators.required],
@@ -70,6 +75,7 @@ export class TemplateFormComponent implements OnInit {
       code: [null],
       specs: this.fb.array([], [this.experimentValidatorService.nameValidatorFactory('name')]),
       cmd: [null, Validators.required],
+      tags: [[], Validators.required],
       envVars: this.fb.array([], [this.experimentValidatorService.nameValidatorFactory('key')]),
       image: [null, Validators.required],
     });
@@ -99,6 +105,10 @@ export class TemplateFormComponent implements OnInit {
     return this.templateForm.get('cmd');
   }
 
+  get tags() {
+    return this.templateForm.get('tags');
+  }
+
   get envVars() {
     return this.templateForm.get('envVars') as FormArray;
   }
@@ -118,6 +128,7 @@ export class TemplateFormComponent implements OnInit {
     this.parameters.clear();
     this.specs.clear();
     this.cmd.reset();
+    this.tags.reset();
     this.envVars.clear();
     this.image.reset();
   }
@@ -127,7 +138,7 @@ export class TemplateFormComponent implements OnInit {
   }
 
   checkExperimentInfo() {
-    return this.image.invalid || this.cmd.invalid || this.envVars.invalid;
+    return this.image.invalid || this.cmd.invalid || this.tags.invalid || this.envVars.invalid;
   }
 
   checkResourceSpec() {
@@ -253,7 +264,8 @@ export class TemplateFormComponent implements OnInit {
           name: this.defaultExperimentName,
           envVars: envVars,
           framework: this.framework,
-          tags: [],
+          namespace: this.NAMESPACE,
+          tags: this.templateForm.get('tags').value,
         },
         spec: specs,
         environment: {

--- a/submarine-workbench/workbench-web/src/app/pages/workbench/template/template-home/template-form/template-form.component.ts
+++ b/submarine-workbench/workbench-web/src/app/pages/workbench/template/template-home/template-form/template-form.component.ts
@@ -264,7 +264,6 @@ export class TemplateFormComponent implements OnInit {
           name: this.defaultExperimentName,
           envVars: envVars,
           framework: this.framework,
-          namespace: this.NAMESPACE,
           tags: this.templateForm.get('tags').value,
         },
         spec: specs,

--- a/submarine-workbench/workbench-web/src/app/pages/workbench/template/template-info/template-info.component.html
+++ b/submarine-workbench/workbench-web/src/app/pages/workbench/template/template-info/template-info.component.html
@@ -68,6 +68,9 @@
         <nz-descriptions-item nzTitle="Environment Varibles">
           {{ templateVars }}
         </nz-descriptions-item>
+        <nz-descriptions-item nzTitle="Tags">
+          <nz-tag *ngFor="let tag of templateInfo.experimentTemplateSpec.experimentSpec.meta.tags">{{tag}}</nz-tag>
+        </nz-descriptions-item>
       </nz-descriptions>
     </nz-tab>
     <nz-tab nzTitle="Parameters">

--- a/submarine-workbench/workbench-web/src/app/pages/workbench/template/template-info/template-info.component.ts
+++ b/submarine-workbench/workbench-web/src/app/pages/workbench/template/template-info/template-info.component.ts
@@ -22,7 +22,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { ExperimentTemplate } from '@submarine/interfaces/experiment-template';
 import { ExperimentService } from '@submarine/services/experiment.service';
 import { NzMessageService } from 'ng-zorro-antd';
-
+import { NzTagModule } from 'ng-zorro-antd/tag';
 @Component({
   selector: 'submarine-template-info',
   templateUrl: './template-info.component.html',


### PR DESCRIPTION
### What is this PR for?

This is the frontend implementation of SUBMARINE-943
Users can add multiple tags to mark experiments with their own category.


It's a little bit different from creating customized experiment, SUBMARINE-958
The tags are defined in template, so you can't edit it when creating the experiment.
But users can edit tags after creating the experiment.

### What type of PR is it?
[Feature]

### Todos

None

### What is the Jira issue?

https://issues.apache.org/jira/projects/SUBMARINE/issues/SUBMARINE-961

### How should this be tested?

Create a template with tags, and create an experiment with that template.

### Screenshots (if appropriate)

Create template with tags
![2021-08-06 23-50-19 的螢幕擷圖](https://user-images.githubusercontent.com/55401762/128537468-9b4538bd-a091-4ab8-be47-afa97efce328.png)
Completed template
![2021-08-06 23-50-33 的螢幕擷圖](https://user-images.githubusercontent.com/55401762/128537482-4ea63d65-0f52-43f6-97e4-096440d3adb4.png)
Create experiment with template
![2021-08-06 23-56-00 的螢幕擷圖](https://user-images.githubusercontent.com/55401762/128538201-617504d3-6201-4318-bb40-eb839a85ad87.png)


### Questions:
* Do the license files need updating? No
* Are there breaking changes for older versions? No
* Does this need new documentation? No
