### PR TITLE
SUBMARINE-965. Users should not have the privilege to create experiments in different namespaces

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -172,6 +172,7 @@ jobs:
           TEST_MODULES: "-pl :submarine-test-k8s"
         run: |
           echo ">>> mvn ${TEST_FLAG} ${TEST_MODULES} ${PROFILE} -B"
+          mvn install -DskipTests
           mvn ${TEST_FLAG} ${TEST_MODULES} ${PROFILE} -B
       - name: Failure status
         run: |

--- a/submarine-server/server-api/src/main/java/org/apache/submarine/server/api/spec/ExperimentMeta.java
+++ b/submarine-server/server-api/src/main/java/org/apache/submarine/server/api/spec/ExperimentMeta.java
@@ -40,7 +40,10 @@ public class ExperimentMeta {
   private List<String> tags = new ArrayList<>();
 
   public ExperimentMeta() {
-
+    namespace = "default";
+    if (System.getenv("ENV_NAMESPACE") != null) {
+      namespace = System.getenv("ENV_NAMESPACE");
+    }
   }
 
   /**
@@ -88,7 +91,7 @@ public class ExperimentMeta {
    * @param namespace namespace
    */
   public void setNamespace(String namespace) {
-    this.namespace = namespace;
+    return;
   }
 
   public String getFramework() {

--- a/submarine-server/server-api/src/main/java/org/apache/submarine/server/api/spec/ExperimentMeta.java
+++ b/submarine-server/server-api/src/main/java/org/apache/submarine/server/api/spec/ExperimentMeta.java
@@ -41,7 +41,9 @@ public class ExperimentMeta {
 
   public ExperimentMeta() {
     namespace = "default";
-    if (System.getenv("ENV_NAMESPACE") != null) {
+    /* The environment variable "ENV_NAMESPACE" will be set by submarine-operator. 
+       On the other hand, if the user creates Submarine with Helm, the variable "namespace" will always be "default". */
+    if (System.getenv("ENV_NAMESPACE") != null) { 
       namespace = System.getenv("ENV_NAMESPACE");
     }
   }

--- a/submarine-server/server-api/src/main/java/org/apache/submarine/server/api/spec/ExperimentMeta.java
+++ b/submarine-server/server-api/src/main/java/org/apache/submarine/server/api/spec/ExperimentMeta.java
@@ -41,8 +41,9 @@ public class ExperimentMeta {
 
   public ExperimentMeta() {
     namespace = "default";
-    /* The environment variable "ENV_NAMESPACE" will be set by submarine-operator. 
-       On the other hand, if the user creates Submarine with Helm, the variable "namespace" will always be "default". */
+    /* The environment variable "ENV_NAMESPACE" will be set by submarine-operator. Hence, 
+     * if the user creates Submarine with Helm, the variable "namespace" will always be "default". 
+     */
     if (System.getenv("ENV_NAMESPACE") != null) { 
       namespace = System.getenv("ENV_NAMESPACE");
     }

--- a/submarine-server/server-api/src/main/java/org/apache/submarine/server/api/spec/ExperimentMeta.java
+++ b/submarine-server/server-api/src/main/java/org/apache/submarine/server/api/spec/ExperimentMeta.java
@@ -91,6 +91,7 @@ public class ExperimentMeta {
    * @param namespace namespace
    */
   public void setNamespace(String namespace) {
+    // TODO: Remove the function
     return;
   }
 

--- a/submarine-server/server-api/src/main/java/org/apache/submarine/server/api/spec/ExperimentMeta.java
+++ b/submarine-server/server-api/src/main/java/org/apache/submarine/server/api/spec/ExperimentMeta.java
@@ -91,7 +91,7 @@ public class ExperimentMeta {
    * @param namespace namespace
    */
   public void setNamespace(String namespace) {
-    // TODO: Remove the function
+    // TODO(kevin85421): Remove the function
     return;
   }
 

--- a/submarine-server/server-core/src/main/java/org/apache/submarine/server/rest/provider/YamlEntityProvider.java
+++ b/submarine-server/server-core/src/main/java/org/apache/submarine/server/rest/provider/YamlEntityProvider.java
@@ -36,14 +36,11 @@ import java.io.OutputStreamWriter;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import java.util.Scanner;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @Provider
 @Consumes({"application/yaml", MediaType.TEXT_PLAIN})
 @Produces({"application/yaml", MediaType.TEXT_PLAIN})
 public class YamlEntityProvider<T> implements MessageBodyWriter<T>, MessageBodyReader<T> {
-  private static final Logger LOG = LoggerFactory.getLogger(YamlEntityProvider.class);
 
   @Override
   public boolean isReadable(Class<?> type, Type genericType,

--- a/submarine-server/server-core/src/main/java/org/apache/submarine/server/rest/provider/YamlEntityProvider.java
+++ b/submarine-server/server-core/src/main/java/org/apache/submarine/server/rest/provider/YamlEntityProvider.java
@@ -58,9 +58,7 @@ public class YamlEntityProvider<T> implements MessageBodyWriter<T>, MessageBodyR
       MultivaluedMap<String, String> httpHeaders, InputStream entityStream)
       throws WebApplicationException {
     Yaml yaml = new Yaml();
-    String entityStreamString = toString(entityStream);
-    LOG.info("YAML readFrom: {}", entityStreamString); 
-    T t = yaml.loadAs(entityStreamString, type);
+    T t = yaml.loadAs(toString(entityStream), type);
     return t;
   }
 

--- a/submarine-server/server-core/src/main/java/org/apache/submarine/server/rest/provider/YamlEntityProvider.java
+++ b/submarine-server/server-core/src/main/java/org/apache/submarine/server/rest/provider/YamlEntityProvider.java
@@ -36,11 +36,14 @@ import java.io.OutputStreamWriter;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import java.util.Scanner;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Provider
 @Consumes({"application/yaml", MediaType.TEXT_PLAIN})
 @Produces({"application/yaml", MediaType.TEXT_PLAIN})
 public class YamlEntityProvider<T> implements MessageBodyWriter<T>, MessageBodyReader<T> {
+  private static final Logger LOG = LoggerFactory.getLogger(YamlEntityProvider.class);
 
   @Override
   public boolean isReadable(Class<?> type, Type genericType,
@@ -55,7 +58,9 @@ public class YamlEntityProvider<T> implements MessageBodyWriter<T>, MessageBodyR
       MultivaluedMap<String, String> httpHeaders, InputStream entityStream)
       throws WebApplicationException {
     Yaml yaml = new Yaml();
-    T t = yaml.loadAs(toString(entityStream), type);
+    String entityStreamString = toString(entityStream);
+    LOG.info("YAML readFrom: {}", entityStreamString); 
+    T t = yaml.loadAs(entityStreamString, type);
     return t;
   }
 

--- a/submarine-server/server-core/src/test/java/org/apache/submarine/server/rest/ExperimentRestApiTest.java
+++ b/submarine-server/server-core/src/test/java/org/apache/submarine/server/rest/ExperimentRestApiTest.java
@@ -222,6 +222,7 @@ public class ExperimentRestApiTest {
     assertEquals(experimentFinishedTime, experiment.getFinishedTime());
     assertEquals(metaName, experiment.getSpec().getMeta().getName());
     assertEquals(metaFramework, experiment.getSpec().getMeta().getFramework());
+    assertEquals("default", experiment.getSpec().getMeta().getNamespace());
     assertEquals(dockerImage, experiment.getSpec().getEnvironment().getDockerImage());
     assertEquals(kernelChannels, experiment.getSpec().getEnvironment().getKernelSpec().getChannels());
     assertEquals(kernelSpecName, experiment.getSpec().getEnvironment().getKernelSpec().getName());

--- a/submarine-server/server-core/src/test/java/org/apache/submarine/server/rest/ExperimentRestApiTest.java
+++ b/submarine-server/server-core/src/test/java/org/apache/submarine/server/rest/ExperimentRestApiTest.java
@@ -75,7 +75,6 @@ public class ExperimentRestApiTest {
   private static final String experimentStatus = "Succeeded";
   private static final String metaName = "foo";
   private static final String metaFramework = "TensorFlow";
-  private static final String metaNamespace = "fooNamespace";
   private static final String dockerImage = "continuumio/anaconda3";
   private static final String kernelSpecName = "team_default_python_3";
   private static final List<String> kernelChannels = Arrays.asList("defaults", "anaconda");
@@ -117,7 +116,6 @@ public class ExperimentRestApiTest {
     kernelSpec.setPipDependencies(kernelPipDependencies);
     meta.setName(metaName);
     meta.setFramework(metaFramework);
-    meta.setNamespace(metaNamespace);
     environmentSpec.setDockerImage(dockerImage);
     environmentSpec.setKernelSpec(kernelSpec);
     experimentSpec.setMeta(meta);
@@ -224,7 +222,6 @@ public class ExperimentRestApiTest {
     assertEquals(experimentFinishedTime, experiment.getFinishedTime());
     assertEquals(metaName, experiment.getSpec().getMeta().getName());
     assertEquals(metaFramework, experiment.getSpec().getMeta().getFramework());
-    assertEquals(metaNamespace, experiment.getSpec().getMeta().getNamespace());
     assertEquals(dockerImage, experiment.getSpec().getEnvironment().getDockerImage());
     assertEquals(kernelChannels, experiment.getSpec().getEnvironment().getKernelSpec().getChannels());
     assertEquals(kernelSpecName, experiment.getSpec().getEnvironment().getKernelSpec().getName());

--- a/submarine-workbench/workbench-web/src/app/interfaces/experiment-spec.ts
+++ b/submarine-workbench/workbench-web/src/app/interfaces/experiment-spec.ts
@@ -20,7 +20,6 @@
 export interface ExperimentMeta {
   name: string;
   description?: string;
-  namespace: string;
   framework: string;
   cmd: string;
   envVars?: {

--- a/submarine-workbench/workbench-web/src/app/pages/workbench/experiment/experiment-home/experiment-form/experiment-customized-form/experiment-customized-form.component.html
+++ b/submarine-workbench/workbench-web/src/app/pages/workbench/experiment/experiment-home/experiment-form/experiment-customized-form/experiment-customized-form.component.html
@@ -102,15 +102,6 @@
           </button>
         </div>
         <div *ngIf="ADVANCED" class="single-field-group">
-          <label for="namespace">
-            <span class="red-star">*</span>
-            Namespace
-          </label>
-          <nz-select formControlName="namespace" id="namespace">
-            <nz-option *ngFor="let namespace of nameSpaceList" [nzValue]="namespace" [nzLabel]="namespace"></nz-option>
-          </nz-select>
-        </div>
-        <div *ngIf="ADVANCED" class="single-field-group">
           <label for="git-repo">Git repository</label>
           <nz-input-group [nzSuffix]="suffixTemplateInfo">
             <input
@@ -273,7 +264,6 @@
       <div *ngSwitchCase="2" id="previewPage">
         <nz-descriptions nzTitle="{{ jobTypes }}" nzBordered [nzColumn]="{ xxl: 2, xl: 2, lg: 2, md: 2, sm: 2, xs: 1 }">
           <nz-descriptions-item nzTitle="Name">{{ finalExperimentSpec.meta.name }}</nz-descriptions-item>
-          <nz-descriptions-item nzTitle="Namespace">{{ finalExperimentSpec.meta.namespace }}</nz-descriptions-item>
           <nz-descriptions-item nzTitle="Command" [nzSpan]="2">
             {{ finalExperimentSpec.meta.cmd }}
           </nz-descriptions-item>

--- a/submarine-workbench/workbench-web/src/app/pages/workbench/experiment/experiment-home/experiment-form/experiment-customized-form/experiment-customized-form.component.ts
+++ b/submarine-workbench/workbench-web/src/app/pages/workbench/experiment/experiment-home/experiment-form/experiment-customized-form/experiment-customized-form.component.ts
@@ -47,10 +47,6 @@ export class ExperimentCustomizedFormComponent implements OnInit, OnDestroy {
   step: number = 0;
   subscriptions: Subscription[] = [];
 
-  // TODO: Fetch all namespaces from submarine server
-  defaultNameSpace = 'default';
-  nameSpaceList = [this.defaultNameSpace, 'submarine'];
-
   // TODO: Fetch all images from submarine server
   imageIndex = 0;
   defaultImage = 'apache/submarine:tf-mnist-with-summaries-1.0';
@@ -90,7 +86,6 @@ export class ExperimentCustomizedFormComponent implements OnInit, OnDestroy {
     this.experiment = new FormGroup({
       experimentName: new FormControl(null, [Validators.pattern('[a-zA-Z0-9\-]*'), Validators.required]),
       description: new FormControl(null, [Validators.required]),
-      namespace: new FormControl(this.defaultNameSpace, [Validators.required]),
       cmd: new FormControl('', [Validators.required]),
       image: new FormControl(this.defaultImage, [Validators.required]),
       envs: new FormArray([], [this.experimentValidatorService.nameValidatorFactory('key')]),
@@ -156,9 +151,6 @@ export class ExperimentCustomizedFormComponent implements OnInit, OnDestroy {
   get description() {
     return this.experiment.get('description');
   }
-  get namespace() {
-    return this.experiment.get('namespace');
-  }
   get cmd() {
     return this.experiment.get('cmd');
   }
@@ -189,7 +181,6 @@ export class ExperimentCustomizedFormComponent implements OnInit, OnDestroy {
     if (this.step === 0) {
       this.experimentFormService.btnStatusChange(
         this.experimentName.invalid ||
-          this.namespace.invalid ||
           this.cmd.invalid ||
           this.image.invalid ||
           this.envs.invalid
@@ -323,7 +314,7 @@ export class ExperimentCustomizedFormComponent implements OnInit, OnDestroy {
     // Construct the spec
     const meta: ExperimentMeta = {
       name: this.experimentName.value.toLowerCase(),
-      namespace: this.namespace.value,
+      namespace: "default",
       framework: this.framework === 'Standalone' ? 'Tensorflow' : this.framework,
       cmd: this.cmd.value,
       envVars: {}
@@ -404,7 +395,6 @@ export class ExperimentCustomizedFormComponent implements OnInit, OnDestroy {
 
   cloneExperiment(spec: ExperimentSpec) {
     this.description.setValue(spec.meta.description);
-    this.namespace.setValue(spec.meta.namespace);
     this.cmd.setValue(spec.meta.cmd);
     this.image.setValue(spec.environment.image);
     if (this.imageList.indexOf(spec.environment.image) === -1) {

--- a/submarine-workbench/workbench-web/src/app/pages/workbench/experiment/experiment-home/experiment-form/experiment-customized-form/experiment-customized-form.component.ts
+++ b/submarine-workbench/workbench-web/src/app/pages/workbench/experiment/experiment-home/experiment-form/experiment-customized-form/experiment-customized-form.component.ts
@@ -314,7 +314,6 @@ export class ExperimentCustomizedFormComponent implements OnInit, OnDestroy {
     // Construct the spec
     const meta: ExperimentMeta = {
       name: this.experimentName.value.toLowerCase(),
-      namespace: "default",
       framework: this.framework === 'Standalone' ? 'Tensorflow' : this.framework,
       cmd: this.cmd.value,
       envVars: {}

--- a/submarine-workbench/workbench-web/src/app/pages/workbench/experiment/experiment-home/experiment-form/experiment-predefined-form/experiment-predefined-form.component.ts
+++ b/submarine-workbench/workbench-web/src/app/pages/workbench/experiment/experiment-home/experiment-form/experiment-predefined-form/experiment-predefined-form.component.ts
@@ -34,7 +34,6 @@ interface ParsedTemplate {
     value: string;
   }[];
   experimentName: string;
-  experimentNamespace: string;
   experimentCommand: string;
   experimentImage: string;
   experimentVars: string;
@@ -130,7 +129,6 @@ export class ExperimentPredefinedFormComponent implements OnInit, OnDestroy {
       let template: ParsedTemplate = {
         templateParams: item.experimentTemplateSpec.parameters.filter((item) => !item.name.startsWith('spec.')),
         experimentName: item.experimentTemplateSpec.experimentSpec.meta.name,
-        experimentNamespace: item.experimentTemplateSpec.experimentSpec.meta.namespace,
         experimentCommand: item.experimentTemplateSpec.experimentSpec.meta.cmd,
         experimentImage: item.experimentTemplateSpec.experimentSpec.environment.image,
         experimentVars: JSON.stringify(item.experimentTemplateSpec.experimentSpec.meta.envVars),

--- a/submarine-workbench/workbench-web/src/app/pages/workbench/template/template-home/template-form/template-form.component.ts
+++ b/submarine-workbench/workbench-web/src/app/pages/workbench/template/template-home/template-form/template-form.component.ts
@@ -54,7 +54,6 @@ export class TemplateFormComponent implements OnInit {
   MEMORY_UNITS = ['M', 'G'];
 
   AUTHOR = 'admin';
-  NAMESPACE = 'default';
 
   constructor(
     private experimentValidatorService: ExperimentValidatorService,
@@ -254,7 +253,6 @@ export class TemplateFormComponent implements OnInit {
           name: this.defaultExperimentName,
           envVars: envVars,
           framework: this.framework,
-          namespace: this.NAMESPACE,
         },
         spec: specs,
         environment: {


### PR DESCRIPTION
### What is this PR for?
In our multi-tenant architecture, users only can create experiments in their namespaces, but the Submarine workbench enables users to specify namespaces.
![截圖 2021-08-08 上午10 17 13](https://user-images.githubusercontent.com/20109646/128638163-c3d30a53-5e21-4460-b2a3-3ded61d49d6e.png)

This patch aims to 

### What type of PR is it?
[Bug Fix]

### Todos
1. Remove the function `public void setNamespace(String namespace)` in ExperimentMeta.java
2. Update experiment RESTful API (remove the field "namespace" in the JSON file)
3. Add a test case to make sure whether the experiment is in the namespace specified by `ENV_NAMESPACE`.

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-965

### How should this be tested?
**Test1**
* Step1: Use submarine-operator to create a submarine service in the namespace "submarine-user-test"
* Step2: Create an experiment, and check whether the experiment is in the namespace "submarine-user-test" rather than "default".

<img width="1439" alt="截圖 2021-08-08 下午11 57 35" src="https://user-images.githubusercontent.com/20109646/128640083-61ffc46d-fc26-4f22-8769-8202092c6574.png">

**Test2**
* Remove the field "namespace" in the Submarine workbench


### Screenshots (if appropriate)
<img width="1439" alt="截圖 2021-08-08 下午11 57 35" src="https://user-images.githubusercontent.com/20109646/128640083-61ffc46d-fc26-4f22-8769-8202092c6574.png">

<img width="994" alt="截圖 2021-08-09 上午1 19 46" src="https://user-images.githubusercontent.com/20109646/128640160-58a94857-346d-4ce9-8d14-97edeb4de26e.png">

### Questions:
* Do the license files need updating? No
* Are there breaking changes for older versions? No
* Does this need new documentation? No
