### PR TITLE
SUBMARINE-954. Experiments and notebooks are still alive after submarine is deleted

### DIFF
--- a/submarine-cloud-v2/pkg/controller/submarine_server.go
+++ b/submarine-cloud-v2/pkg/controller/submarine_server.go
@@ -75,11 +75,13 @@ func newSubmarineServerDeployment(submarine *v1alpha1.Submarine) *appsv1.Deploym
 		serverImage = "apache/submarine:server-" + submarine.Spec.Version
 	}
 
+	ownerReference := *metav1.NewControllerRef(submarine, v1alpha1.SchemeGroupVersion.WithKind("Submarine"))
+
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: serverName,
 			OwnerReferences: []metav1.OwnerReference{
-				*metav1.NewControllerRef(submarine, v1alpha1.SchemeGroupVersion.WithKind("Submarine")),
+				ownerReference,
 			},
 		},
 		Spec: appsv1.DeploymentSpec{
@@ -121,6 +123,22 @@ func newSubmarineServerDeployment(submarine *v1alpha1.Submarine) *appsv1.Deploym
 								{
 									Name:  "ENV_NAMESPACE",
 									Value: submarine.Namespace,
+								},
+								{
+									Name:  "SUBMARINE_APIVERSION",
+									Value: ownerReference.APIVersion,
+								},
+								{
+									Name:  "SUBMARINE_KIND",
+									Value: ownerReference.Kind,
+								},
+								{
+									Name:  "SUBMARINE_NAME",
+									Value: ownerReference.Name,
+								},
+								{
+									Name:  "SUBMARINE_UID",
+									Value: string(ownerReference.UID),
 								},
 							},
 							Ports: []corev1.ContainerPort{

--- a/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/util/OwnerReferenceUtils.java
+++ b/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/util/OwnerReferenceUtils.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.submarine.server.submitter.k8s.util;
+
+import java.util.ArrayList;
+
+import io.kubernetes.client.models.V1OwnerReference;
+
+public class OwnerReferenceUtils {
+  private static final String SUBMARINE_APIVERSION = "SUBMARINE_APIVERSION";
+  private static final String SUBMARINE_KIND = "SUBMARINE_KIND";
+  private static final String SUBMARINE_NAME = "SUBMARINE_NAME";
+  private static final String SUBMARINE_UID = "SUBMARINE_UID";
+
+  public static ArrayList<V1OwnerReference> getOwnerReference() {
+    ArrayList<V1OwnerReference> ownerReferences = new ArrayList<>();
+    V1OwnerReference owner = new V1OwnerReference();
+    if (System.getenv(SUBMARINE_UID) != null) {
+      String apiVersion = System.getenv(SUBMARINE_APIVERSION);
+      String kind = System.getenv(SUBMARINE_KIND);
+      String name = System.getenv(SUBMARINE_NAME);
+      String uid = System.getenv(SUBMARINE_UID);
+      Boolean blockOwnerDeletion = true;
+      Boolean controller = true;
+      owner.setApiVersion(apiVersion);
+      owner.setKind(kind);
+      owner.setName(name);
+      owner.setUid(uid);
+      owner.setBlockOwnerDeletion(blockOwnerDeletion);
+      owner.setController(controller);
+      ownerReferences.add(owner);
+    }
+    return ownerReferences;
+  }
+}


### PR DESCRIPTION
### What is this PR for?
<!-- A few sentences describing the overall goals of the pull request's commits.
First time? Check out the contributing guide - https://submarine.apache.org/contribution/contributions.html
-->

After the submarine is down, we can find that the experiment and notebook pods are still alive in the cluster. 

Reproduce steps:

1. create a submarine
2. access to the workbench by port forwarding
3. add notebook or experiment from the workbench
4. delete submarine
5. we can find out that notebooks, tfjobs, pytorchjobs and relating components are still alive.

To fix the bug, we can maybe add onwerReferences to the created resources.

Reference:

ownerReference: https://kubernetes.io/docs/concepts/overview/working-with-objects/owners-dependents/

ps. This only works on submarine created by submarine-operator. If you use helm to install submarine, you should clean up by yourself.

### What type of PR is it?
[Bug Fix]

### Todos
* [x] - add submarine custom resource apiVersion, kind, name and uid to submarine-server's environment on creating deployment by submarine-operator
* [x] - set ownerReference on creating notebooks (including persistentVolumeClaim, ingressroute) and MLJobs

### What is the Jira issue?
<!-- * Open an issue on Jira https://issues.apache.org/jira/browse/SUBMARINE/
* Put link here, and add [SUBMARINE-*Jira number*] in PR title, eg. `SUBMARINE-23. PR title`
-->
https://issues.apache.org/jira/browse/SUBMARINE-954

### How should this be tested?
<!--
* First time? Setup Travis CI as described on https://submarine.apache.org/contribution/contributions.html#continuous-integration
* Strongly recommended: add automated unit tests for any new or changed behavior
* Outline any manual steps to test the PR here.
-->

1. Follow submarine-operator [README.md](https://github.com/apache/submarine/tree/master/submarine-cloud-v2) to setup submarine
2. Create notebooks and experiments
3. Delete submarine custom resource

And you can find out that all the stuff was deleted.

### Screenshots (if appropriate)


https://user-images.githubusercontent.com/17617373/128871152-854a6813-3a4a-445c-ae26-e98aae91876f.mov



### Questions:
* Do the license files need updating? No
* Are there breaking changes for older versions? No
* Does this need new documentation? No
