### PR TITLE
SUBMARINE-975. Create storageClass for database, minio, tensorboard to control persistentVolume

### DIFF
--- a/submarine-cloud-v2/helm-charts/submarine-operator/templates/rbac.yaml
+++ b/submarine-cloud-v2/helm-charts/submarine-operator/templates/rbac.yaml
@@ -56,7 +56,6 @@ rules:
       - namespaces
       - jobs
       - serviceaccounts
-      - persistentvolumes
       - persistentvolumeclaims
       - pods/portforward
       - events
@@ -78,8 +77,8 @@ rules:
   - apiGroups:
       - "rbac.authorization.k8s.io"
     resources:
-      - clusterroles
-      - clusterrolebindings
+      - roles
+      - rolebindings
     verbs:
       - "*"
   - apiGroups:

--- a/submarine-cloud-v2/helm-charts/submarine-operator/templates/storageclass.yaml
+++ b/submarine-cloud-v2/helm-charts/submarine-operator/templates/storageclass.yaml
@@ -1,0 +1,45 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: submarine-database-sc
+provisioner: k8s.io/minikube-hostpath
+reclaimPolicy: Delete
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: submarine-tensorboard-sc
+provisioner: k8s.io/minikube-hostpath
+reclaimPolicy: Delete
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: submarine-mlflow-sc
+provisioner: k8s.io/minikube-hostpath
+reclaimPolicy: Delete
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: submarine-minio-sc
+provisioner: k8s.io/minikube-hostpath
+reclaimPolicy: Delete
+

--- a/submarine-cloud-v2/main.go
+++ b/submarine-cloud-v2/main.go
@@ -91,7 +91,6 @@ func main() {
 		kubeInformerFactory.Apps().V1().Deployments(),
 		kubeInformerFactory.Core().V1().Services(),
 		kubeInformerFactory.Core().V1().ServiceAccounts(),
-		kubeInformerFactory.Core().V1().PersistentVolumes(),
 		kubeInformerFactory.Core().V1().PersistentVolumeClaims(),
 		kubeInformerFactory.Extensions().V1beta1().Ingresses(),
 		traefikInformerFactory.Traefik().V1alpha1().IngressRoutes(),

--- a/submarine-cloud-v2/pkg/controller/submarine_database.go
+++ b/submarine-cloud-v2/pkg/controller/submarine_database.go
@@ -43,7 +43,7 @@ func newSubmarineDatabasePersistentVolumeClaim(submarine *v1alpha1.Submarine) *c
 		},
 		Spec: corev1.PersistentVolumeClaimSpec{
 			AccessModes: []corev1.PersistentVolumeAccessMode{
-				corev1.ReadWriteOnce,
+				corev1.ReadWriteMany,
 			},
 			Resources: corev1.ResourceRequirements{
 				Requests: corev1.ResourceList{

--- a/submarine-cloud-v2/pkg/controller/submarine_mlflow.go
+++ b/submarine-cloud-v2/pkg/controller/submarine_mlflow.go
@@ -32,46 +32,8 @@ import (
 	"k8s.io/klog/v2"
 )
 
-func newSubmarineMlflowPersistentVolume(submarine *v1alpha1.Submarine) *corev1.PersistentVolume {
-	var persistentVolumeSource corev1.PersistentVolumeSource
-	switch submarine.Spec.Storage.StorageType {
-	case "nfs":
-		persistentVolumeSource = corev1.PersistentVolumeSource{
-			NFS: &corev1.NFSVolumeSource{
-				Server: submarine.Spec.Storage.NfsIP,
-				Path:   submarine.Spec.Storage.NfsPath,
-			},
-		}
-	case "host":
-		hostPathType := corev1.HostPathDirectoryOrCreate
-		persistentVolumeSource = corev1.PersistentVolumeSource{
-			HostPath: &corev1.HostPathVolumeSource{
-				Path: submarine.Spec.Storage.HostPath,
-				Type: &hostPathType,
-			},
-		}
-	}
-	return &corev1.PersistentVolume{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: pvName(mlflowPvNamePrefix, submarine.Namespace),
-			OwnerReferences: []metav1.OwnerReference{
-				*metav1.NewControllerRef(submarine, v1alpha1.SchemeGroupVersion.WithKind("Submarine")),
-			},
-		},
-		Spec: corev1.PersistentVolumeSpec{
-			AccessModes: []corev1.PersistentVolumeAccessMode{
-				corev1.ReadWriteMany,
-			},
-			Capacity: corev1.ResourceList{
-				corev1.ResourceStorage: resource.MustParse(submarine.Spec.Mlflow.StorageSize),
-			},
-			PersistentVolumeSource: persistentVolumeSource,
-		},
-	}
-}
-
 func newSubmarineMlflowPersistentVolumeClaim(submarine *v1alpha1.Submarine) *corev1.PersistentVolumeClaim {
-	storageClassName := ""
+	storageClassName := mlflowScName
 	return &corev1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: mlflowPvcName,
@@ -88,7 +50,6 @@ func newSubmarineMlflowPersistentVolumeClaim(submarine *v1alpha1.Submarine) *cor
 					corev1.ResourceStorage: resource.MustParse(submarine.Spec.Mlflow.StorageSize),
 				},
 			},
-			VolumeName:       pvName(mlflowPvNamePrefix, submarine.Namespace),
 			StorageClassName: &storageClassName,
 		},
 	}
@@ -219,33 +180,7 @@ func newSubmarineMlflowIngressRoute(submarine *v1alpha1.Submarine) *traefikv1alp
 func (c *Controller) createSubmarineMlflow(submarine *v1alpha1.Submarine) error {
 	klog.Info("[createSubmarineMlflow]")
 
-	// Step 1: Create PersistentVolume
-	// PersistentVolumes are not namespaced resources, so we add the namespace
-	// as a suffix to distinguish them
-	pv, err := c.persistentvolumeLister.Get(pvName(mlflowPvNamePrefix, submarine.Namespace))
-
-	// If the resource doesn't exist, we'll create it
-	if errors.IsNotFound(err) {
-		pv, err = c.kubeclientset.CoreV1().PersistentVolumes().Create(context.TODO(), newSubmarineMlflowPersistentVolume(submarine), metav1.CreateOptions{})
-		if err != nil {
-			klog.Info(err)
-		}
-		klog.Info(" Create PersistentVolume: ", pv.Name)
-	}
-	// If an error occurs during Get/Create, we'll requeue the item so we can
-	// attempt processing again later. This could have been caused by a
-	// temporary network failure, or any other transient reason.
-	if err != nil {
-		return err
-	}
-
-	if !metav1.IsControlledBy(pv, submarine) {
-		msg := fmt.Sprintf(MessageResourceExists, pv.Name)
-		c.recorder.Event(submarine, corev1.EventTypeWarning, ErrResourceExists, msg)
-		return fmt.Errorf(msg)
-	}
-
-	// Step 2: Create PersistentVolumeClaim
+	// Step 1: Create PersistentVolumeClaim
 	pvc, err := c.persistentvolumeclaimLister.PersistentVolumeClaims(submarine.Namespace).Get(mlflowPvcName)
 	// If the resource doesn't exist, we'll create it
 	if errors.IsNotFound(err) {
@@ -270,7 +205,7 @@ func (c *Controller) createSubmarineMlflow(submarine *v1alpha1.Submarine) error 
 		return fmt.Errorf(msg)
 	}
 
-	// Step 3: Create Deployment
+	// Step 2: Create Deployment
 	deployment, err := c.deploymentLister.Deployments(submarine.Namespace).Get(mlflowName)
 	if errors.IsNotFound(err) {
 		deployment, err = c.kubeclientset.AppsV1().Deployments(submarine.Namespace).Create(context.TODO(), newSubmarineMlflowDeployment(submarine), metav1.CreateOptions{})
@@ -292,7 +227,7 @@ func (c *Controller) createSubmarineMlflow(submarine *v1alpha1.Submarine) error 
 		return fmt.Errorf(msg)
 	}
 
-	// Step 4: Create Service
+	// Step 3: Create Service
 	service, err := c.serviceLister.Services(submarine.Namespace).Get(mlflowServiceName)
 	// If the resource doesn't exist, we'll create it
 	if errors.IsNotFound(err) {
@@ -315,7 +250,7 @@ func (c *Controller) createSubmarineMlflow(submarine *v1alpha1.Submarine) error 
 		return fmt.Errorf(msg)
 	}
 
-	// Step 5: Create IngressRoute
+	// Step 4: Create IngressRoute
 	ingressroute, err := c.ingressrouteLister.IngressRoutes(submarine.Namespace).Get(mlflowIngressRouteName)
 	// If the resource doesn't exist, we'll create it
 	if errors.IsNotFound(err) {


### PR DESCRIPTION
### What is this PR for?
<!-- A few sentences describing the overall goals of the pull request's commits.
First time? Check out the contributing guide - https://submarine.apache.org/contribution/contributions.html
-->

To create persistent volumes, submarine-operator creates persistent volumes with different names depending on the namespace (eg. `submarine-database-pv–default`)

However, we can use storage class to create persistent volumes dynamically and delete them easily.

This will be implemented only on the submarine operator. Besides, only minikube support the current storage class provisioner, and volumes can only be in the host (nfs not supported).

### What type of PR is it?
[Improvement]

### Todos
- [x] Add storage class
- [x] Modify operator to create persistent volume claim with storage class name
- [x] Remove persistent volume creation in operator

### What is the Jira issue?
<!-- * Open an issue on Jira https://issues.apache.org/jira/browse/SUBMARINE/
* Put link here, and add [SUBMARINE-*Jira number*] in PR title, eg. `SUBMARINE-23. PR title`
-->

https://issues.apache.org/jira/browse/SUBMARINE-975

### How should this be tested?
<!--
* First time? Setup Travis CI as described on https://submarine.apache.org/contribution/contributions.html#continuous-integration
* Strongly recommended: add automated unit tests for any new or changed behavior
* Outline any manual steps to test the PR here.
-->

Follow submarine-operator instructions.

### Screenshots (if appropriate)

https://user-images.githubusercontent.com/17617373/129319157-5923ebcf-cdf4-45ae-b18c-e3cc0eb45b16.mov

### Questions:
* Do the license files need updating? No
* Are there breaking changes for older versions? No
* Does this need new documentation? No
