### PR TITLE
SUBMARINE-977. Fix sonarcloud workflow run error

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -18,8 +18,7 @@ on:
   push:
     branches:
       - master
-  pull_request:
-    types: [opened, synchronize, reopened]
+
 jobs:
   sonarcloud:
     if: github.repository == 'apache/submarine'
@@ -29,11 +28,35 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
-      - name: print secret
-        run: echo "${{ secrets.SONARCLOUD_TOKEN }}" && echo "${{ secrets.SONAR_TOKEN }}"
-      - name: SonarCloud Scan
-        uses: SonarSource/sonarcloud-github-action@master
+      - name: Cache Maven packages
+        uses: actions/cache@v1
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+      - name: Cache SonarCloud packages
+        uses: actions/cache@v1
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: "1.8"
+      - name: Set up Maven 3.6.3
+        uses: stCarolas/setup-maven@v4
+        with:
+          maven-version: 3.6.3
+      - name: Build the project with JDK 8
+        run: mvn clean install -DskipTests
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - name: Build and analyze with JDK 11 # sonar-maven-plugin only support JDK 11
+        run: mvn verify -DskipTests org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -pl $EXCLUDE_MODULE -Dsonar.host.url=https://sonarcloud.io -Dsonar.organization=apache -Dsonar.projectKey=apache_submarine
         env:
           SONAR_TOKEN: ${{ secrets.SONARCLOUD_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          
+          EXCLUDE_MODULE: '!:submarine-commons-rpc,!:submarine-spark-security' # Exclude the modules that can't be compiled with JDK 11


### PR DESCRIPTION
### What is this PR for?
<!-- A few sentences describing the overall goals of the pull request's commits.
First time? Check out the contributing guide - https://submarine.apache.org/contribution/contributions.html
-->
https://github.com/apache/submarine/runs/3329896724
sonar-maven-plugin only supports JDK 11, so exclude the module that can not be compiled with JDK 11

1. Build the project with jdk8
2. Change to jdk11
3. Run `mvn verify -DskipTests org.sonarsource.scanner.maven:sonar-maven-plugin:sonar` with JDK 11 to upload result to sonarcloud

### What type of PR is it?
[Bug Fix ]

### Todos
No

### What is the Jira issue?
<!-- * Open an issue on Jira https://issues.apache.org/jira/browse/SUBMARINE/
* Put link here, and add [SUBMARINE-*Jira number*] in PR title, eg. `SUBMARINE-23. PR title`
-->
https://issues.apache.org/jira/browse/SUBMARINE-977

### How should this be tested?
<!--
* First time? Setup Travis CI as described on https://submarine.apache.org/contribution/contributions.html#continuous-integration
* Strongly recommended: add automated unit tests for any new or changed behavior
* Outline any manual steps to test the PR here.
-->
Pass the CIs, and I successfully upload the result to my sonarcloud
https://sonarcloud.io/dashboard?id=pingsutw_hadoop-submarine
 
### Screenshots (if appropriate)

### Questions:
* Do the license files need updating? No
* Are there breaking changes for older versions? No
* Does this need new documentation? No
