### PR TITLE
SUBMARINE-992. Change minio docker image

### DIFF
--- a/helm-charts/submarine/templates/submarine-minio.yaml
+++ b/helm-charts/submarine/templates/submarine-minio.yaml
@@ -64,7 +64,7 @@ spec:
     spec:
       containers:
       - name: submarine-minio-container
-        image: minio/minio:latest
+        image: minio/minio:RELEASE.2021-02-14T04-01-33Z
         imagePullPolicy: IfNotPresent
         args:
         - server


### PR DESCRIPTION
### What is this PR for?
Submarine minio is using minio charts' `helm chart` which is archived after April 2021 (https://github.com/minio/charts)
However the new package `minio operator` is using Kubernetes 1.19+, we should use the docker image which minio charts can support.

### What type of PR is it?
[Bug Fix]

### Todos


### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-992

### How should this be tested?
Check the http://localhost:32080/minio link is working

### Screenshots (if appropriate)
https://user-images.githubusercontent.com/38066413/130038984-68a92f2a-af50-470f-8c95-7b548998f5dc.mp4

### Questions:
* Do the license files need updating? No
* Are there breaking changes for older versions? No
* Does this need new documentation? No
