### PR TITLE
SUBMARINE-995. Fix website project name

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -26,7 +26,7 @@ module.exports = {
   onBrokenMarkdownLinks: 'warn',
   favicon: 'img/submarine.ico',
   organizationName: 'apache', // Usually your GitHub org/user name.
-  projectName: 'submarine', // Usually your repo name.
+  projectName: 'submarine-site', // Don't change the project name, the website will be updated to submarine-site repo
   themeConfig: {
     navbar: {
       title: 'Apache Submarine',


### PR DESCRIPTION
### What is this PR for?
The project name of submarine website must be `submarine-site` not `submarine`.

### What type of PR is it?
[Bug Fix]

### Todos


### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-995

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* Do the license files need updating? No
* Are there breaking changes for older versions? No
* Does this need new documentation? No
