### PR TITLE
SUBMARINE-996. Submarine logo 404 not found

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -32,7 +32,7 @@ module.exports = {
       title: 'Apache Submarine',
       logo: {
         alt: 'Apache Submarine Site Logo',
-        src: 'https://github.com/apache/submarine/blob/master/website/docs/assets/128-black.png?raw=true',
+        src: 'img/icons/128.png',
       },
       items: [
         {


### PR DESCRIPTION
### What is this PR for?

The submarine logo image cannot be loaded on submarine.apache.org

![image](https://user-images.githubusercontent.com/47914085/131091594-73756df1-ed08-4099-90d6-e196623c34d2.png)

### What type of PR is it?
[Bug Fix]

### Todos

### What is the Jira issue?

https://issues.apache.org/jira/projects/SUBMARINE/issues/SUBMARINE-996?filter=myopenissues

### How should this be tested?

### Screenshots (if appropriate)

Fixed:
![image](https://user-images.githubusercontent.com/47914085/131091550-16089890-e703-4868-bac8-54087903eec2.png)

### Questions:
* Do the license files need updating? No
* Are there breaking changes for older versions? No
* Does this need new documentation? No
