### PR TITLE
SUBMARINE-999. Make the submarine related storage class into one single storage class

### DIFF
--- a/helm-charts/submarine/templates/storageclass.yaml
+++ b/helm-charts/submarine/templates/storageclass.yaml
@@ -17,7 +17,7 @@
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  name: notebook-storageclass
+  name: submarine-storageclass
   labels:
     app: notebook-controller
 provisioner: k8s.io/minikube-hostpath

--- a/submarine-cloud-v2/helm-charts/submarine-operator/templates/storageclass.yaml
+++ b/submarine-cloud-v2/helm-charts/submarine-operator/templates/storageclass.yaml
@@ -18,30 +18,6 @@
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  name: submarine-database-sc
-{{- template "storageClass.fields" . }}
----
-apiVersion: storage.k8s.io/v1
-kind: StorageClass
-metadata:
-  name: submarine-tensorboard-sc
-{{- template "storageClass.fields" . }}
----
-apiVersion: storage.k8s.io/v1
-kind: StorageClass
-metadata:
-  name: submarine-mlflow-sc
-{{- template "storageClass.fields" . }}
----
-apiVersion: storage.k8s.io/v1
-kind: StorageClass
-metadata:
-  name: submarine-minio-sc
-{{- template "storageClass.fields" . }}
----
-apiVersion: storage.k8s.io/v1
-kind: StorageClass
-metadata:
-  name: notebook-storageclass
+  name: submarine-storageclass
 {{- template "storageClass.fields" . }}
 

--- a/submarine-cloud-v2/pkg/controller/controller.go
+++ b/submarine-cloud-v2/pkg/controller/controller.go
@@ -62,6 +62,8 @@ import (
 
 const controllerAgentName = "submarine-controller"
 
+const storageClassName = "submarine-storageclass"
+
 const (
 	serverName                  = "submarine-server"
 	databaseName                = "submarine-database"
@@ -69,17 +71,13 @@ const (
 	mlflowName                  = "submarine-mlflow"
 	minioName                   = "submarine-minio"
 	ingressName                 = serverName + "-ingress"
-	databaseScName              = databaseName + "-sc"
 	databasePvcName             = databaseName + "-pvc"
-	tensorboardScName           = tensorboardName + "-sc"
 	tensorboardPvcName          = tensorboardName + "-pvc"
 	tensorboardServiceName      = tensorboardName + "-service"
 	tensorboardIngressRouteName = tensorboardName + "-ingressroute"
-	mlflowScName                = mlflowName + "-sc"
 	mlflowPvcName               = mlflowName + "-pvc"
 	mlflowServiceName           = mlflowName + "-service"
 	mlflowIngressRouteName      = mlflowName + "-ingressroute"
-	minioScName                 = minioName + "-sc"
 	minioPvcName                = minioName + "-pvc"
 	minioServiceName            = minioName + "-service"
 	minioIngressRouteName       = minioName + "-ingressroute"

--- a/submarine-cloud-v2/pkg/controller/submarine_database.go
+++ b/submarine-cloud-v2/pkg/controller/submarine_database.go
@@ -33,7 +33,7 @@ import (
 )
 
 func newSubmarineDatabasePersistentVolumeClaim(submarine *v1alpha1.Submarine) *corev1.PersistentVolumeClaim {
-	storageClassName := databaseScName
+	storageClassName := storageClassName
 	return &corev1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: databasePvcName,

--- a/submarine-cloud-v2/pkg/controller/submarine_minio.go
+++ b/submarine-cloud-v2/pkg/controller/submarine_minio.go
@@ -35,7 +35,7 @@ import (
 )
 
 func newSubmarineMinioPersistentVolumeClaim(submarine *v1alpha1.Submarine) *corev1.PersistentVolumeClaim {
-	storageClassName := minioScName
+	storageClassName := storageClassName
 	return &corev1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: minioPvcName,

--- a/submarine-cloud-v2/pkg/controller/submarine_mlflow.go
+++ b/submarine-cloud-v2/pkg/controller/submarine_mlflow.go
@@ -33,7 +33,7 @@ import (
 )
 
 func newSubmarineMlflowPersistentVolumeClaim(submarine *v1alpha1.Submarine) *corev1.PersistentVolumeClaim {
-	storageClassName := mlflowScName
+	storageClassName := storageClassName
 	return &corev1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: mlflowPvcName,

--- a/submarine-cloud-v2/pkg/controller/submarine_tensorboard.go
+++ b/submarine-cloud-v2/pkg/controller/submarine_tensorboard.go
@@ -35,7 +35,7 @@ import (
 )
 
 func newSubmarineTensorboardPersistentVolumeClaim(submarine *v1alpha1.Submarine) *corev1.PersistentVolumeClaim {
-	storageClassName := tensorboardScName
+	storageClassName := storageClassName
 	return &corev1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: tensorboardPvcName,

--- a/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/util/NotebookUtils.java
+++ b/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/util/NotebookUtils.java
@@ -44,7 +44,7 @@ public class NotebookUtils {
 
   private static final Logger LOG = LoggerFactory.getLogger(NotebookUtils.class);
   public static final String STORAGE = "10Gi";
-  public static final String SC_NAME = "notebook-storageclass";
+  public static final String SC_NAME = "submarine-storageclass";
   public static final String STORAGE_PREFIX = "notebook-storage-";
   public static final String PV_PREFIX = "notebook-pv-";
   public static final String PVC_PREFIX = "notebook-pvc-";


### PR DESCRIPTION
### What is this PR for?
<!-- A few sentences describing the overall goals of the pull request's commits.
First time? Check out the contributing guide - https://submarine.apache.org/contribution/contributions.html
-->

There are five storage class in helm charts for submarine (server, database, tensorboard, mlflow, minio, notebook).

However, they all have the same configurations, so we can just use one storage class instead.

### What type of PR is it?
[Improvement]

### Todos


### What is the Jira issue?
<!-- * Open an issue on Jira https://issues.apache.org/jira/browse/SUBMARINE/
* Put link here, and add [SUBMARINE-*Jira number*] in PR title, eg. `SUBMARINE-23. PR title`
-->

https://issues.apache.org/jira/browse/SUBMARINE-999

### How should this be tested?
<!--
* First time? Setup Travis CI as described on https://submarine.apache.org/contribution/contributions.html#continuous-integration
* Strongly recommended: add automated unit tests for any new or changed behavior
* Outline any manual steps to test the PR here.
-->

1. Install submarine operator
2. Add a submarine custom resource
3. Create a notebook from the workbench

You can find out that everything works fine. 

### Screenshots (if appropriate)

The only storage class:

<img width="803" alt="Screen Shot 2021-08-27 at 4 51 59 PM" src="https://user-images.githubusercontent.com/17617373/131100653-b68202d2-6574-4b68-b0c5-a1b22e511482.png">

### Questions:
* Do the license files need updating? No
* Are there breaking changes for older versions? No
* Does this need new documentation? No
