### PR TITLE
SUBMARINE-998. NanoID for experiment name

### DIFF
--- a/submarine-workbench/workbench-web/package.json
+++ b/submarine-workbench/workbench-web/package.json
@@ -27,6 +27,7 @@
     "lodash": "^4.17.19",
     "md5": "^2.2.1",
     "nanoid": "^3.1.12",
+    "nanoid-dictionary": "^4.3.0",
     "ng-zorro-antd": "8.5.2",
     "rxjs": "~6.4.0",
     "tslib": "^1.10.0",

--- a/submarine-workbench/workbench-web/src/app/pages/workbench/experiment/experiment-home/experiment-form/experiment-customized-form/experiment-customized-form.component.ts
+++ b/submarine-workbench/workbench-web/src/app/pages/workbench/experiment/experiment-home/experiment-form/experiment-customized-form/experiment-customized-form.component.ts
@@ -29,7 +29,8 @@ import {
 import { ExperimentFormService } from '@submarine/services/experiment.form.service';
 import { ExperimentService } from '@submarine/services/experiment.service';
 import { ExperimentValidatorService } from '@submarine/services/experiment.validator.service';
-import { nanoid } from 'nanoid';
+import { customAlphabet } from 'nanoid';
+import { alphanumeric } from 'nanoid-dictionary';
 import { NzMessageService } from 'ng-zorro-antd';
 import { Subscription } from 'rxjs';
 
@@ -397,7 +398,7 @@ export class ExperimentCustomizedFormComponent implements OnInit, OnDestroy {
     // Enable user from modifying the name
     this.experimentName.enable();
     // Put value back
-    const id: string = nanoid(8);
+    const id: string = customAlphabet(alphanumeric, 8)();
     const cloneExperimentName = spec.meta.name + '-' + id;
     this.experimentName.setValue(cloneExperimentName.toLocaleLowerCase());
     this.cloneExperiment(spec);


### PR DESCRIPTION
### What is this PR for?

Nano id uses URL-friendly symbols (A-Za-z0-9_-), but experiment name didn't accept "_".
So its character set need to be modify with [nano-dictionary](https://github.com/CyberAP/nanoid-dictionary)


### What type of PR is it?
[Bug Fix]

### Todos

None

### What is the Jira issue?

https://issues.apache.org/jira/projects/SUBMARINE/issues/SUBMARINE-998

### How should this be tested?

Just clone a experiment and check its name

### Screenshots (if appropriate)

![2021-08-28 21-08-37 的螢幕擷圖](https://user-images.githubusercontent.com/55401762/131218993-6f2bd989-e8ea-4784-aee2-19c7708cd28a.png)

### Questions:
* Do the license files need updating? No
* Are there breaking changes for older versions? No
* Does this need new documentation? No
