### PR TITLE
SUBMARINE-1001. Experiment Patch Didn't Work.

### DIFF
--- a/submarine-server/server-core/src/main/java/org/apache/submarine/server/experiment/ExperimentManager.java
+++ b/submarine-server/server-core/src/main/java/org/apache/submarine/server/experiment/ExperimentManager.java
@@ -233,6 +233,8 @@ public class ExperimentManager {
     checkExperimentId(id);
     checkSpec(newSpec);
 
+    newSpec.getMeta().setExperimentId(id);
+
     ExperimentEntity entity = experimentService.select(id);
     Experiment experiment = buildExperimentFromEntity(entity);
     Experiment patchExperiment = submitter.patchExperiment(newSpec);

--- a/submarine-server/server-core/src/main/java/org/apache/submarine/server/rest/ExperimentRestApi.java
+++ b/submarine-server/server-core/src/main/java/org/apache/submarine/server/rest/ExperimentRestApi.java
@@ -193,7 +193,6 @@ public class ExperimentRestApi {
           @ApiResponse(responseCode = "404", description = "Experiment not found")})
   public Response patchExperiment(@PathParam(RestConstants.ID) String id, ExperimentSpec spec) {
     try {
-      spec.getMeta().setExperimentId(id.toString());
       Experiment experiment = experimentManager.patchExperiment(id, spec);
       return new JsonResponse.Builder<Experiment>(Response.Status.OK).success(true)
           .result(experiment).build();

--- a/submarine-server/server-core/src/main/java/org/apache/submarine/server/rest/ExperimentRestApi.java
+++ b/submarine-server/server-core/src/main/java/org/apache/submarine/server/rest/ExperimentRestApi.java
@@ -193,6 +193,7 @@ public class ExperimentRestApi {
           @ApiResponse(responseCode = "404", description = "Experiment not found")})
   public Response patchExperiment(@PathParam(RestConstants.ID) String id, ExperimentSpec spec) {
     try {
+      spec.getMeta().setExperimentId(id.toString());
       Experiment experiment = experimentManager.patchExperiment(id, spec);
       return new JsonResponse.Builder<Experiment>(Response.Status.OK).success(true)
           .result(experiment).build();


### PR DESCRIPTION
### What is this PR for?

The reason why patch of experiment occurs error is when parsing the experimentSpec to MLJob, it will set the name of meta to experimentId of meta in experimentSpec.
However experimentId of meta in experimentSpec received from workbench is null, making patchNamespacedCustomObject error.

### What type of PR is it?
[Bug Fix]

### Todos

None

### What is the Jira issue?

https://issues.apache.org/jira/projects/SUBMARINE/issues/SUBMARINE-1001

### How should this be tested?

Just create a new experiment and update it.

### Screenshots (if appropriate)

None

### Questions:
* Do the license files need updating? No
* Are there breaking changes for older versions? No
* Does this need new documentation? No
