### PR TITLE
SUBMARINE-1012. Submarine CR status is inconsistent with actual state

### DIFF
--- a/submarine-cloud-v2/pkg/controller/controller.go
+++ b/submarine-cloud-v2/pkg/controller/controller.go
@@ -643,10 +643,6 @@ func (c *Controller) checkSubmarineDependentsReady(submarine *v1alpha1.Submarine
 			if condition.Type == appsv1.DeploymentReplicaFailure {
 				return false, fmt.Errorf("failed creating replicas of %s, message: %s", deployment.Name, condition.Message)
 			}
-			// progressing error, ex. ProgressDeadlineExceeded
-			if condition.Type == appsv1.DeploymentProgressing && condition.Status == corev1.ConditionFalse {
-				return false, fmt.Errorf("failed creating replicas of %s, message: %s", deployment.Name, condition.Message)
-			}
 		}
 		// check if ready replicas are same as targeted replicas
 		if deployment.Status.ReadyReplicas != deployment.Status.Replicas {


### PR DESCRIPTION
### What is this PR for?
When creating the submarine using the operator, the status of the submarine CR shows mlflow failed due to time-out processing. However, the mlflow deployment is running.

#### Cause:
Submarine operator treat progressing error, ex. ProgressDeadlineExceeded, as a fatal error. However, the deployment controller will continue to process failed deployment, so the deployment may be running in several minutes. This causes inconsistent CR status with the actual state.

#### Solution:
Does not treat progressing error as a fatal error

#### References:
https://pkg.go.dev/k8s.io/api/apps/v1#DeploymentSpec

### What type of PR is it?
[Bug Fix]

### Todos

### What is the Jira issue?
https://issues.apache.org/jira/projects/SUBMARINE/issues/SUBMARINE-1012

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* Do the license files need updating? No
* Are there breaking changes for older versions? No
* Does this need new documentation? No
