### PR TITLE
SUBMARINE-1016. submarine-mlflow deployment takes a long time to be ready

### DIFF
--- a/submarine-cloud-v2/pkg/controller/controller.go
+++ b/submarine-cloud-v2/pkg/controller/controller.go
@@ -67,6 +67,7 @@ const storageClassName = "submarine-storageclass"
 const (
 	serverName                  = "submarine-server"
 	databaseName                = "submarine-database"
+	databasePort                = 3306
 	tensorboardName             = "submarine-tensorboard"
 	mlflowName                  = "submarine-mlflow"
 	minioName                   = "submarine-minio"

--- a/submarine-cloud-v2/pkg/controller/submarine_database.go
+++ b/submarine-cloud-v2/pkg/controller/submarine_database.go
@@ -89,7 +89,7 @@ func newSubmarineDatabaseDeployment(submarine *v1alpha1.Submarine) *appsv1.Deplo
 							ImagePullPolicy: "IfNotPresent",
 							Ports: []corev1.ContainerPort{
 								{
-									ContainerPort: 3306,
+									ContainerPort: databasePort,
 								},
 							},
 							Env: []corev1.EnvVar{
@@ -103,6 +103,13 @@ func newSubmarineDatabaseDeployment(submarine *v1alpha1.Submarine) *appsv1.Deplo
 									MountPath: "/var/lib/mysql",
 									Name:      "volume",
 									SubPath:   databaseName,
+								},
+							},
+							ReadinessProbe: &corev1.Probe{
+								Handler: corev1.Handler{
+									TCPSocket: &corev1.TCPSocketAction{
+										Port: intstr.FromInt(databasePort),
+									},
 								},
 							},
 						},
@@ -134,8 +141,8 @@ func newSubmarineDatabaseService(submarine *v1alpha1.Submarine) *corev1.Service 
 		Spec: corev1.ServiceSpec{
 			Ports: []corev1.ServicePort{
 				{
-					Port:       3306,
-					TargetPort: intstr.FromInt(3306),
+					Port:       databasePort,
+					TargetPort: intstr.FromInt(databasePort),
 					Name:       databaseName,
 				},
 			},

--- a/submarine-cloud-v2/pkg/controller/submarine_mlflow.go
+++ b/submarine-cloud-v2/pkg/controller/submarine_mlflow.go
@@ -76,6 +76,17 @@ func newSubmarineMlflowDeployment(submarine *v1alpha1.Submarine) *appsv1.Deploym
 					},
 				},
 				Spec: corev1.PodSpec{
+					InitContainers: []corev1.Container{
+						{
+							Name:  "check-database-connection",
+							Image: "busybox:1.28",
+							Command: []string{
+								"sh",
+								"-c",
+								fmt.Sprintf("until nc -z %s %d; do echo waiting for database connection; sleep 20; done", databaseName, databasePort),
+							},
+						},
+					},
 					Containers: []corev1.Container{
 						{
 							Name:            mlflowName + "-container",


### PR DESCRIPTION
### What is this PR for?
The submarine-mlflow and submarine-database deployments are created at the same time and mlflow needs to wait for the database. Since mlflow use exponential back-off waiting, it takes a long time to be in the ready state.

### What type of PR is it?
[Bug Fix]

### Todos
* [x] - Add ReadinessProbe for submarine-database
* [x] - Add InitContainers for submarine-mlflow

Reference: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/

### What is the Jira issue?
https://issues.apache.org/jira/projects/SUBMARINE/issues/SUBMARINE-1016

### How should this be tested?

### Screenshots (if appropriate)

Before:
![Screenshot from 2021-09-07 22-22-36](https://user-images.githubusercontent.com/47914085/132993005-518bcd45-8662-4317-83f4-9d8628066893.png)

After:
![Screenshot from 2021-09-12 23-10-09](https://user-images.githubusercontent.com/47914085/132993023-22fcb635-6123-40e8-ac42-75c5fcf8daa7.png)

### Questions:
* Do the license files need updating? No
* Are there breaking changes for older versions? No
* Does this need new documentation? No
