### PR TITLE
SUBMARINE-1028. Extend timeout for integration tests

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -28,7 +28,7 @@ env:
 jobs:
   submarine-e2e:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
     services:
       mysql:
         image: mysql:5.7
@@ -78,7 +78,7 @@ jobs:
           mvn ${TEST_FLAG} ${TEST_MODULES} ${PROFILE} -B
   submarine-k8s:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
### What is this PR for?
Sometimes GitHub Actions' server is not stable, then it will take around 20 minutes and lead to timeout of integration tests.

### What type of PR is it?
[Improvement]

### Todos

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-1028

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* Do the license files need updating? No
* Are there breaking changes for older versions? No
* Does this need new documentation? No
