### PR TITLE
SUBMARINE-1035. Get started button in website is wrong

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -98,22 +98,22 @@ module.exports = {
       ],
     },
     footer: {
-        style: 'dark',
-        logo: {
-            alt: 'Apache Open Source Logo',
-            src: 'https://hadoop.apache.org/asf_logo_wide.png',
-            href: 'https://www.apache.org/',
-        },
-        links: [
+      style: 'dark',
+      logo: {
+          alt: 'Apache Open Source Logo',
+          src: 'https://hadoop.apache.org/asf_logo_wide.png',
+          href: 'https://www.apache.org/',
+      },
+      links: [
+        {
+          title: 'Docs',
+          items: [
             {
-                title: 'Docs',
-                items: [
-                    {
-                        label: 'Getting Started',
-                        to: 'docs/',
-                    },
-                    {
-                        label: 'API docs',
+              label: 'Getting Started',
+              to: 'docs/gettingStarted/quickstart',
+            },
+            {
+              label: 'API docs',
               to: 'docs/api/environment',
             },
           ],
@@ -144,8 +144,8 @@ module.exports = {
               },
           ],
         },
-        ],
-        copyright: `Apache Submarine, Submarine, Apache, the Apache feather logo, and the Apache Submarine project logo are
+      ],
+      copyright: `Apache Submarine, Submarine, Apache, the Apache feather logo, and the Apache Submarine project logo are
        either registered trademarks or trademarks of the Apache Software Foundation in the United States and other
         countries.<br> Copyright © ${new Date().getFullYear()} Apache Submarine is Apache2 Licensed software.`,
     },

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -88,7 +88,7 @@ function Home() {
                 'button button--outline button--secondary button--lg',
                 styles.getStarted,
               )}
-              to={useBaseUrl('/docs')}>
+              to={useBaseUrl('/docs/gettingStarted/quickstart')}>
               Get Started
             </Link>
             <iframe

--- a/website/versioned_docs/version-0.6.0/devDocs/Development.md
+++ b/website/versioned_docs/version-0.6.0/devDocs/Development.md
@@ -18,7 +18,7 @@ title: Development Guide
 -->
 
 # Project Overview
-The document [Submarine Local Deployment](../gettingStarted/localDeployment.md) shows how to deploy the Submarine service to your Kubernetes cluster. The Submarine service consists mainly of nine components, and you can check them with the following command:
+The document [Getting Started/Quickstart](../gettingStarted/quickstart.md) shows how to deploy the Submarine service to your Kubernetes cluster. The Submarine service consists mainly of nine components, and you can check them with the following command:
 
 ```
 kubectl get pods -n ${your_namespace}
@@ -107,7 +107,7 @@ Checkstyle plugin may help to detect violations directly from the IDE.
 
 1. Deploy the Submarine
 
-   Follow [Getting Started/Submarine Local Deployment](../gettingStarted/localDeployment.md), and make sure you can connect to `http://localhost:32080` in the browser.
+   Follow [Getting Started/Quickstart](../gettingStarted/quickstart.md), and make sure you can connect to `http://localhost:32080` in the browser.
 
 2. Install the dependencies
 


### PR DESCRIPTION
### What is this PR for?
The get started button should direct to https://submarine.apache.org/docs/gettingStarted/quickstart
And edit all the reference of old local deployment document. 

### What type of PR is it?
Bug Fix

### Todos


### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-1035

### How should this be tested?
Build the website locally and browse.

### Screenshots (if appropriate)

### Questions:
* Do the license files need updating? No
* Are there breaking changes for older versions? No
* Does this need new documentation? No
