### PR TITLE
SUBMARINE-1021. Experiment Watcher

### DIFF
--- a/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/K8sSubmitter.java
+++ b/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/K8sSubmitter.java
@@ -635,6 +635,11 @@ public class K8sSubmitter implements Submitter {
               }
             } finally {
               LOG.info("WATCH TFJob END");
+              try {
+                watchTF.close();
+              } catch (Exception e){
+                LOG.error("{}", e.getMessage());
+              }
               throw new RuntimeException();
             }
         }
@@ -650,6 +655,11 @@ public class K8sSubmitter implements Submitter {
               }
             } finally {
               LOG.info("WATCH PytorchJob END");
+              try {
+                watchPytorch.close();
+              } catch (Exception e){
+                LOG.error("{}", e.getMessage());
+              }
               throw new RuntimeException();
             }
         }


### PR DESCRIPTION
### What is this PR for?

Use k8s java client to build watchers of TFJobs and PytorchJobs, logging status when the experiment status change.
[Watcher examples](https://github.com/kubernetes-client/java/blob/master/examples/examples-release-12/src/main/java/io/kubernetes/client/examples/WatchExample.java)

We will create a websocket connection between server and workbench, and modify the frontend logic of workbench in the following PRs.

### What type of PR is it?
[Feature]

### Todos

None

### What is the Jira issue?

https://issues.apache.org/jira/projects/SUBMARINE/issues/SUBMARINE-1021

### How should this be tested?

It will run with the initializing of k8s submitter, then keep watching the experiments.
You can see the log when status of experiment changing.

### Screenshots (if appropriate)


https://user-images.githubusercontent.com/55401762/136215425-5dcf4c15-3810-42b5-9511-ceb00b781405.mp4



### Questions:
* Do the license files need updating? No
* Are there breaking changes for older versions? No
* Does this need new documentation? No
