### PR TITLE
SUBMARINE-1057. Correct the link in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ submarine_client.get_log(id)
 submarine_client.list_experiments(status='running')
 ```
 
-For a quick-start, see [Submarine On K8s](https://submarine.apache.org/docs/adminDocs/k8s/README)
+For a quick-start, see [Submarine On K8s](https://submarine.apache.org/docs/gettingStarted/quickstart)
 
 ### Example: Submit a pre-defined experiment template job
 


### PR DESCRIPTION
### What is this PR for?
It shows 404 not found
https://github.com/apache/submarine/blob/master/README.md?plain=1#L132

should be change to https://submarine.apache.org/docs/gettingStarted/quickstart

### What type of PR is it?
[Bug Fix]

### Todos

### What is the Jira issue?
https://issues.apache.org/jira/projects/SUBMARINE/issues/SUBMARINE-1057

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* Do the license files need updating? No
* Are there breaking changes for older versions? No
* Does this need new documentation? No
