### PR TITLE
SUBMARINE-1081. Upgrade helm-charts crd version to v1

### DIFF
--- a/helm-charts/submarine/charts/notebook-controller/crds/crd.yaml
+++ b/helm-charts/submarine/charts/notebook-controller/crds/crd.yaml
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: notebooks.kubeflow.org
@@ -24,9 +24,9 @@ spec:
     kind: Notebook
     plural: notebooks
     singular: notebook
+    shortNames:
+    - nb
   scope: Namespaced
-  subresources:
-    status: {}
   versions:
   - name: v1alpha1
     served: true
@@ -37,44 +37,47 @@ spec:
   - name: v1
     served: true
     storage: false
-  validation:
-    openAPIV3Schema:
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          properties:
-            template:
-              description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
-                Important: Run "make" to regenerate code after modifying this file'
-              properties:
-                spec:
-                  type: object
-              type: object
-          type: object
-        status:
-          properties:
-            conditions:
-              description: Conditions is an array of current conditions
-              items:
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              template:
+                description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
+                  Important: Run "make" to regenerate code after modifying this file'
                 properties:
-                  type:
-                    description: Type of the confition/
-                    type: string
-                required:
-                - type
+                  spec:
+                    type: object
                 type: object
-              type: array
-          required:
-          - conditions
-          type: object
+            type: object
+          status:
+            properties:
+              conditions:
+                description: Conditions is an array of current conditions
+                items:
+                  properties:
+                    type:
+                      description: Type of the confition/
+                      type: string
+                  required:
+                  - type
+                  type: object
+                type: array
+            required:
+            - conditions
+            type: object

--- a/helm-charts/submarine/charts/notebook-controller/crds/crd.yaml
+++ b/helm-charts/submarine/charts/notebook-controller/crds/crd.yaml
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: notebooks.kubeflow.org
@@ -27,6 +27,8 @@ spec:
     shortNames:
     - nb
   scope: Namespaced
+  subresources:
+    status: {}
   versions:
   - name: v1alpha1
     served: true
@@ -37,47 +39,44 @@ spec:
   - name: v1
     served: true
     storage: false
-    subresources:
-      status: {}
-    schema:
-      openAPIV3Schema:
-        type: object
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            properties:
-              template:
-                description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
-                  Important: Run "make" to regenerate code after modifying this file'
-                properties:
-                  spec:
-                    type: object
-                type: object
-            type: object
-          status:
-            properties:
-              conditions:
-                description: Conditions is an array of current conditions
-                items:
-                  properties:
-                    type:
-                      description: Type of the confition/
-                      type: string
-                  required:
-                  - type
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            template:
+              description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
+                Important: Run "make" to regenerate code after modifying this file'
+              properties:
+                spec:
                   type: object
-                type: array
-            required:
-            - conditions
-            type: object
+              type: object
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions is an array of current conditions
+              items:
+                properties:
+                  type:
+                    description: Type of the confition/
+                    type: string
+                required:
+                - type
+                type: object
+              type: array
+          required:
+          - conditions
+          type: object

--- a/helm-charts/submarine/charts/pytorchjob/crds/crd.yaml
+++ b/helm-charts/submarine/charts/pytorchjob/crds/crd.yaml
@@ -15,45 +15,53 @@
 # limitations under the License.
 #
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: pytorchjobs.kubeflow.org
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .status.conditions[-1:].type
-    name: State
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    name: Age
-    type: date
+  
   group: kubeflow.org
   names:
     kind: PyTorchJob
     plural: pytorchjobs
     singular: pytorchjob
+    shortNames:
+    - ptj
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
-          properties:
-            pytorchReplicaSpecs:
-              properties:
-                Master:
-                  properties:
-                    replicas:
-                      maximum: 1
-                      minimum: 1
-                      type: integer
-                Worker:
-                  properties:
-                    replicas:
-                      minimum: 1
-                      type: integer
   versions:
   - name: v1
     served: true
     storage: true
+    subresources:
+      status: {}
+    additionalPrinterColumns:
+    - jsonPath: .status.conditions[-1:].type
+      name: State
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              pytorchReplicaSpecs:
+                type: object
+                properties:
+                  Master:
+                    type: object
+                    properties:
+                      replicas:
+                        maximum: 1
+                        minimum: 1
+                        type: integer
+                  Worker:
+                    type: object
+                    properties:
+                      replicas:
+                        minimum: 1
+                        type: integer

--- a/helm-charts/submarine/charts/pytorchjob/templates/rbac.yaml
+++ b/helm-charts/submarine/charts/pytorchjob/templates/rbac.yaml
@@ -22,7 +22,7 @@ metadata:
     app: pytorch-operator
   name: pytorch-operator
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
@@ -52,7 +52,7 @@ rules:
   verbs:
   - '*'
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:

--- a/helm-charts/submarine/charts/tfjob/crds/crd.yaml
+++ b/helm-charts/submarine/charts/tfjob/crds/crd.yaml
@@ -15,50 +15,58 @@
 # limitations under the License.
 #
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: tfjobs.kubeflow.org
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .status.conditions[-1:].type
-    name: State
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    name: Age
-    type: date
   group: kubeflow.org
   names:
     kind: TFJob
     plural: tfjobs
     singular: tfjob
+    shortNames:
+    - tfj
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
-          properties:
-            tfReplicaSpecs:
-              properties:
-                Chief:
-                  properties:
-                    replicas:
-                      maximum: 1
-                      minimum: 1
-                      type: integer
-                PS:
-                  properties:
-                    replicas:
-                      minimum: 1
-                      type: integer
-                Worker:
-                  properties:
-                    replicas:
-                      minimum: 1
-                      type: integer
   versions:
   - name: v1
     served: true
     storage: true
+    subresources:
+      status: {}
+    additionalPrinterColumns:
+    - jsonPath: .status.conditions[-1:].type
+      name: State
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              tfReplicaSpecs:
+                type: object
+                properties:
+                  Chief:
+                    type: object
+                    properties:
+                      replicas:
+                        maximum: 1
+                        minimum: 1
+                        type: integer
+                  PS:
+                    type: object
+                    properties:
+                      replicas:
+                        minimum: 1
+                        type: integer
+                  Worker:
+                    type: object
+                    properties:
+                      replicas:
+                        minimum: 1
+                        type: integer

--- a/helm-charts/submarine/charts/tfjob/templates/cluster-role-binding.yaml
+++ b/helm-charts/submarine/charts/tfjob/templates/cluster-role-binding.yaml
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:

--- a/helm-charts/submarine/charts/tfjob/templates/cluster-role.yaml
+++ b/helm-charts/submarine/charts/tfjob/templates/cluster-role.yaml
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:

--- a/helm-charts/submarine/charts/traefik/crds/ingressroute-tcp.yaml
+++ b/helm-charts/submarine/charts/traefik/crds/ingressroute-tcp.yaml
@@ -15,15 +15,21 @@
 # limitations under the License.
 #
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: ingressroutetcps.traefik.containo.us
 spec:
   group: traefik.containo.us
-  version: v1alpha1
   names:
     kind: IngressRouteTCP
     plural: ingressroutetcps
     singular: ingressroutetcp
   scope: Namespaced
+  versions: 
+  - name: v1alpha1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object

--- a/helm-charts/submarine/charts/traefik/crds/ingressroute-udp.yaml
+++ b/helm-charts/submarine/charts/traefik/crds/ingressroute-udp.yaml
@@ -15,16 +15,21 @@
 # limitations under the License.
 #
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: ingressrouteudps.traefik.containo.us
-
 spec:
   group: traefik.containo.us
-  version: v1alpha1
   names:
     kind: IngressRouteUDP
     plural: ingressrouteudps
     singular: ingressrouteudp
   scope: Namespaced
+  versions: 
+  - name: v1alpha1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object

--- a/helm-charts/submarine/charts/traefik/crds/ingressroute.yaml
+++ b/helm-charts/submarine/charts/traefik/crds/ingressroute.yaml
@@ -15,15 +15,49 @@
 # limitations under the License.
 #
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: ingressroutes.traefik.containo.us
 spec:
   group: traefik.containo.us
-  version: v1alpha1
   names:
     kind: IngressRoute
     plural: ingressroutes
     singular: ingressroute
   scope: Namespaced
+  versions: 
+  - name: v1alpha1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              entryPoints:
+                type: array
+                items:
+                  type: string
+              routes:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    kind: 
+                      type: string
+                    match: 
+                      type: string 
+                    services:
+                      type: array
+                      items:
+                        type: object
+                        kind: 
+                          type: string 
+                        name: 
+                          type: string
+                        port: 
+                          type: int
+

--- a/helm-charts/submarine/charts/traefik/crds/middlewares.yaml
+++ b/helm-charts/submarine/charts/traefik/crds/middlewares.yaml
@@ -15,15 +15,21 @@
 # limitations under the License.
 #
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: middlewares.traefik.containo.us
 spec:
   group: traefik.containo.us
-  version: v1alpha1
   names:
     kind: Middleware
     plural: middlewares
     singular: middleware
   scope: Namespaced
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object

--- a/helm-charts/submarine/charts/traefik/crds/tls-options.yaml
+++ b/helm-charts/submarine/charts/traefik/crds/tls-options.yaml
@@ -15,15 +15,21 @@
 # limitations under the License.
 #
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: tlsoptions.traefik.containo.us
 spec:
   group: traefik.containo.us
-  version: v1alpha1
   names:
     kind: TLSOption
     plural: tlsoptions
     singular: tlsoption
   scope: Namespaced
+  versions: 
+  - name: v1alpha1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object

--- a/helm-charts/submarine/charts/traefik/crds/tls-stores.yaml
+++ b/helm-charts/submarine/charts/traefik/crds/tls-stores.yaml
@@ -15,16 +15,22 @@
 # limitations under the License.
 #
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: tlsstores.traefik.containo.us
-
 spec:
   group: traefik.containo.us
-  version: v1alpha1
   names:
     kind: TLSStore
     plural: tlsstores
     singular: tlsstore
   scope: Namespaced
+  versions: 
+  - name: v1alpha1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+

--- a/helm-charts/submarine/charts/traefik/crds/traefik-services.yaml
+++ b/helm-charts/submarine/charts/traefik/crds/traefik-services.yaml
@@ -15,15 +15,21 @@
 # limitations under the License.
 #
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: traefikservices.traefik.containo.us
 spec:
   group: traefik.containo.us
-  version: v1alpha1
   names:
     kind: TraefikService
     plural: traefikservices
     singular: traefikservice
   scope: Namespaced
+  versions: 
+  - name: v1alpha1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object

--- a/helm-charts/submarine/templates/submarine-ingress.yaml
+++ b/helm-charts/submarine/templates/submarine-ingress.yaml
@@ -1,16 +1,18 @@
 {{ if .Values.submarine.traefik.enabled }}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ .Values.submarine.server.name}}-ingress
   namespace: {{ .Release.namespace }}
-
 spec:
   rules:
     - http:
         paths:
           - path: /
+            pathType: Prefix
             backend:
-              serviceName: {{ .Values.submarine.server.name }}
-              servicePort: {{ .Values.submarine.server.servicePort }}
+              service:
+                name: {{ .Values.submarine.server.name }}
+                port: 
+                  number: {{ .Values.submarine.server.servicePort }}
 {{ end }}


### PR DESCRIPTION
### What is this PR for?
<!-- A few sentences describing the overall goals of the pull request's commits.
First time? Check out the contributing guide - https://submarine.apache.org/contribution/contributions.html
-->

Now, we are using old v1beta1 api version for our crd. We want to replace it with the new v1 version to support higher versions of kubernetes.

### What type of PR is it?
[Improvement]

### Todos
* [x] - Upgrade some role-binding version, cluster-role-binding, and ingress version
* [x] - Upgrade pytorchjob, tfjob, traefik to v1

### What is the Jira issue?
<!-- * Open an issue on Jira https://issues.apache.org/jira/browse/SUBMARINE/
* Put link here, and add [SUBMARINE-*Jira number*] in PR title, eg. `SUBMARINE-23. PR title`
-->

https://issues.apache.org/jira/projects/SUBMARINE/issues/SUBMARINE-1081?filter=allissues

### How should this be tested?
<!--
* First time? Setup Travis CI as described on https://submarine.apache.org/contribution/contributions.html#continuous-integration
* Strongly recommended: add automated unit tests for any new or changed behavior
* Outline any manual steps to test the PR here.
-->
### Screenshots (if appropriate)

### Questions:
* Do the license files need updating? No
* Are there breaking changes for older versions? No
* Does this need new documentation? No
