### PR TITLE
SUBMARINE-1120. Fix Submarine Helm can not start submarine-operator pod error.

### DIFF
--- a/helm-charts/submarine/templates/rbac.yaml
+++ b/helm-charts/submarine/templates/rbac.yaml
@@ -92,7 +92,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: submarine-operator
-  namespace: default
+  namespace: {{ .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -105,4 +105,4 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: submarine-operator
-    namespace: default
+    namespace: {{ .Release.Namespace }}


### PR DESCRIPTION
### What is this PR for?
Fix https://issues.apache.org/jira/browse/SUBMARINE-1120

### What type of PR is it?
Bug Fix

### Todos

* [x] - Change `submarine-operator` ServiceAccount namespace in helm template so that submarine-operator can start normally.

### What is the Jira issue?

https://issues.apache.org/jira/browse/SUBMARINE-1120

### How should this be tested?

Use the `helm install` command to test. And we can directly see the result: whether the `submarine-operator` pod starts and runs normally.

### Screenshots (if appropriate)
no

### Questions:
* Do the license files need updating? No
* Are there breaking changes for older versions? No
* Does this need new documentation? No
