### PR TITLE
SUBMARINE-1128. Fix Submarine server can not connect to database url error

### DIFF
--- a/submarine-commons/commons-utils/src/main/java/org/apache/submarine/commons/utils/SubmarineConfVars.java
+++ b/submarine-commons/commons-utils/src/main/java/org/apache/submarine/commons/utils/SubmarineConfVars.java
@@ -53,8 +53,8 @@ public class SubmarineConfVars {
 
     JDBC_DRIVERCLASSNAME("jdbc.driverClassName", "com.mysql.jdbc.Driver"),
     JDBC_URL("jdbc.url", "jdbc:mysql://127.0.0.1:3306/submarine" +
-        "?useUnicode=true&characterEncoding=UTF-8&autoReconnect=true&allowMultiQueries=true" +
-        "failOverReadOnly=false&zeroDateTimeBehavior=convertToNull&useSSL=false&"),
+        "?useUnicode=true&characterEncoding=UTF-8&autoReconnect=true&allowMultiQueries=true&" +
+        "failOverReadOnly=false&zeroDateTimeBehavior=convertToNull&useSSL=false"),
     JDBC_USERNAME("jdbc.username", "submarine"),
     JDBC_PASSWORD("jdbc.password", "password"),
     METASTORE_JDBC_URL("metastore.jdbc.url", "jdbc:mysql://127.0.0.1:3306/metastore" +


### PR DESCRIPTION
### What is this PR for?
Current default database url has  a syntax error in the JDBC link of MySQL.

### What type of PR is it?
Bug Fix

### Todos
* [ x ] - Fix & symbol position


### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-1128

### How should this be tested?
can test default link by local env

### Screenshots (if appropriate)
no

### Questions:
* Do the license files need updating? No
* Are there breaking changes for older versions?  No
* Does this need new documentation? No
