### PR TITLE
SUBMARINE-1098. Show information in the model version information page

### DIFF
--- a/submarine-workbench/workbench-web/src/app/interfaces/model-version-info.ts
+++ b/submarine-workbench/workbench-web/src/app/interfaces/model-version-info.ts
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export interface ModelVersionInfo {
+    name: string,
+    version: string,
+    source: string,
+    userId: string,
+    experimentId: string,
+    currentStage: string,
+    creationTime: string,
+    lastUpdatedTime: string,
+    dataset: string,
+    description: string,
+    tags: string
+}

--- a/submarine-workbench/workbench-web/src/app/interfaces/model-version-info.ts
+++ b/submarine-workbench/workbench-web/src/app/interfaces/model-version-info.ts
@@ -19,7 +19,7 @@
 
 export interface ModelVersionInfo {
     name: string,
-    version: string,
+    version: number,
     source: string,
     userId: string,
     experimentId: string,
@@ -28,5 +28,5 @@ export interface ModelVersionInfo {
     lastUpdatedTime: string,
     dataset: string,
     description: string,
-    tags: string
+    tags: Array<string>
 }

--- a/submarine-workbench/workbench-web/src/app/pages/workbench/model/model-version/model-version.component.html
+++ b/submarine-workbench/workbench-web/src/app/pages/workbench/model/model-version/model-version.component.html
@@ -19,17 +19,17 @@
 
 <div style="margin: 15px; padding: 15px; background-color: white">
   <p>Version: {{ modelVersion }}</p>
-  <p>Description: Resnet152</p>
-  <p>Tags:</p>
-  <p>Stage:</p>
+  <p>Description: {{ modelVersionInfo.description }}</p>
+  <p>Tags: {{ modelVersionInfo.tags }}</p>
+  <p>Stage: {{modelVersionInfo.currentStage}}</p>
   <h3>Model version info</h3>
-  <p>User id: abcdef</p>
+  <p>User id: {{modelVersionInfo.userId}}</p>
   <p>
     Experiment id:
-    <a href="#">123456789</a>
+    <a href="#">{{modelVersionInfo.experimentId}}</a>
   </p>
-  <p>Dataset: mnist</p>
-  <p>Created: 2021-09-01 07:57</p>
-  <p>Updated: 2021-09-21 03:00</p>
-  <p>Source: s3:/example/model</p>
+  <p>Dataset: {{modelVersionInfo.dataset}}</p>
+  <p>Created: {{modelVersionInfo.creationTime | date: 'M/d/yyyy, h:mm a'}}</p>
+  <p>Updated: {{modelVersionInfo.lastUpdatedTime | date: 'M/d/yyyy, h:mm a'}}</p>
+  <p>Source: {{modelVersionInfo.source}}</p>
 </div>

--- a/submarine-workbench/workbench-web/src/app/pages/workbench/model/model-version/model-version.component.html
+++ b/submarine-workbench/workbench-web/src/app/pages/workbench/model/model-version/model-version.component.html
@@ -29,7 +29,7 @@
     <a href="#">{{modelVersionInfo.experimentId}}</a>
   </p>
   <p>Dataset: {{modelVersionInfo.dataset}}</p>
-  <p>Created: {{modelVersionInfo.creationTime | date: 'M/d/yyyy, h:mm a'}}</p>
-  <p>Updated: {{modelVersionInfo.lastUpdatedTime | date: 'M/d/yyyy, h:mm a'}}</p>
+  <p>Created: {{modelVersionInfo.creationTime }}</p>
+  <p>Updated: {{modelVersionInfo.lastUpdatedTime }}</p>
   <p>Source: {{modelVersionInfo.source}}</p>
 </div>

--- a/submarine-workbench/workbench-web/src/app/pages/workbench/model/model-version/model-version.component.html
+++ b/submarine-workbench/workbench-web/src/app/pages/workbench/model/model-version/model-version.component.html
@@ -21,15 +21,15 @@
   <p>Version: {{ modelVersion }}</p>
   <p>Description: {{ modelVersionInfo.description }}</p>
   <p>Tags: {{ modelVersionInfo.tags }}</p>
-  <p>Stage: {{modelVersionInfo.currentStage}}</p>
+  <p>Stage: {{ modelVersionInfo.currentStage }}</p>
   <h3>Model version info</h3>
-  <p>User id: {{modelVersionInfo.userId}}</p>
+  <p>User id: {{ modelVersionInfo.userId }}</p>
   <p>
     Experiment id:
-    <a href="#">{{modelVersionInfo.experimentId}}</a>
+    <a href="/workbench/experiment/info/{{modelVersionInfo.experimentId}}">{{ modelVersionInfo.experimentId }}</a>
   </p>
-  <p>Dataset: {{modelVersionInfo.dataset}}</p>
-  <p>Created: {{modelVersionInfo.creationTime }}</p>
-  <p>Updated: {{modelVersionInfo.lastUpdatedTime }}</p>
-  <p>Source: {{modelVersionInfo.source}}</p>
+  <p>Dataset: {{ modelVersionInfo.dataset }}</p>
+  <p>Created: {{ modelVersionInfo.creationTime }}</p>
+  <p>Updated: {{ modelVersionInfo.lastUpdatedTime }}</p>
+  <p>Source: {{ modelVersionInfo.source }}</p>
 </div>

--- a/submarine-workbench/workbench-web/src/app/pages/workbench/model/model-version/model-version.component.ts
+++ b/submarine-workbench/workbench-web/src/app/pages/workbench/model/model-version/model-version.component.ts
@@ -34,7 +34,7 @@ export class ModelVersionComponent implements OnInit {
   modelName;
   modelVersion;
   modelVersionInfo: ModelVersionInfo;
-  test;
+  static_tags: Array<string> = ['tag1', 'tag2', 'tag3'];
 
   constructor(
     private router: Router, 
@@ -46,27 +46,11 @@ export class ModelVersionComponent implements OnInit {
   ngOnInit() {
     this.modelName = this.route.snapshot.params.name;
     this.modelVersion = this.route.snapshot.params.version;
-    this.test = 'test message';
-    this.modelVersionInfo = {
-      'name': "register",
-      'version': "1",
-      'source': "s3://submarine/experiment-1637939541827-0001/example/1",
-      'userId': "test_userId",
-      'experimentId': "experiment-1637939541827-0001",
-      'currentStage': "None",
-      'creationTime': "2021-11-26 15:12:29",
-      'lastUpdatedTime': "2021-11-26 15:12:29",
-      'dataset': null,
-      'description': null,
-      'tags': "123"
-    }
     this.experimentService.emitInfo(this.modelName);
-    console.log(this.modelVersionInfo);
-    /**
     this.modelVersionService.querySpecificModel(this.modelName, this.modelVersion).subscribe(
       (item) => {
         this.modelVersionInfo = item;
       }
-    )*/
+    );
   }
 }

--- a/submarine-workbench/workbench-web/src/app/pages/workbench/model/model-version/model-version.component.ts
+++ b/submarine-workbench/workbench-web/src/app/pages/workbench/model/model-version/model-version.component.ts
@@ -34,6 +34,7 @@ export class ModelVersionComponent implements OnInit {
   modelName;
   modelVersion;
   modelVersionInfo: ModelVersionInfo;
+  test;
 
   constructor(
     private router: Router, 
@@ -45,11 +46,27 @@ export class ModelVersionComponent implements OnInit {
   ngOnInit() {
     this.modelName = this.route.snapshot.params.name;
     this.modelVersion = this.route.snapshot.params.version;
+    this.test = 'test message';
+    this.modelVersionInfo = {
+      'name': "register",
+      'version': "1",
+      'source': "s3://submarine/experiment-1637939541827-0001/example/1",
+      'userId': "test_userId",
+      'experimentId': "experiment-1637939541827-0001",
+      'currentStage': "None",
+      'creationTime': "2021-11-26 15:12:29",
+      'lastUpdatedTime': "2021-11-26 15:12:29",
+      'dataset': null,
+      'description': null,
+      'tags': "123"
+    }
     this.experimentService.emitInfo(this.modelName);
+    console.log(this.modelVersionInfo);
+    /**
     this.modelVersionService.querySpecificModel(this.modelName, this.modelVersion).subscribe(
       (item) => {
         this.modelVersionInfo = item;
       }
-    )
+    )*/
   }
 }

--- a/submarine-workbench/workbench-web/src/app/pages/workbench/model/model-version/model-version.component.ts
+++ b/submarine-workbench/workbench-web/src/app/pages/workbench/model/model-version/model-version.component.ts
@@ -34,7 +34,6 @@ export class ModelVersionComponent implements OnInit {
   modelName;
   modelVersion;
   modelVersionInfo: ModelVersionInfo;
-  static_tags: Array<string> = ['tag1', 'tag2', 'tag3'];
 
   constructor(
     private router: Router, 

--- a/submarine-workbench/workbench-web/src/app/pages/workbench/model/model-version/model-version.component.ts
+++ b/submarine-workbench/workbench-web/src/app/pages/workbench/model/model-version/model-version.component.ts
@@ -20,6 +20,9 @@
 import { Component, OnInit, ViewChild } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { ExperimentService } from '@submarine/services/experiment.service';
+import { ModelVersionInfo } from '@submarine/interfaces/model-version-info';
+import { ModelVersionService } from '@submarine/services/model-version.service';
+import { isThisSecond } from 'date-fns';
 
 @Component({
   selector: 'submarine-model-version',
@@ -30,12 +33,23 @@ export class ModelVersionComponent implements OnInit {
   isLoading = true;
   modelName;
   modelVersion;
+  modelVersionInfo: ModelVersionInfo;
 
-  constructor(private router: Router, private route: ActivatedRoute, private experimentService: ExperimentService) {}
+  constructor(
+    private router: Router, 
+    private route: ActivatedRoute, 
+    private experimentService: ExperimentService,
+    private modelVersionService: ModelVersionService
+  ) {}
 
   ngOnInit() {
     this.modelName = this.route.snapshot.params.name;
     this.modelVersion = this.route.snapshot.params.version;
     this.experimentService.emitInfo(this.modelName);
+    this.modelVersionService.querySpecificModel(this.modelName, this.modelVersion).subscribe(
+      (item) => {
+        this.modelVersionInfo = item;
+      }
+    )
   }
 }

--- a/submarine-workbench/workbench-web/src/app/services/model-version.service.ts
+++ b/submarine-workbench/workbench-web/src/app/services/model-version.service.ts
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { of, throwError, Observable, Subject } from 'rxjs';
+import { BaseApiService } from '@submarine/services/base-api.service';
+import { Rest } from '@submarine/interfaces';
+import { ModelVersionInfo } from '@submarine/interfaces/model-version-info';
+import { switchMap } from 'rxjs/operators';
+
+@Injectable({
+    providedIn: 'root',
+})
+
+export class ModelVersionService {
+
+  private emitInfoSource = new Subject<string>();
+  infoEmitted$ = this.emitInfoSource.asObservable();
+
+  constructor(private baseApi: BaseApiService, private httpClient: HttpClient) {}
+
+  emitInfo(id: string) {
+      this.emitInfoSource.next(id);
+  }
+
+  querySpecificModel(name: string, version: string) : Observable<ModelVersionInfo> {
+      const apiUrl = this.baseApi.getRestApi('/v1/model-version/' + name + '/' + version + '/');
+      return this.httpClient.get<Rest<ModelVersionInfo>>(apiUrl).pipe(
+          switchMap((res) => {
+              if (res.success) {
+                  return of(res.result);
+              } else {
+                  throw this.baseApi.createRequestError(res.message, res.code, apiUrl, 'get');
+              }
+          })
+      );
+  }
+}


### PR DESCRIPTION
### What is this PR for?
Use REST API to get the information of the model in the model version page.

### What type of PR is it?
Feature

### Todos
* [ ] - Add tags component.

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-1098

### How should this be tested?
Save a model and checkout the model version page.

### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/71302532/145612020-c54f84c9-9b12-451a-8f1b-86abbb209fc3.png)


### Questions:
* Do the license files need updating? No
* Are there breaking changes for older versions? No
* Does this need new documentation? No
