### PR TITLE
SUBMARINE-1130. New route to serve pod

### DIFF
--- a/submarine-cloud-v2/artifacts/submarine/submarine-rbac.yaml
+++ b/submarine-cloud-v2/artifacts/submarine/submarine-rbac.yaml
@@ -68,6 +68,19 @@ rules:
   - patch
   - update
 - apiGroups:
+  - networking.istio.io
+  resources:
+  - virtualservices
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update  
+- apiGroups:
   - ""
   resources:
   - pods

--- a/submarine-serve/src/main/java/org/apache/submarine/serve/istio/IstioHTTPDestination.java
+++ b/submarine-serve/src/main/java/org/apache/submarine/serve/istio/IstioHTTPDestination.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.submarine.serve.istio;
+
+import com.google.gson.annotations.SerializedName;
+import org.apache.submarine.serve.utils.IstioConstants;
+
+public class IstioHTTPDestination {
+  @SerializedName("destination")
+  private IstioDestination destination;
+
+  public IstioHTTPDestination(String host){
+    this.destination = new IstioDestination(host);
+  }
+
+
+  public static class IstioDestination{
+    @SerializedName("host")
+    private String host;
+
+    @SerializedName("port")
+    private IstioPort port;
+
+    public IstioDestination(String host) {
+      this.host = host;
+      this.port = new IstioPort(IstioConstants.DEFAULT_SERVE_POD_PORT);
+    }
+  }
+
+  public static class IstioPort {
+    @SerializedName("number")
+    private Integer number;
+
+    public IstioPort(Integer port){
+      this.number = port;
+    }
+  }
+}

--- a/submarine-serve/src/main/java/org/apache/submarine/serve/istio/IstioHTTPMatchRequest.java
+++ b/submarine-serve/src/main/java/org/apache/submarine/serve/istio/IstioHTTPMatchRequest.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.submarine.serve.istio;
+
+import com.google.gson.annotations.SerializedName;
+
+public class IstioHTTPMatchRequest {
+  @SerializedName("uri")
+  private IstioPrefix prefix;
+
+  public IstioHTTPMatchRequest(String prefix) {
+    this.prefix = new IstioPrefix(prefix);
+  }
+
+  public static class IstioPrefix {
+    @SerializedName("prefix")
+    private String path;
+
+    public IstioPrefix(String path){
+      this.path = path;
+    }
+  }
+}

--- a/submarine-serve/src/main/java/org/apache/submarine/serve/istio/IstioHTTPRoute.java
+++ b/submarine-serve/src/main/java/org/apache/submarine/serve/istio/IstioHTTPRoute.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.submarine.serve.istio;
+
+import com.google.gson.annotations.SerializedName;
+import org.apache.submarine.serve.utils.IstioConstants;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class IstioHTTPRoute {
+  @SerializedName("match")
+  private List<IstioHTTPMatchRequest> match = new ArrayList<>();
+
+  @SerializedName("route")
+  private List<IstioHTTPDestination> route = new ArrayList<>();
+
+  @SerializedName("rewrite")
+  private IstioRewrite rewrite;
+
+  public IstioHTTPRoute() {
+    this.rewrite = new IstioRewrite(IstioConstants.REWRITE_URL);
+  }
+
+  @Override
+  public String toString() {
+    return "'rewrite': {'uri': " + rewrite.getRewrite() + "}";
+
+  }
+
+  public void addHTTPMatchRequest(IstioHTTPMatchRequest match){
+    this.match.add(match);
+  }
+
+  public void addHTTPDestination(IstioHTTPDestination destination){
+    this.route.add(destination);
+  }
+  public static class IstioRewrite{
+    @SerializedName("uri")
+    private String uri;
+
+    public IstioRewrite(String rewrite){
+      this.uri = rewrite;
+    }
+
+    public String getRewrite() {
+      return uri;
+    }
+  }
+
+}

--- a/submarine-serve/src/main/java/org/apache/submarine/serve/istio/IstioVirtualService.java
+++ b/submarine-serve/src/main/java/org/apache/submarine/serve/istio/IstioVirtualService.java
@@ -1,0 +1,153 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.submarine.serve.istio;
+
+import com.google.gson.annotations.SerializedName;
+import io.kubernetes.client.models.V1ObjectMeta;
+import org.apache.submarine.serve.utils.IstioConstants;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class IstioVirtualService {
+  @SerializedName("apiVersion")
+  private String apiVersion = IstioConstants.API_VERSION;
+
+  @SerializedName("kind")
+  private String kind = IstioConstants.KIND;
+
+  @SerializedName("metadata")
+  private V1ObjectMeta metadata;
+
+  @SerializedName("spec")
+  private IstioVirtualServiceSpec spec;
+
+  // transient to avoid being serialized
+  private transient String group = IstioConstants.GROUP;
+
+  private transient String version = IstioConstants.VERSION;
+
+  private transient String plural = IstioConstants.PLURAL;
+
+  public IstioVirtualService(String modelName, Integer modelVersion) {
+    V1ObjectMeta metadata = new V1ObjectMeta();
+    metadata.setName(modelName);
+    metadata.setNamespace(IstioConstants.DEFAULT_NAMESPACE);
+    setMetadata(metadata);
+    setSpec(new IstioVirtualServiceSpec(modelName, modelVersion));
+  }
+
+  public String getApiVersion() {
+    return apiVersion;
+  }
+
+  public void setApiVersion(String apiVersion) {
+    this.apiVersion = apiVersion;
+  }
+
+  public String getKind() {
+    return kind;
+  }
+
+  public void setKind(String kind) {
+    this.kind = kind;
+  }
+
+  public V1ObjectMeta getMetadata() {
+    return metadata;
+  }
+
+  public void setMetadata(V1ObjectMeta metadata) {
+    this.metadata = metadata;
+  }
+
+  public String getGroup() {
+    return group;
+  }
+
+  public void setGroup(String group) {
+    this.group = group;
+  }
+
+  public String getVersion() {
+    return version;
+  }
+
+  public void setVersion(String version) {
+    this.version = version;
+  }
+
+  public String getPlural() {
+    return plural;
+  }
+
+  public void setPlural(String plural) {
+    this.plural = plural;
+  }
+
+  public IstioVirtualServiceSpec getSpec() {
+    return spec;
+  }
+
+  public void setSpec(IstioVirtualServiceSpec istioVirtualServiceSpec){
+    this.spec = istioVirtualServiceSpec;
+  }
+
+  public static class IstioVirtualServiceSpec {
+    @SerializedName("hosts")
+    private List<String> hosts = new ArrayList<>();
+    @SerializedName("gateways")
+    private List<String> gateways = new ArrayList<>();
+    @SerializedName("http")
+    private List<IstioHTTPRoute> httpRoute = new ArrayList<>();
+
+    public IstioVirtualServiceSpec(String modelName, Integer modelVersion) {
+      hosts.add(IstioConstants.DEFAULT_INGRESS_HOST);
+      gateways.add(IstioConstants.DEFAULT_GATEWAY);
+      IstioHTTPDestination destination = new IstioHTTPDestination(
+          modelName + "-" + IstioConstants.DEFAULT_NAMESPACE);
+      IstioHTTPMatchRequest matchRequest = new IstioHTTPMatchRequest("/" + modelName
+          + "/"  + String.valueOf(modelVersion) + "/");
+      IstioHTTPRoute httpRoute = new IstioHTTPRoute();
+      httpRoute.addHTTPDestination(destination);
+      httpRoute.addHTTPMatchRequest(matchRequest);
+      setHTTPRoute(httpRoute);
+    }
+
+    public List<String> getHosts() {
+      return this.hosts;
+    }
+
+    public void addHost(String host) {
+      hosts.add(host);
+    }
+
+    public List<String> getGateways() {
+      return this.gateways;
+    }
+
+    public void addGateway(String gateway) {
+      gateways.add(gateway);
+    }
+
+    public void setHTTPRoute(IstioHTTPRoute istioHTTPRoute){
+      this.httpRoute.add(istioHTTPRoute);
+    }
+  }
+}

--- a/submarine-serve/src/main/java/org/apache/submarine/serve/utils/IstioConstants.java
+++ b/submarine-serve/src/main/java/org/apache/submarine/serve/utils/IstioConstants.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.submarine.serve.utils;
+
+public class IstioConstants {
+  public static final String API_VERSION = "networking.istio.io/v1beta1";
+
+  public static final String KIND = "VirtualService";
+
+  public static final String GROUP = "networking.istio.io";
+
+  public static final String VERSION = "v1beta1";
+
+  public static final String PLURAL = "virtualservices";
+
+  public static final String REWRITE_URL = "/"; 
+
+  public static final String DEFAULT_NAMESPACE = "default";
+
+  public static final String DEFAULT_GATEWAY = "istio-system/seldon-gateway";
+
+  public static final Integer DEFAULT_SERVE_POD_PORT = 8000;
+
+  public static final String DEFAULT_INGRESS_HOST = "*"; 
+
+}


### PR DESCRIPTION
### What is this PR for?
Add a new route to serve pod.
new route: http://\{submarine ip}/{model name}/{model version}/api/v1.0/predictions

### What type of PR is it?
Feature

### Todos

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-1130

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* Do the license files need updating? No
* Are there breaking changes for older versions? No
* Does this need new documentation? No
