### PR TITLE
SUBMARINE-1122. Job "Build submarine quickstart" failed in github actions

### DIFF
--- a/dev-support/examples/quickstart/Dockerfile
+++ b/dev-support/examples/quickstart/Dockerfile
@@ -13,12 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM continuumio/anaconda3
+FROM python:3.7
 MAINTAINER Apache Software Foundation <dev@submarine.apache.org>
 
 ADD ./tmp/submarine-sdk /opt/
 # install submarine-sdk locally
-RUN pip install /opt/pysubmarine/.[tf-latest] 
+RUN pip install /opt/pysubmarine/.[tf2]
 RUN pip install tensorflow_datasets
 
 ADD ./train.py /opt/

--- a/website/docs/gettingStarted/quickstart.md
+++ b/website/docs/gettingStarted/quickstart.md
@@ -182,6 +182,7 @@ if __name__ == '__main__':
 Build a docker image equipped with the requirement of the environment.
 
 ```bash
+eval $(minikube docker-env)
 ./dev-support/examples/quickstart/build.sh
 ```
 


### PR DESCRIPTION
### What is this PR for?
Job "Build submarine quickstart" failed in recent github actions

![](https://issues.apache.org/jira/secure/attachment/13037195/image-2021-12-09-23-00-21-233.png)

### What type of PR is it?
[Bug Fix]

### Todos

### What is the Jira issue?
https://issues.apache.org/jira/projects/SUBMARINE/issues/SUBMARINE-1122

### How should this be tested?

Before this PR, running `./dev-support/examples/quickstart/build.sh` will fail due to the python version is too new in the docker image "continuumio/anaconda3". This PR uses the image "python:3.7" so that the above build command will succeed.

### Screenshots (if appropriate)

### Questions:
* Do the license files need updating? No
* Are there breaking changes for older versions? No
* Does this need new documentation? No
