### PR TITLE
SUBMARINE-1126. Let Jupyter Notebook save user setting after pod restarted.

### DIFF
--- a/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/util/NotebookUtils.java
+++ b/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/util/NotebookUtils.java
@@ -44,10 +44,11 @@ public class NotebookUtils {
 
   private static final Logger LOG = LoggerFactory.getLogger(NotebookUtils.class);
   public static final String STORAGE = "10Gi";
+  public static final String DEFAULT_USER_STORAGE = "100Mi";
   public static final String SC_NAME = "submarine-storageclass";
-  public static final String STORAGE_PREFIX = "notebook-storage-";
-  public static final String PV_PREFIX = "notebook-pv-";
-  public static final String PVC_PREFIX = "notebook-pvc-";
+  public static final String STORAGE_PREFIX = "notebook-storage";
+  public static final String PV_PREFIX = "notebook-pv";
+  public static final String PVC_PREFIX = "notebook-pvc";
   public static final String HOST_PATH = "/mnt";
 
   public enum ParseOpt {


### PR DESCRIPTION
### What is this PR for?
Jupyter Notebook have created a workspace volume `/home/jovyan/workspace` , but the user settings are saved in `/home/jovyan/.jupyter/lab/user-settings/@jupyterlab/`. 
So that after pod restart, submarine will lost user settings. I think we should add a new volume to save user settings in `/home/jovyan/.jupyter/`.

### What type of PR is it?
Improvement

### Todos
* [x] - Add a new PVC named `notebook-pvc-user-*` when creating notebook pod CRD

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-1126

### How should this be tested?
There are no new test cases right now.

### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/12069428/146344069-5c92950b-cbd0-41d9-bc01-69625e9945a0.png)

### Questions:
* Do the license files need updating? No
* Are there breaking changes for older versions? No
* Does this need new documentation? Maybe No
