### PR TITLE
SUBMARINE-1125. Fix Conda Version match error

### DIFF
--- a/submarine-commons/commons-utils/src/main/java/org/apache/submarine/commons/utils/SubmarineConfVars.java
+++ b/submarine-commons/commons-utils/src/main/java/org/apache/submarine/commons/utils/SubmarineConfVars.java
@@ -70,7 +70,7 @@ public class SubmarineConfVars {
         "org.apache.submarine.server.submitter.yarn.YarnRuntimeFactory"),
     SUBMARINE_SUBMITTER("submarine.submitter", "k8s"),
     ENVIRONMENT_CONDA_MIN_VERSION("environment.conda.min.version", "4.0.1"),
-    ENVIRONMENT_CONDA_MAX_VERSION("environment.conda.max.version", "4.10.10");
+    ENVIRONMENT_CONDA_MAX_VERSION("environment.conda.max.version", "4.11.10");
 
     private String varName;
     @SuppressWarnings("rawtypes")

--- a/submarine-server/server-submitter/submitter-k8s/src/test/java/org/apache/submarine/server/submitter/k8s/ExperimentSpecParserTest.java
+++ b/submarine-server/server-submitter/submitter-k8s/src/test/java/org/apache/submarine/server/submitter/k8s/ExperimentSpecParserTest.java
@@ -255,7 +255,7 @@ public class ExperimentSpecParserTest extends SpecBuilder {
                + "\"$currentVersion\" | sort -V | head -n2 | tail -1 )\" "
                     + "!= \"$currentVersion\" ]; then echo \"Conda version " +
                     "should be between minVersion=\"4.0.1\"; " +
-                    "and maxVersion=\"4.10.10\";\"; exit 1; else echo "
+                    "and maxVersion=\"4.11.10\";\"; exit 1; else echo "
                     + "\"Conda current version is " + currentVersion + ". "
                         + "Moving forward with env creation and activation.\"; "
                         + "fi && " +

--- a/submarine-test/test-k8s/src/test/java/org/apache/submarine/rest/ExperimentRestApiIT.java
+++ b/submarine-test/test-k8s/src/test/java/org/apache/submarine/rest/ExperimentRestApiIT.java
@@ -344,7 +344,7 @@ public class ExperimentRestApiIT extends AbstractSubmarineServerTest {
             + "\"$currentVersion\" | sort -V | head -n2 | tail -1 )\" "
             + "!= \"$currentVersion\" ]; then echo \"Conda version " +
             "should be between minVersion=\"4.0.1\"; " +
-            "and maxVersion=\"4.10.10\";\"; exit 1; else echo "
+            "and maxVersion=\"4.11.10\";\"; exit 1; else echo "
             + "\"Conda current version is " + currentVersion + ". "
             + "Moving forward with env creation and activation.\"; "
             + "fi && ";


### PR DESCRIPTION
### What is this PR for?
The Conda version in jupyter-notebook-0.7.0-SNAPSHOT docker image is 4.11.0 now. But in Submarine it still check version from 4.0.1 to 4.10.10, so that when notebook pod start, it report error like this:
![image](https://user-images.githubusercontent.com/12069428/146346285-b30b19f9-927c-412a-8098-c1906ef51fc1.png)


### What type of PR is it?
Bug Fix 

### Todos
* [x] - Replace max version to 4.11

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-1125

### How should this be tested?
Can test in new docker image.

### Screenshots (if appropriate)

### Questions:
* Do the license files need updating? No
* Are there breaking changes for older versions? No
* Does this need new documentation? No
