### PR TITLE
SUBMARINE-1148. Persist kind cluster data in local directory

### DIFF
--- a/dev-support/kind-config.yaml
+++ b/dev-support/kind-config.yaml
@@ -1,0 +1,22 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+  kubeadmConfigPatches:
+  - |
+    kind: InitConfiguration
+    nodeRegistration:
+      kubeletExtraArgs:
+        node-labels: "ingress-ready=true"
+        authorization-mode: "AlwaysAllow"
+  extraPortMappings:
+  - containerPort: 32080
+    hostPort: 80
+    protocol: TCP
+  - containerPort: 443
+    hostPort: 443
+    protocol: TCP
+  extraMounts:
+    - hostPath: /mnt/data
+      containerPath: /submarine
+

--- a/dev-support/kind-config.yaml
+++ b/dev-support/kind-config.yaml
@@ -11,7 +11,7 @@ nodes:
         authorization-mode: "AlwaysAllow"
   extraPortMappings:
   - containerPort: 32080
-    hostPort: 80
+    hostPort: 32080
     protocol: TCP
   - containerPort: 443
     hostPort: 443

--- a/helm-charts/submarine/kind-values.yaml
+++ b/helm-charts/submarine/kind-values.yaml
@@ -1,0 +1,32 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: submarine-operator
+replicas: 1
+image: apache/submarine:operator-0.7.0-SNAPSHOT
+# dev is to tell helm to install submarine-operator or not
+dev: false
+# storageClass is for dynamically creating persistent volumes
+storageClass:
+  # reclaimPolicy is to determine the action after the persistent volume is released
+  reclaimPolicy: Delete
+  # volumeBindingMode controls when volume binding and dynamically provisioning should occur
+  volumeBindingMode: WaitForFirstConsumer
+  # provisioner is to determine what volume plugin is used for provisioning PVs
+  provisioner: kubernetes.io/no-provisioner
+  # parameters describe volumes belonging to the storage class
+  parameters:

--- a/helm-charts/submarine/templates/pv.yaml
+++ b/helm-charts/submarine/templates/pv.yaml
@@ -1,0 +1,101 @@
+{{- if eq .Values.storageClass.provisioner "kubernetes.io/no-provisioner"}}
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: database-pv
+  labels:
+    type: local
+spec:
+  storageClassName: submarine-storageclass
+  capacity:
+    storage: 10Gi
+  accessModes:
+    - ReadWriteOnce
+  local:
+    path: /submarine
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          - kind-control-plane
+
+---
+
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: minio-pv
+  labels:
+    type: local
+spec:
+  storageClassName: submarine-storageclass
+  capacity:
+    storage: 10Gi
+  accessModes:
+    - ReadWriteOnce
+  local:
+    path: /submarine
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          - kind-control-plane
+
+---
+
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: mlflow-pv
+  labels:
+    type: local
+spec:
+  storageClassName: submarine-storageclass
+  capacity:
+    storage: 10Gi
+  accessModes:
+    - ReadWriteOnce
+  local:
+    path: /submarine
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          - kind-control-plane
+
+---
+
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: tensorboard-pv
+  labels:
+    type: local
+spec:
+  storageClassName: submarine-storageclass
+  capacity:
+    storage: 10Gi
+  accessModes:
+    - ReadWriteOnce
+  local:
+    path: /submarine
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          - kind-control-plane
+
+{{- end }}
+


### PR DESCRIPTION
Signed-off-by: Kevin Su <pingsutw@apache.org>

### What is this PR for?
<!-- A few sentences describing the overall goals of the pull request's commits.
First time? Check out the contributing guide - https://submarine.apache.org/contribution/contributions.html
-->
Add a new helm chart value.yaml, so that the users can directly apply this YAML to install submarine in the kind cluster, and install PV if using [Local volumes](https://kubernetes.io/docs/concepts/storage/storage-classes/#local)

### What type of PR is it?
[Improvement]

### Todos
* [ ] - Task

### What is the Jira issue?
<!-- * Open an issue on Jira https://issues.apache.org/jira/browse/SUBMARINE/
* Put link here, and add [SUBMARINE-*Jira number*] in PR title, eg. `SUBMARINE-23. PR title`
-->
https://issues.apache.org/jira/browse/SUBMARINE-1148

### How should this be tested?
<!--
* First time? Setup Travis CI as described on https://submarine.apache.org/contribution/contributions.html#continuous-integration
* Strongly recommended: add automated unit tests for any new or changed behavior
* Outline any manual steps to test the PR here.
-->
pass the CIs

### Screenshots (if appropriate)

### Questions:
* Do the license files need updating? No
* Are there breaking changes for older versions? No
* Does this need new documentation? No
