### PR TITLE
SUBMARINE-1135. Implement CLI Config Command

### DIFF
--- a/submarine-sdk/pysubmarine/setup.py
+++ b/submarine-sdk/pysubmarine/setup.py
@@ -44,7 +44,7 @@ setup(
         "click==8.0.3",
         "rich==10.15.2",
         "dacite==1.6.0",
-        "dataclasses==0.8",
+        "dataclasses>=0.6",
         "pyaml==21.10.1",
     ],
     extras_require={

--- a/submarine-sdk/pysubmarine/setup.py
+++ b/submarine-sdk/pysubmarine/setup.py
@@ -26,6 +26,7 @@ setup(
     long_description_content_type="text/markdown",
     url="https://github.com/apache/submarine",
     packages=find_packages(exclude=["tests", "tests.*"]),
+    package_data={"submarine.cli.config": ["cli_config.yaml"]},
     install_requires=[
         "six>=1.10.0",
         "numpy==1.19.2",
@@ -41,6 +42,9 @@ setup(
         "mlflow>=1.15.0",
         "boto3>=1.17.58",
         "click==8.0.3",
+        "dacite==1.6.0",
+        "dataclasses==0.8",
+        "pyaml==21.10.1",
     ],
     extras_require={
         "tf": ["tensorflow==1.15.0"],

--- a/submarine-sdk/pysubmarine/setup.py
+++ b/submarine-sdk/pysubmarine/setup.py
@@ -42,6 +42,7 @@ setup(
         "mlflow>=1.15.0",
         "boto3>=1.17.58",
         "click==8.0.3",
+        "rich==10.15.2",
         "dacite==1.6.0",
         "dataclasses==0.8",
         "pyaml==21.10.1",

--- a/submarine-sdk/pysubmarine/submarine/cli/config/__init__.py
+++ b/submarine-sdk/pysubmarine/submarine/cli/config/__init__.py
@@ -1,11 +1,11 @@
 # Licensed to the Apache Software Foundation (ASF) under one or more
-# contributor license agreements. See the NOTICE file distributed with
+# contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
 # The ASF licenses this file to You under the Apache License, Version 2.0
 # (the "License"); you may not use this file except in compliance with
-# the License. You may obtain a copy of the License at
+# the License.  You may obtain a copy of the License at
 #
-# http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,11 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-mypy==0.910
-types-requests==2.25.6
-types-certifi==2020.4.0
-types-six==1.16.1
-types-python-dateutil==2.8.0
-types-dataclasses==0.6.1
-types-PyYAML==6.0.1
-sqlalchemy[mypy]
+from submarine.cli.config.command import get_config, init_config, list_config, set_config
+
+__all__ = [
+    "list_config",
+    "get_config",
+    "set_config",
+    "init_config",
+]

--- a/submarine-sdk/pysubmarine/submarine/cli/config/cli_config.yaml
+++ b/submarine-sdk/pysubmarine/submarine/cli/config/cli_config.yaml
@@ -1,0 +1,3 @@
+connection:
+  hostname: "localhost"
+  port: 32080

--- a/submarine-sdk/pysubmarine/submarine/cli/config/command.py
+++ b/submarine-sdk/pysubmarine/submarine/cli/config/command.py
@@ -1,0 +1,82 @@
+"""
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+ http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+"""
+
+from dataclasses import asdict
+from typing import Union
+
+import click
+from rich.console import Console
+from rich.json import JSON as richJSON
+from rich.panel import Panel
+
+from submarine.cli.config.config import initConfig, loadConfig, rgetattr, rsetattr, saveConfig
+
+
+@click.command("list")
+def list_config():
+    """List Submarine CLI Config"""
+    console = Console()
+    _config = loadConfig()
+    json_data = richJSON.from_data({**asdict(_config)})
+    console.print(Panel(json_data, title="SubmarineCliConfig"))
+
+
+@click.command("get")
+@click.argument("param")
+def get_config(param):
+    """Get Submarine CLI Config"""
+    _config = loadConfig()
+    try:
+        click.echo("{}={}".format(param, rgetattr(_config, param)))
+    except AttributeError as err:
+        click.echo(err)
+
+
+@click.command("set")
+@click.argument("param")
+@click.argument("value")
+def set_config(param, value):
+    """Set Submarine CLI Config"""
+    _config = loadConfig()
+    _paramField = rgetattr(_config, param)
+    # define types that can be cast from command line input
+    primitive = (int, str, bool)
+
+    def is_primitiveType(_type):
+        return _type in primitive
+
+    # cast type
+    if type(_paramField) == type(Union) and is_primitiveType(type(_paramField).__args__[0]):
+        value = type(_paramField).__args__[0](value)
+    elif is_primitiveType(type(_paramField)):
+        value = type(_paramField)(value)
+
+    try:
+        rsetattr(_config, param, value)
+    except TypeError as err:
+        click.echo(err)
+    saveConfig(_config)
+
+
+@click.command("init")
+def init_config():
+    """Init Submarine CLI Config"""
+    try:
+        initConfig()
+        click.echo("Submarine CLI Config initialized")
+    except AttributeError as err:
+        click.echo(err)

--- a/submarine-sdk/pysubmarine/submarine/cli/config/config.py
+++ b/submarine-sdk/pysubmarine/submarine/cli/config/config.py
@@ -1,0 +1,127 @@
+"""
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+ http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+"""
+
+import functools
+import os
+from dataclasses import asdict, dataclass, field
+from typing import Optional, Union
+
+import click
+import dacite
+import yaml
+
+CONFIG_YAML_PATH = os.path.join(os.path.dirname(__file__), "cli_config.yaml")
+
+
+@dataclass
+class BaseConfig:
+    def __setattr__(self, __name, __value) -> None:
+        """
+        Override __setattr__ for custom type checking
+        """
+        # ignore this line for mypy checking, since there is some errors for mypy to check dataclass
+        _field = self.__dataclass_fields__[__name]  # type: ignore
+        if type(_field.type) == type(Union):
+            if not isinstance(__value, _field.type.__args__):
+                msg = (
+                    "Field `{0.name}` is of type {1}, should be one of the type: {0.type.__args__}"
+                    .format(_field, type(__value))
+                )
+                raise TypeError(msg)
+        else:
+            if not isinstance(__value, _field.type):
+                msg = "Field {0.name} is of type {1}, should be {0.type}".format(
+                    _field, type(__value)
+                )
+                raise TypeError(msg)
+
+        super().__setattr__(__name, __value)
+
+
+@dataclass
+class ConnectionConfig(BaseConfig):
+    hostname: Optional[str] = field(
+        default="localhost",
+        metadata={"help": "Hostname for submarine CLI to connect"},
+    )
+
+    port: Optional[int] = field(
+        default=8080,
+        metadata={"help": "Port for submarine CLI to connect"},
+    )
+
+
+@dataclass
+class SubmarineCliConfig(BaseConfig):
+    connection: ConnectionConfig = field(
+        default_factory=lambda: ConnectionConfig(),
+        metadata={"help": "Port for submarine CLI to connect"},
+    )
+
+
+def rgetattr(obj, attr, *args):
+    """
+    Recursive get attr
+    Example:
+        rgetattr(obj,"a.b.c") is equivalent to obj.a.b.c
+    """
+
+    def _getattr(obj, attr):
+        return getattr(obj, attr, *args)
+
+    return functools.reduce(_getattr, [obj] + attr.split("."))
+
+
+def rsetattr(obj, attr, val):
+    """
+    Recursive set attr
+    Example:
+        rsetattr(obj,"a.b.c",val) is equivalent to obj.a.b.c = val
+    """
+    pre, _, post = attr.rpartition(".")
+    if pre:
+        _r = rgetattr(obj, pre)
+        return setattr(_r, post, val)
+    else:
+        return setattr(obj, post, val)
+
+
+def loadConfig(config_path: str = CONFIG_YAML_PATH) -> Optional[SubmarineCliConfig]:
+    with open(config_path, "r") as stream:
+        try:
+            parsed_yaml: dict = yaml.safe_load(stream)
+            return_config: SubmarineCliConfig = dacite.from_dict(
+                data_class=SubmarineCliConfig, data=parsed_yaml
+            )
+            return return_config
+        except yaml.YAMLError as exc:
+            click.echo("Error Reading Config")
+            click.echo(exc)
+            return None
+
+
+def saveConfig(config: SubmarineCliConfig, config_path: str = CONFIG_YAML_PATH):
+    with open(config_path, "w") as stream:
+        try:
+            yaml.safe_dump({**asdict(config)}, stream)
+        except yaml.YAMLError as exc:
+            click.echo("Error Saving Config")
+            click.echo(exc)
+
+
+def initConfig(config_path: str = CONFIG_YAML_PATH):
+    saveConfig(SubmarineCliConfig(), config_path)

--- a/submarine-sdk/pysubmarine/submarine/cli/config/config.py
+++ b/submarine-sdk/pysubmarine/submarine/cli/config/config.py
@@ -60,7 +60,7 @@ class ConnectionConfig(BaseConfig):
     )
 
     port: Optional[int] = field(
-        default=8080,
+        default=32080,
         metadata={"help": "Port for submarine CLI to connect"},
     )
 

--- a/submarine-sdk/pysubmarine/submarine/cli/config/config.py
+++ b/submarine-sdk/pysubmarine/submarine/cli/config/config.py
@@ -35,7 +35,7 @@ class BaseConfig:
         """
         # ignore this line for mypy checking, since there is some errors for mypy to check dataclass
         _field = self.__dataclass_fields__[__name]  # type: ignore
-        if type(_field.type) == type(Union):
+        if hasattr(_field.type, "__origin__") and _field.type.__origin__ == Union:
             if not isinstance(__value, _field.type.__args__):
                 msg = (
                     "Field `{0.name}` is of type {1}, should be one of the type: {0.type.__args__}"
@@ -43,7 +43,7 @@ class BaseConfig:
                 )
                 raise TypeError(msg)
         else:
-            if not isinstance(__value, _field.type):
+            if not type(__value) == _field.type:
                 msg = "Field {0.name} is of type {1}, should be {0.type}".format(
                     _field, type(__value)
                 )

--- a/submarine-sdk/pysubmarine/submarine/cli/main.py
+++ b/submarine-sdk/pysubmarine/submarine/cli/main.py
@@ -17,6 +17,7 @@
 
 import click
 
+from submarine.cli.config import command as config_cmd
 from submarine.cli.environment import command as environment_cmd
 from submarine.cli.experiment import command as experiment_cmd
 from submarine.cli.notebook import command as notebook_cmd
@@ -49,6 +50,11 @@ def cmdgrp_sandbox():
     pass
 
 
+@entry_point.group("config")
+def cmdgrp_config():
+    pass
+
+
 # experiment
 cmdgrp_list.add_command(experiment_cmd.list_experiment)
 cmdgrp_get.add_command(experiment_cmd.get_experiment)
@@ -65,3 +71,9 @@ cmdgrp_delete.add_command(environment_cmd.delete_environment)
 # sandbox
 cmdgrp_sandbox.add_command(sandbox_cmd.start_sandbox)
 cmdgrp_sandbox.add_command(sandbox_cmd.delete_sandbox)
+
+# config
+cmdgrp_config.add_command(config_cmd.set_config)
+cmdgrp_config.add_command(config_cmd.list_config)
+cmdgrp_config.add_command(config_cmd.get_config)
+cmdgrp_config.add_command(config_cmd.init_config)

--- a/submarine-sdk/pysubmarine/tests/cli/test_config.py
+++ b/submarine-sdk/pysubmarine/tests/cli/test_config.py
@@ -16,7 +16,7 @@
 from click.testing import CliRunner
 
 from submarine.cli import main
-from submarine.cli.config.config import initConfig, loadConfig
+from submarine.cli.config.config import SubmarineCliConfig, initConfig, loadConfig
 
 
 def test_list_config():
@@ -28,6 +28,16 @@ def test_list_config():
     assert "SubmarineCliConfig" in result.output
     assert '"hostname": "{}"'.format(_config.connection.hostname) in result.output
     assert '"port": {}'.format(_config.connection.port) in result.output
+
+
+def test_init_config():
+    runner = CliRunner()
+    result = runner.invoke(main.entry_point, ["config", "init"])
+    result = runner.invoke(main.entry_point, ["config", "list"])
+    _default_config = SubmarineCliConfig()
+    assert result.exit_code == 0
+    assert '"hostname": "{}"'.format(_default_config.connection.hostname) in result.output
+    assert '"port": {}'.format(_default_config.connection.port) in result.output
 
 
 def test_get_set_experiment():

--- a/submarine-sdk/pysubmarine/tests/cli/test_config.py
+++ b/submarine-sdk/pysubmarine/tests/cli/test_config.py
@@ -1,0 +1,52 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from click.testing import CliRunner
+
+from submarine.cli import main
+from submarine.cli.config.config import initConfig, loadConfig
+
+
+def test_list_config():
+    initConfig()
+    runner = CliRunner()
+    result = runner.invoke(main.entry_point, ["config", "list"])
+    _config = loadConfig()
+    assert result.exit_code == 0
+    assert "SubmarineCliConfig" in result.output
+    assert '"hostname": "{}"'.format(_config.connection.hostname) in result.output
+    assert '"port": {}'.format(_config.connection.port) in result.output
+
+
+def test_get_set_experiment():
+    initConfig()
+    mock_hostname = "mockhost"
+    runner = CliRunner()
+    result = runner.invoke(main.entry_point, ["config", "get", "connection.hostname"])
+    assert result.exit_code == 0
+    _config = loadConfig()
+    assert "connection.hostname={}".format(_config.connection.hostname) in result.output
+
+    result = runner.invoke(
+        main.entry_point, ["config", "set", "connection.hostname", mock_hostname]
+    )
+    assert result.exit_code == 0
+
+    result = runner.invoke(main.entry_point, ["config", "get", "connection.hostname"])
+    assert result.exit_code == 0
+    _config = loadConfig()
+    assert "connection.hostname={}".format(mock_hostname) in result.output
+    assert mock_hostname == _config.connection.hostname
+    initConfig()


### PR DESCRIPTION
### What is this PR for?

Implement `submarine config` command to set *_port_* and *_hostname_* for API connection.
Usage:
`submarine config init` : init config file (restore to default)
`submarine config list` : list config content
`submarine config set <param> <value>` : set param = value in config
`submarine config get <param>` : get param

Examples:
1. Change API port to `8080`
`submarine config set connection.port 8080`
2. Change hostname to `127.0.0.1`
`submarine config set connection.hostname 127.0.0.1`

### What type of PR is it?
[Feature]

### Todos
None

### What is the Jira issue?
https://issues.apache.org/jira/projects/SUBMARINE/issues/SUBMARINE-1135

### How should this be tested?
python unit test is implemented

### Screenshots (if appropriate)
![](https://i.imgur.com/fk1MStN.png)

### Questions:
* Do the license files need updating? No
* Are there breaking changes for older versions? No
* Does this need new documentation? Yes
