### PR TITLE
SUBMARINE-1124 Add the status of NOT_FOUND to replace the delete operation

### DIFF
--- a/submarine-commons/commons-utils/src/main/java/org/apache/submarine/commons/utils/SubmarineConfVars.java
+++ b/submarine-commons/commons-utils/src/main/java/org/apache/submarine/commons/utils/SubmarineConfVars.java
@@ -54,7 +54,9 @@ public class SubmarineConfVars {
     JDBC_DRIVERCLASSNAME("jdbc.driverClassName", "com.mysql.jdbc.Driver"),
     JDBC_URL("jdbc.url", "jdbc:mysql://127.0.0.1:3306/submarine" +
         "?useUnicode=true&characterEncoding=UTF-8&autoReconnect=true&allowMultiQueries=true&" +
-        "failOverReadOnly=false&zeroDateTimeBehavior=convertToNull&useSSL=false"),
+        "failOverReadOnly=false&zeroDateTimeBehavior=convertToNull&useSSL=false&" +
+        // use timezone for dateformat, current default database timezone is utc
+        "serverTimezone=UTC&useTimezone=true&useLegacyDatetimeCode=true"),
     JDBC_USERNAME("jdbc.username", "submarine"),
     JDBC_PASSWORD("jdbc.password", "password"),
     METASTORE_JDBC_URL("metastore.jdbc.url", "jdbc:mysql://127.0.0.1:3306/metastore" +

--- a/submarine-server/server-api/src/main/java/org/apache/submarine/server/api/notebook/Notebook.java
+++ b/submarine-server/server-api/src/main/java/org/apache/submarine/server/api/notebook/Notebook.java
@@ -112,6 +112,7 @@ public class Notebook {
     STATUS_RUNNING("running"),
     STATUS_WAITING("waiting"),
     STATUS_TERMINATING("terminating"),
+    STATUS_NOT_FOUND("not_found"),
     STATUS_PULLING("pulling");
 
     private String value;

--- a/submarine-server/server-core/src/main/java/org/apache/submarine/server/notebook/NotebookManager.java
+++ b/submarine-server/server-core/src/main/java/org/apache/submarine/server/notebook/NotebookManager.java
@@ -142,10 +142,12 @@ public class NotebookManager {
         Notebook notebook = submitter.findNotebook(nb.getSpec());
         notebook.setNotebookId(nb.getNotebookId());
         notebook.setSpec(nb.getSpec());
+        if (notebook.getCreatedTime() == null) {
+          notebook.setCreatedTime(nb.getCreatedTime());
+        }
         notebookList.add(notebook);
       } catch (SubmarineRuntimeException e) {
-        LOG.warn("Submitter can not find notebook: {}, will delete it", nb.getNotebookId());
-        notebookService.delete(nb.getNotebookId().toString());
+        LOG.error("Error when get notebook resource, skip this row!", e);
       }
     }
     return notebookList;

--- a/submarine-server/server-core/src/main/java/org/apache/submarine/server/notebook/database/service/NotebookService.java
+++ b/submarine-server/server-core/src/main/java/org/apache/submarine/server/notebook/database/service/NotebookService.java
@@ -21,6 +21,8 @@ package org.apache.submarine.server.notebook.database.service;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.submarine.commons.utils.exception.SubmarineRuntimeException;
@@ -138,6 +140,8 @@ public class NotebookService {
     return entity;
   }
 
+  private static final DateFormat RESOURCE_TIME_FORMAT = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX");
+
   /**
    * Create a new notebook instance from entity.
    *
@@ -151,6 +155,7 @@ public class NotebookService {
       notebook.setSpec(new Gson().fromJson(entity.getNotebookSpec(), NotebookSpec.class));
       notebook.setName(notebook.getSpec().getMeta().getName());
       notebook.setStatus(entity.getNotebookStatus());
+      notebook.setCreatedTime(RESOURCE_TIME_FORMAT.format(entity.getCreateTime()));
     } catch (Exception e) {
       LOG.error(e.getMessage(), e);
       throw new SubmarineRuntimeException("Unable to build notebook from entity");

--- a/submarine-server/server-core/src/main/java/org/apache/submarine/server/notebook/database/service/NotebookService.java
+++ b/submarine-server/server-core/src/main/java/org/apache/submarine/server/notebook/database/service/NotebookService.java
@@ -21,8 +21,6 @@ package org.apache.submarine.server.notebook.database.service;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.submarine.commons.utils.exception.SubmarineRuntimeException;
@@ -140,8 +138,6 @@ public class NotebookService {
     return entity;
   }
 
-  private static final DateFormat RESOURCE_TIME_FORMAT = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX");
-
   /**
    * Create a new notebook instance from entity.
    *
@@ -155,7 +151,6 @@ public class NotebookService {
       notebook.setSpec(new Gson().fromJson(entity.getNotebookSpec(), NotebookSpec.class));
       notebook.setName(notebook.getSpec().getMeta().getName());
       notebook.setStatus(entity.getNotebookStatus());
-      notebook.setCreatedTime(RESOURCE_TIME_FORMAT.format(entity.getCreateTime()));
     } catch (Exception e) {
       LOG.error(e.getMessage(), e);
       throw new SubmarineRuntimeException("Unable to build notebook from entity");

--- a/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/K8sSubmitter.java
+++ b/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/K8sSubmitter.java
@@ -547,9 +547,9 @@ public class K8sSubmitter implements Submitter {
 
     try {
       Object object = api.deleteNamespacedCustomObject(notebookCR.getGroup(), notebookCR.getVersion(),
-              namespace, notebookCR.getPlural(),
-              notebookCR.getMetadata().getName(), null, null, null,
-              null, new V1DeleteOptionsBuilder().withApiVersion(notebookCR.getApiVersion()).build());
+          namespace, notebookCR.getPlural(),
+          notebookCR.getMetadata().getName(), null, null, null,
+          null, new V1DeleteOptionsBuilder().withApiVersion(notebookCR.getApiVersion()).build());
       notebook = NotebookUtils.parseObject(object, NotebookUtils.ParseOpt.PARSE_OPT_DELETE);
     } catch (ApiException e) {
       API_EXCEPTION_404_CONSUMER.apply(e);
@@ -572,7 +572,7 @@ public class K8sSubmitter implements Submitter {
     deletePersistentVolumeClaim(String.format("%s-%s", NotebookUtils.PVC_PREFIX, name), namespace);
     // user set pvc
     deletePersistentVolumeClaim(String.format("%s-user-%s", NotebookUtils.PVC_PREFIX, name), namespace);
-    
+
     // configmap
     if (StringUtils.isNoneBlank(OVERWRITE_JSON)) {
       deleteConfigMap(namespace, String.format("%s-%s", NotebookUtils.OVERWRITE_PREFIX, name));
@@ -899,7 +899,7 @@ public class K8sSubmitter implements Submitter {
   /**
    * Delete ConfigMap
    */
-  public void deleteConfigMap(String namespace, String name) throws ApiException {
+  public void deleteConfigMap(String namespace, String name) {
     try {
       coreApi.deleteNamespacedConfigMap(name, namespace,
           "true", null, null, null,
@@ -915,12 +915,8 @@ public class K8sSubmitter implements Submitter {
    */
   private void rollbackCreationConfigMap(String namespace, String ... names)
           throws SubmarineRuntimeException {
-    try {
-      for (String name : names) {
-        deleteConfigMap(namespace, name);
-      }
-    } catch (ApiException e) {
-      throw new SubmarineRuntimeException(e.getCode(), e.getMessage());
+    for (String name : names) {
+      deleteConfigMap(namespace, name);
     }
   }
 

--- a/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/util/NotebookUtils.java
+++ b/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/util/NotebookUtils.java
@@ -94,11 +94,15 @@ public class NotebookUtils {
     throw new SubmarineRuntimeException(500, "K8s Submitter parse upstream response failed.");
   }
 
-  private static Notebook buildNotebookResponse(NotebookCR notebookCR) {
+  public static Notebook buildNotebookResponse(NotebookCR notebookCR) {
     Notebook notebook = new Notebook();
     notebook.setUid(notebookCR.getMetadata().getUid());
     notebook.setName(notebookCR.getMetadata().getName());
     notebook.setCreatedTime(notebookCR.getMetadata().getCreationTimestamp().toString());
+    if (notebookCR.getMetadata().getCreationTimestamp() != null) {
+      notebook.setCreatedTime(notebookCR.getMetadata().getCreationTimestamp().toString());
+    }
+
     // notebook url
     notebook.setUrl("/notebook/" + notebookCR.getMetadata().getNamespace() + "/" +
             notebookCR.getMetadata().getName() + "/lab");

--- a/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/util/NotebookUtils.java
+++ b/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/util/NotebookUtils.java
@@ -98,7 +98,6 @@ public class NotebookUtils {
     Notebook notebook = new Notebook();
     notebook.setUid(notebookCR.getMetadata().getUid());
     notebook.setName(notebookCR.getMetadata().getName());
-    notebook.setCreatedTime(notebookCR.getMetadata().getCreationTimestamp().toString());
     if (notebookCR.getMetadata().getCreationTimestamp() != null) {
       notebook.setCreatedTime(notebookCR.getMetadata().getCreationTimestamp().toString());
     }


### PR DESCRIPTION
### What is this PR for?
Submarine delete notebook row from mysql database when k8s client can not find this related NoteBook CRD. But sometimes maybe due to timeout or API error caused by network and other reasons, it also report an error. At this time, submarine will think that the resource has been lost and forcibly delete it.

This is not a perfect logic. I think the better logic is to prompt the foreground that this resource has been lost and allow the user to delete it by himself.

At the same time, the logic of deletion should also be readjusted. If the resource does not exist, the program can continue to execute without throwing an exception. Otherwise, an endless loop will appear, and users cannot add or delete resources with the same name.

### What type of PR is it?
Bug Fix

### Todos
* [x] - Add a new status NOT_FOUND
* [x] - Modify delete logic, if resources do not exist, skip it. 

### What is the Jira issue?
https://issues.apache.org/jira/projects/SUBMARINE/issues/SUBMARINE-1124

### How should this be tested?
Right now there no new test cases.

### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/12069428/147805316-d9e9226c-d4a0-4c93-a960-6e1986b08852.png)

### Questions:
* Do the license files need updating? No
* Are there breaking changes for older versions? No
* Does this need new documentation? No
