### PR TITLE
SUBMARINE-1181. Fix the Python dependency

### DIFF
--- a/submarine-sdk/pysubmarine/github-actions/test-requirements.txt
+++ b/submarine-sdk/pysubmarine/github-actions/test-requirements.txt
@@ -22,7 +22,7 @@ attrdict==2.0.0
 pytest==3.2.1
 pytest-cov==2.6.0
 pytest-localserver==0.5.0
-pylint==2.5.2
+pylint==2.12.2
 PyMySQL==0.9.3
 pytest-mock==1.13.0
 certifi >= 14.05.14

--- a/website/docs/userDocs/submarine-sdk/pysubmarine/development.md
+++ b/website/docs/userDocs/submarine-sdk/pysubmarine/development.md
@@ -27,17 +27,17 @@ in its own conda environment by running the following
 conda create --name submarine-dev python=3.6
 conda activate submarine-dev
 
-# Install auto-format and lints (lint-requirements.txt is in ./dev-support/style-check/python)
-pip install -r lint-requirements.txt
+# Install auto-format and lints from current checkout
+pip install -r ./dev-support/style-check/python/lint-requirements.txt
 
-# Install mypy (mypy-requirements.txt is in ./dev-support/style-check/python)
-pip install -r mypy-requirements.txt
+# Install mypy from current checkout
+pip install -r ./dev-support/style-check/python/mypy-requirements.txt
 
-# test-requirements.txt is in ./submarine-sdk/pysubmarine/github-actions
-pip install -r test-requirements.txt
+# test-requirements.txt from current checkout
+pip install -r ./submarine-sdk/pysubmarine/github-actions/test-requirements.txt
 
 # Installs pysubmarine from current checkout
-pip install ./submarine-sdk/pysubmarine
+pip install -e ./submarine-sdk/pysubmarine
 ```
 
 ### PySubmarine Docker


### PR DESCRIPTION
### What is this PR for?
The 5.9.3 version of `isort` is installed in the lint-requirements however it will be downgraded by the 2.5.2 version of `pylint`.


### What type of PR is it?
[Improvement]

### Todos

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-1181

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* Do the license files need updating? No
* Are there breaking changes for older versions? No
* Does this need new documentation? No
