### PR TITLE
SUBMARINE-1186 Add error message on submarine operator e2e test creation failed

### DIFF
--- a/submarine-cloud-v2/test/e2e/basic_test.go
+++ b/submarine-cloud-v2/test/e2e/basic_test.go
@@ -56,16 +56,16 @@ func TestSubmitSubmarineCustomResourceYaml(t *testing.T) {
 	assert.Equal(t, nil, err)
 
 	// wait for submarine to be in RUNNING state
-	status := GetJobStatus(t, submarineNs, submarineName)
+	state := GetJobState(t, submarineNs, submarineName)
 	err = wait.Poll(INTERVAL, TIMEOUT, func() (done bool, err error) {
-		if status == v1alpha1.RunningState {
+		if state.State == v1alpha1.RunningState {
 			return true, nil
 		}
-		if status == v1alpha1.FailedState {
-			return true, fmt.Errorf("fail to create submarine %s/%s", submarineNs, submarineName)
+		if state.State == v1alpha1.FailedState {
+			return true, fmt.Errorf("fail to create submarine %s/%s: %s", submarineNs, submarineName, state.ErrorMessage)
 		}
 
-		status = GetJobStatus(t, submarineNs, submarineName)
+		state = GetJobState(t, submarineNs, submarineName)
 
 		return false, nil
 	})

--- a/submarine-cloud-v2/test/e2e/main_test.go
+++ b/submarine-cloud-v2/test/e2e/main_test.go
@@ -45,10 +45,10 @@ var STATES = [4]string{
 	"FAILED",
 }
 
-func GetJobStatus(t *testing.T, submarineNs, submarineName string) v1alpha1.SubmarineStateType {
+func GetJobState(t *testing.T, submarineNs, submarineName string) v1alpha1.SubmarineState {
 	submarine, err := operatorFramework.GetSubmarine(framework.SubmarineClient, submarineNs, submarineName)
 	assert.Equal(t, nil, err)
-	return submarine.Status.SubmarineState.State
+	return submarine.Status.SubmarineState
 }
 
 func TestMain(m *testing.M) {


### PR DESCRIPTION
### What is this PR for?
<!-- A few sentences describing the overall goals of the pull request's commits.
First time? Check out the contributing guide - https://submarine.apache.org/contribution/contributions.html
-->

While running the submarine operator e2e test, it says only the creation failed without the error message inside the creation process.

Hence, this issue is to add more error messages to the operator end to end test.

### What type of PR is it?
Improvement

### Todos

None

### What is the Jira issue?
<!-- * Open an issue on Jira https://issues.apache.org/jira/browse/SUBMARINE/
* Put link here, and add [SUBMARINE-*Jira number*] in PR title, eg. `SUBMARINE-23. PR title`
-->
https://issues.apache.org/jira/browse/SUBMARINE-1186

### How should this be tested?
<!--
* First time? Setup Travis CI as described on https://submarine.apache.org/contribution/contributions.html#continuous-integration
* Strongly recommended: add automated unit tests for any new or changed behavior
* Outline any manual steps to test the PR here.
-->

Follow the `Run Operator End-to-end Tests` part in the submarine-cloud-v2 developer-guild

### Screenshots (if appropriate)
None

### Questions:
* Do the license files need updating? No
* Are there breaking changes for older versions? No
* Does this need new documentation? No
