### PR TITLE
SUBMARINE-1184. Get namespace via Downward API

### DIFF
--- a/submarine-cloud-v2/pkg/controller/submarine_server.go
+++ b/submarine-cloud-v2/pkg/controller/submarine_server.go
@@ -65,10 +65,6 @@ func newSubmarineServerDeployment(submarine *v1alpha1.Submarine) *appsv1.Deploym
 			Value: serverName + "." + submarine.Namespace,
 		},
 		{
-			Name:  "ENV_NAMESPACE",
-			Value: submarine.Namespace,
-		},
-		{
 			Name:  "SUBMARINE_APIVERSION",
 			Value: ownerReference.APIVersion,
 		},

--- a/submarine-cloud-v2/pkg/controller/submarine_server.go
+++ b/submarine-cloud-v2/pkg/controller/submarine_server.go
@@ -65,6 +65,14 @@ func newSubmarineServerDeployment(submarine *v1alpha1.Submarine) *appsv1.Deploym
 			Value: serverName + "." + submarine.Namespace,
 		},
 		{
+			Name: "ENV_NAMESPACE",
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{
+					FieldPath: "metadata.namespace",
+				},
+			},
+		},
+		{
 			Name:  "SUBMARINE_APIVERSION",
 			Value: ownerReference.APIVersion,
 		},

--- a/submarine-server/server-api/pom.xml
+++ b/submarine-server/server-api/pom.xml
@@ -37,6 +37,11 @@
       <artifactId>submarine-commons-utils</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.submarine</groupId>
+      <artifactId>submarine-k8s-utils</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
       <version>${protobuf-java.version}</version>

--- a/submarine-server/server-api/src/main/java/org/apache/submarine/server/api/spec/ExperimentMeta.java
+++ b/submarine-server/server-api/src/main/java/org/apache/submarine/server/api/spec/ExperimentMeta.java
@@ -24,6 +24,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.submarine.server.k8s.utils.K8sUtils;
+
 /**
  * ExperimentMeta is metadata that all experiments must have.
  */
@@ -33,20 +35,14 @@ public class ExperimentMeta {
 
   private String experimentId;
   private String name;
-  private String namespace;
+  private final String namespace;
   private String framework;
   private String cmd;
   private Map<String, String> envVars = new HashMap<>();
   private List<String> tags = new ArrayList<>();
 
   public ExperimentMeta() {
-    namespace = "default";
-    /* The environment variable "ENV_NAMESPACE" will be set by submarine-operator. Hence, 
-     * if the user creates Submarine with Helm, the variable "namespace" will always be "default". 
-     */
-    if (System.getenv("ENV_NAMESPACE") != null) { 
-      namespace = System.getenv("ENV_NAMESPACE");
-    }
+    namespace = K8sUtils.getNamespace();
   }
 
   /**

--- a/submarine-server/server-submitter/k8s-utils/pom.xml
+++ b/submarine-server/server-submitter/k8s-utils/pom.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <!--
   Licensed to the Apache Software Foundation (ASF) under one
   or more contributor license agreements.  See the NOTICE file
   distributed with this work for additional information
@@ -16,23 +19,36 @@
   KIND, either express or implied.  See the License for the
   specific language governing permissions and limitations
   under the License.
-  --><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  -->
   <parent>
-    <artifactId>submarine-server</artifactId>
     <groupId>org.apache.submarine</groupId>
+    <artifactId>submarine-server-submitter</artifactId>
     <version>0.7.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
-  <artifactId>submarine-server-submitter</artifactId>
-  <version>0.7.0-SNAPSHOT</version>
-  <packaging>pom</packaging>
-  <name>Submarine: Submitter</name>
+  <artifactId>submarine-k8s-utils</artifactId>
+  <name>Submarine: K8S Utils</name>
 
-  <modules>
-    <module>submitter-k8s</module>
-    <module>submarine-k8s-agent</module>
-    <module>k8s-utils</module>
-  </modules>
+  <dependencies>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>${slf4j.version}</version>
+    </dependency>
 
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-log4j12</artifactId>
+      <version>${slf4j.version}</version>
+    </dependency>
+
+    <!-- Test libraries -->
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>${junit.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
 </project>

--- a/submarine-server/server-submitter/k8s-utils/src/main/java/org/apache/submarine/server/k8s/utils/K8sUtils.java
+++ b/submarine-server/server-submitter/k8s-utils/src/main/java/org/apache/submarine/server/k8s/utils/K8sUtils.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.submarine.server.k8s.utils;
+
+import java.io.BufferedReader;
+import java.io.FileReader;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Utility methods for common k8s operations.
+ *
+ * @author Chi-Sheng Liu
+ * @since 0.7.0-SNAPSHOT
+ */
+public abstract class K8sUtils {
+
+  private static final Logger LOG = LoggerFactory.getLogger(K8sUtils.class);
+  private static String namespace = null;
+
+  /**
+   * Get the current Kubernetes namespace.
+   * @return The current Kubernetes namespace.
+   */
+  public static String getNamespace() {
+    if (namespace == null) {
+      String filename = "/var/run/secrets/kubernetes.io/serviceaccount/namespace";
+      try {
+        try (BufferedReader reader = new BufferedReader(new FileReader(filename))) {
+          namespace = reader.readLine();
+        }
+        if (namespace == null) {
+          throw new IllegalStateException("No content in " + filename);
+        }
+      } catch (Throwable e) {
+        LOG.error("Error occurs when reading the current namespace value.", e);
+      }
+    }
+    return namespace;
+  }
+}

--- a/submarine-server/server-submitter/k8s-utils/src/main/java/org/apache/submarine/server/k8s/utils/K8sUtils.java
+++ b/submarine-server/server-submitter/k8s-utils/src/main/java/org/apache/submarine/server/k8s/utils/K8sUtils.java
@@ -19,9 +19,6 @@
 
 package org.apache.submarine.server.k8s.utils;
 
-import java.io.BufferedReader;
-import java.io.FileReader;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -42,17 +39,11 @@ public abstract class K8sUtils {
    */
   public static String getNamespace() {
     if (namespace == null) {
-      String filename = "/var/run/secrets/kubernetes.io/serviceaccount/namespace";
-      try {
-        try (BufferedReader reader = new BufferedReader(new FileReader(filename))) {
-          namespace = reader.readLine();
-        }
-        if (namespace == null) {
-          throw new IllegalStateException("No content in " + filename);
-        }
-      } catch (Throwable e) {
-        LOG.error("Error occurs when reading the current namespace value.", e);
+      namespace = System.getenv("ENV_NAMESPACE");
+      if (namespace == null) {
+        namespace = "default";
       }
+      LOG.info("Namespace: {}", namespace);
     }
     return namespace;
   }

--- a/submarine-server/server-submitter/k8s-utils/src/main/resources/log4j.properties
+++ b/submarine-server/server-submitter/k8s-utils/src/main/resources/log4j.properties
@@ -1,0 +1,25 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+log4j.rootLogger = info, stdout
+
+log4j.appender.stdout = org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.Target = System.out
+log4j.appender.stdout.layout = org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern = [%-5p] %d{yyyy-MM-dd HH:mm:ss,SSS} method:%l%n%m%n

--- a/submarine-server/server-submitter/submitter-k8s/pom.xml
+++ b/submarine-server/server-submitter/submitter-k8s/pom.xml
@@ -53,6 +53,12 @@
 
     <dependency>
       <groupId>org.apache.submarine</groupId>
+      <artifactId>submarine-k8s-utils</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.submarine</groupId>
       <artifactId>submarine-server-api</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/K8sSubmitter.java
+++ b/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/K8sSubmitter.java
@@ -63,6 +63,7 @@ import org.apache.submarine.serve.istio.IstioVirtualService;
 import org.apache.submarine.serve.pytorch.SeldonPytorchServing;
 import org.apache.submarine.serve.seldon.SeldonDeployment;
 import org.apache.submarine.serve.tensorflow.SeldonTFServing;
+import org.apache.submarine.server.k8s.utils.K8sUtils;
 import org.apache.submarine.server.api.Submitter;
 import org.apache.submarine.server.api.exception.InvalidSpecException;
 import org.apache.submarine.server.api.experiment.Experiment;
@@ -104,9 +105,6 @@ public class K8sSubmitter implements Submitter {
 
   private static final String TF_JOB_SELECTOR_KEY = "tf-job-name=";
   private static final String PYTORCH_JOB_SELECTOR_KEY = "pytorch-job-name=";
-
-  private static final String ENV_NAMESPACE = "ENV_NAMESPACE";
-
 
   // Add an exception Consumer, handle the problem that delete operation does not have the resource
   public static final Function<ApiException, Object> API_EXCEPTION_404_CONSUMER = e -> {
@@ -939,11 +937,7 @@ public class K8sSubmitter implements Submitter {
   }
 
   private String getServerNamespace() {
-    String namespace = "default";
-    if (System.getenv(ENV_NAMESPACE) != null) {
-      namespace = System.getenv(ENV_NAMESPACE);
-    }
-    return namespace;
+    return K8sUtils.getNamespace();
   }
 
   private enum ParseOp {


### PR DESCRIPTION
### What is this PR for?
Get the current namespace with the downward API.

In the beginning, I tried to get the current namespace by reading the file `/var/run/secrets/kubernetes.io/serviceaccount/namespace`. However, not all Kubernetes environments have this file. Therefore I decided to use the downward API to get the current namespace.

References:
+ https://stackoverflow.com/questions/31557932/how-to-get-the-namespace-from-inside-a-pod-in-openshift
+ https://github.com/kubernetes/kubernetes/blob/release-1.0/docs/user-guide/downward-api.md

### What type of PR is it?
[Improvement]

### Todos

### What is the Jira issue?
https://issues.apache.org/jira/projects/SUBMARINE/issues/SUBMARINE-1184

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* Do the license files need updating? No
* Are there breaking changes for older versions? No
* Does this need new documentation? No
