### PR TITLE
SUBMARINE-1202. fix 404 issue and avoiding NotbookHandler receive the events of previous notebook with same name

### DIFF
--- a/submarine-server/server-submitter/submarine-k8s-agent/src/main/java/org/apache/submarine/server/k8s/agent/handler/NotebookHandler.java
+++ b/submarine-server/server-submitter/submarine-k8s-agent/src/main/java/org/apache/submarine/server/k8s/agent/handler/NotebookHandler.java
@@ -52,7 +52,7 @@ public class NotebookHandler extends CustomResourceHandler {
   private GenericKubernetesApi<CoreV1Event, CoreV1EventList> eventClient;
   private GenericKubernetesApi<NotebookCR, NotebookCRList> notebookCRClient;
 
-  private String podName;
+  private String uid;
   public NotebookHandler() throws IOException {
     super();
   }
@@ -86,10 +86,10 @@ public class NotebookHandler extends CustomResourceHandler {
       listOptions.setLabelSelector(podLabelSelector);
       V1PodList podList = podClient.list(namespace, listOptions).throwsApiException().getObject();
 
-      this.podName = podList.getItems().get(0).getMetadata().getName();
+      this.uid = podList.getItems().get(podList.getItems().size() - 1).getMetadata().getUid();
 
       listOptions = new ListOptions();
-      String fieldSelector = String.format("involvedObject.name=%s", this.podName);
+      String fieldSelector = String.format("involvedObject.uid=%s", this.uid);
       listOptions.setFieldSelector(fieldSelector);
       watcher = eventClient.watch(namespace, listOptions);
 

--- a/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/parser/NotebookSpecParser.java
+++ b/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/parser/NotebookSpecParser.java
@@ -325,6 +325,6 @@ public class NotebookSpecParser {
     
     agentContainer.env(envVarList);
     
-    containers.add(0, agentContainer);    
+    containers.add(agentContainer);    
   }
 }


### PR DESCRIPTION
### What is this PR for?
fix the issue of notebook routing not found and receive previous events which causes crash of agent
### What type of PR is it?
Bug fix

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-1202

### How should this be tested?
should pass existed tests.
### Screenshots
![Screen Shot 2022-03-01 at 1 39 01 PM](https://user-images.githubusercontent.com/5687317/156112085-c5ed9a11-917b-4bd7-9de0-136e22122a84.png) 
![Screen Shot 2022-03-01 at 1 40 09 PM](https://user-images.githubusercontent.com/5687317/156112091-a3164cc6-5ad2-42f9-9360-3d1310f3f14e.png)

### Questions:
* Do the license files need updating? No
* Are there breaking changes for older versions? No
* Does this need new documentation? No
