### PR TITLE
SUBMARINE-1215. Fix java.lang.NullPointerException in K8sSubmitter.getInfo() method

### DIFF
--- a/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/K8sSubmitter.java
+++ b/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/K8sSubmitter.java
@@ -25,6 +25,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 
@@ -263,11 +264,11 @@ public class K8sSubmitter implements Submitter {
       mlJob.getMetadata().setNamespace(getServerNamespace());
       mlJob.getMetadata().setOwnerReferences(OwnerReferenceUtils.getOwnerReference());
       AgentPod agentPod = new AgentPod(getServerNamespace(), spec.getMeta().getName(),
-              mlJob.getPlural().equals(TFJob.CRD_TF_PLURAL_V1) 
+              mlJob.getPlural().equals(TFJob.CRD_TF_PLURAL_V1)
               ? CustomResourceType.TFJob : CustomResourceType.PyTorchJob,
               spec.getMeta().getExperimentId());
-            
-      
+
+
       Object object = mlJob.getPlural().equals(TFJob.CRD_TF_PLURAL_V1)
               ? tfJobClient.create(getServerNamespace(), (TFJob) mlJob,
                       new CreateOptions()).throwsApiException().getObject()
@@ -440,9 +441,10 @@ public class K8sSubmitter implements Submitter {
     }
   }
 
-  public Info getInfo(String name, String ingressRouteName) throws ApiException{
+  public Info getInfo(String name, String ingressRouteName) throws ApiException {
     V1Deployment deploy = appsV1Api.readNamespacedDeploymentStatus(name, getServerNamespace(), "true");
-    boolean available = deploy.getStatus().getAvailableReplicas() > 0; // at least one replica is running
+    boolean available = Optional.ofNullable(deploy.getStatus().getAvailableReplicas())
+            .map(ar -> ar > 0).orElse(false); // at least one replica is running
 
     IngressRoute ingressRoute = new IngressRoute();
     V1ObjectMeta meta = new V1ObjectMeta();


### PR DESCRIPTION
### What is this PR for?
When there is no mlflow, a `NullPointerException` will appear in the background. This PR is mainly to fix the background problem.

### What type of PR is it?
Bug Fix

### Todos
* [x] - Use Optional to avoid NullPointerException

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-1215

### How should this be tested?
After fixing the background problem, the button will always turn when there is no mlflow in the k8s. I don't know if the front also needs to deal with it.
![image](https://user-images.githubusercontent.com/12069428/158007459-2ade1263-fc43-4a32-a991-d79c1925737b.png)

### Screenshots (if appropriate)
No

### Questions:
* Do the license files need updating? No
* Are there breaking changes for older versions? No
* Does this need new documentation? No
