### PR TITLE
SUBMARINE-1136. fix sending the repeat request bug in experiment page

### DIFF
--- a/submarine-workbench/workbench-web/src/app/pages/workbench/experiment/experiment-home/experiment-home.component.ts
+++ b/submarine-workbench/workbench-web/src/app/pages/workbench/experiment/experiment-home/experiment-home.component.ts
@@ -76,6 +76,12 @@ export class ExperimentHomeComponent implements OnInit {
     this.onSwitchAutoReload();
   }
 
+  ngOnDestroy() {
+    if (this.reloadSub) {
+      this.reloadSub.unsubscribe();
+    }
+  }
+
   fetchExperimentList(isAutoReload: boolean) {
     this.experimentService.fetchExperimentList().subscribe(
       (list) => {


### PR DESCRIPTION
### What is this PR for?
When switching the pages between experiment and other pages, the reload request doesn't destroy. Fix by destroying the reload subscribe when switching the page.

### What type of PR is it?
[Bug Fix]

### Todos

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-1136
### How should this be tested?

### Screenshots (if appropriate)
https://user-images.githubusercontent.com/38066413/158012550-3eec4d17-9055-462a-b53e-b08fa7949c15.mp4



### Questions:
* Do the license files need updating? Yes/No
* Are there breaking changes for older versions? Yes/No
* Does this need new documentation? Yes/No
