### PR TITLE
SUBMARINE-1216. Fix some wrong version in Release 0.7.0

### DIFF
--- a/dev-support/mini-submarine/README.md
+++ b/dev-support/mini-submarine/README.md
@@ -23,7 +23,7 @@ This is a docker image built for submarine development and quick start test.
 ### Use the image we provide
 
 ```
-docker pull apache/submarine:mini-0.5.0
+docker pull apache/submarine:mini-0.6.0
 ```
 
 ### Create image by yourself
@@ -66,8 +66,8 @@ export submarine_version=0.7.0
 export release_candidates_path=~/releases/submarine-release
 ./build_mini-submarine.sh
 #docker run -it -h submarine-dev --net=bridge --privileged -P local/mini-submarine:0.7.0 /bin/bash
-docker tag local/mini-submarine:0.7.0 apache/mini-submarine:0.7.0:RC0
-docker push apache/mini-submarine:0.7.0:RC0
+docker tag local/mini-submarine:0.7.0 apache/mini-submarine:0.7.0-RC0
+docker push apache/mini-submarine:0.7.0-RC0
 ```
 In the container, we can verify that the submarine jar version is the expected 0.7.0. Then we can upload this image with a "RC" tag for a vote.
 

--- a/helm-charts/submarine/Chart.yaml
+++ b/helm-charts/submarine/Chart.yaml
@@ -16,7 +16,7 @@
 #
 
 apiVersion: v2
-appVersion: "0.5.0"
+appVersion: "0.7.0"
 description: Submarine is Cloud Native Machine Learning Platform.
 name: submarine
 version: 0.7.0

--- a/helm-charts/submarine/charts/notebook-controller/Chart.yaml
+++ b/helm-charts/submarine/charts/notebook-controller/Chart.yaml
@@ -34,4 +34,4 @@ version: 0.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 1.0.0
+appVersion: 1.1.0

--- a/helm-charts/submarine/charts/pytorchjob/Chart.yaml
+++ b/helm-charts/submarine/charts/pytorchjob/Chart.yaml
@@ -35,4 +35,4 @@ version: 0.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 1.0.0
+appVersion: 1.1.0

--- a/helm-charts/submarine/charts/tfjob/Chart.yaml
+++ b/helm-charts/submarine/charts/tfjob/Chart.yaml
@@ -35,4 +35,4 @@ version: 0.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 1.0.0
+appVersion: 1.1.0


### PR DESCRIPTION
### What is this PR for?
There are mismatches in some documents and yamls in the 0.7.0 release. This PR is to fix the wrong version.

### What type of PR is it?
Hot Fix

### Todos
* [x] - The appVersion in helm should be repalced from 0.5.0 to 0.7.0
* [x] - The appVersion in notebook controller, pytorchjob and tfjob helm should be repalced from 1.0.0 to 1.1.0
* [x] - Some versions in mini submarine readme need to be repalced (if this document needed)

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-1216

### How should this be tested?
Fix wrong versions

### Screenshots (if appropriate)
No

### Questions:
* Do the license files need updating? No
* Are there breaking changes for older versions? No
* Does this need new documentation? No
