### PR TITLE
SUBMARINE-1217. Image name for defined experiment

### DIFF
--- a/submarine-workbench/workbench-web/src/app/pages/workbench/experiment/experiment-home/experiment-form/experiment-customized-form/experiment-customized-form.component.ts
+++ b/submarine-workbench/workbench-web/src/app/pages/workbench/experiment/experiment-home/experiment-form/experiment-customized-form/experiment-customized-form.component.ts
@@ -97,6 +97,17 @@ export class ExperimentCustomizedFormComponent implements OnInit, OnDestroy {
       gitRepo: new FormControl(null, [])
     });
 
+    this.experimentService.fetchExperimentList().subscribe(
+      (list) => {
+        list.forEach((item) => {
+          this.imageList.push(item.spec.environment.image);
+        });
+      },
+      (error) => {
+        console.error(error);
+      }
+    )
+
     // Bind the component method for callback
     this.checkStatus = this.checkStatus.bind(this);
 


### PR DESCRIPTION
### What is this PR for?
Fetch image name in the database and present in the workbench for creating experiment.

### What type of PR is it?
Feature 

### Todos


### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-1217

### How should this be tested?

### Screenshots (if appropriate)
Create an experiment
<img width="1123" alt="截圖 2022-03-14 下午3 25 48" src="https://user-images.githubusercontent.com/54139205/158124379-478334ca-6476-4c52-a105-2cc7150275de.png">

The list contains the previous image
<img width="1258" alt="截圖 2022-03-14 下午3 26 02" src="https://user-images.githubusercontent.com/54139205/158124203-a6d5f771-4832-4856-b6f6-012cd22e6b63.png">


### Questions:
* Do the license files need updating? No
* Are there breaking changes for older versions? No
* Does this need new documentation? No
