### PR TITLE
SUBMARINE-1218. delete agent pod as well both in the deleting operation of experiment and notebook

### DIFF
--- a/submarine-server/server-api/src/main/java/org/apache/submarine/server/api/Submitter.java
+++ b/submarine-server/server-api/src/main/java/org/apache/submarine/server/api/Submitter.java
@@ -111,10 +111,11 @@ public interface Submitter {
   /**
    * Delete a notebook with spec
    * @param spec spec
+   * @param notebookId notebookId
    * @return object
    * @throws SubmarineRuntimeException running error
    */
-  Notebook deleteNotebook(NotebookSpec spec) throws SubmarineRuntimeException;
+  Notebook deleteNotebook(NotebookSpec spec, String notebookId) throws SubmarineRuntimeException;
 
   /**
    * List notebooks with userID

--- a/submarine-server/server-core/src/main/java/org/apache/submarine/server/notebook/NotebookManager.java
+++ b/submarine-server/server-core/src/main/java/org/apache/submarine/server/notebook/NotebookManager.java
@@ -172,7 +172,7 @@ public class NotebookManager {
    */
   public Notebook deleteNotebook(String id) throws SubmarineRuntimeException {
     Notebook notebook = getNotebook(id);
-    Notebook patchNotebook = submitter.deleteNotebook(notebook.getSpec());
+    Notebook patchNotebook = submitter.deleteNotebook(notebook.getSpec(), id);
     notebookService.delete(id);
     notebook.rebuild(patchNotebook);
     return notebook;

--- a/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/parser/NotebookSpecParser.java
+++ b/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/parser/NotebookSpecParser.java
@@ -63,7 +63,7 @@ public class NotebookSpecParser {
           SubmarineConfiguration.getInstance();
 
 
-  public static NotebookCR parseNotebook(NotebookSpec spec, String notebookId, String namespace) {
+  public static NotebookCR parseNotebook(NotebookSpec spec, String namespace) {
     NotebookCR notebookCR = new NotebookCR();
     notebookCR.setMetadata(parseMetadata(spec));
     notebookCR.setSpec(parseNotebookCRSpec(spec));

--- a/submarine-server/server-submitter/submitter-k8s/src/test/java/org/apache/submarine/server/submitter/k8s/NotebookSpecParserTest.java
+++ b/submarine-server/server-submitter/submitter-k8s/src/test/java/org/apache/submarine/server/submitter/k8s/NotebookSpecParserTest.java
@@ -41,7 +41,7 @@ public class NotebookSpecParserTest extends SpecBuilder {
   @Test
   public void testValidNotebook() throws IOException, URISyntaxException {
     NotebookSpec notebookSpec = (NotebookSpec) buildFromJsonFile(NotebookSpec.class, notebookReqFile);
-    NotebookCR notebook = NotebookSpecParser.parseNotebook(notebookSpec, null, null);
+    NotebookCR notebook = NotebookSpecParser.parseNotebook(notebookSpec, null);
 
     validateMetadata(notebookSpec.getMeta(), notebook.getMetadata());
     validateEnvironment(notebookSpec, notebook.getSpec());


### PR DESCRIPTION
### What is this PR for?
Just like @KUAN-HSUN-LI  mentioned in jira ticket, the existed agent pod will occurs error if we recreate the custom resource with the same name with deleing resource, so I fired this PR to add the step to delete agent pod in the deleting operation.

### What type of PR is it?
Bug Fix

### Todos
N/A

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-1218
### How should this be tested?
should pass existed tests.
### Screenshots (if appropriate)
![Screen Shot 2022-03-17 at 11 13 11 PM](https://user-images.githubusercontent.com/5687317/158834481-b45e8118-1053-4878-a1aa-b9969acf6a06.png)
![Screen Shot 2022-03-17 at 11 13 21 PM](https://user-images.githubusercontent.com/5687317/158834502-50b6d7a5-7484-4ef3-b316-16e42d7b6c8b.png)
![Screen Shot 2022-03-17 at 11 13 28 PM](https://user-images.githubusercontent.com/5687317/158834532-8bb1e5ff-c779-49e0-93ef-8b8fa5d62c9c.png)
![Screen Shot 2022-03-17 at 11 14 32 PM](https://user-images.githubusercontent.com/5687317/158834568-02e68d04-f4ea-4b66-91d5-23cb972821ba.png)
![Screen Shot 2022-03-17 at 11 14 59 PM](https://user-images.githubusercontent.com/5687317/158834588-197a1c97-dc18-467f-8fff-d5d5491c255a.png)
![Screen Shot 2022-03-17 at 11 15 07 PM](https://user-images.githubusercontent.com/5687317/158834847-bef8571e-9b66-45b9-8039-61b03a368a47.png)
![Screen Shot 2022-03-17 at 11 15 15 PM](https://user-images.githubusercontent.com/5687317/158834638-5cabffa8-4223-482c-9660-565b3af6cdaf.png)
![Screen Shot 2022-03-17 at 11 16 33 PM](https://user-images.githubusercontent.com/5687317/158834665-b9a2b678-bf62-4c94-8b7a-2367f9dbc275.png)

### Questions:
* Do the license files need updating?No
* Are there breaking changes for older versions?No
* Does this need new documentation?No
