### PR TITLE
SUBMARINE-1223. Update Submarine Operator CRD to v1

### DIFF
--- a/helm-charts/submarine/crds/crd.yaml
+++ b/helm-charts/submarine/crds/crd.yaml
@@ -94,5 +94,21 @@ spec:
                     type: boolean
                   storageSize:
                     type: string
+          status:
+            type: object
+            properties:
+              availableServerReplicas:
+                type: integer
+              availableDatabaseReplicas:
+                type: integer
+              submarineState:
+                type: object
+                properties:
+                  state:
+                    type: string
+                  errorMessage:
+                    type: string
     served: true
     storage: true
+    subresources:
+      status: {}

--- a/helm-charts/submarine/crds/crd.yaml
+++ b/helm-charts/submarine/crds/crd.yaml
@@ -15,67 +15,84 @@
 # limitations under the License.
 #
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: submarines.submarine.apache.org
+  labels:
+    app.kubernetes.io/name: submarine-operator
+    app.kubernetes.io/version: "0.7.0"
+    app.kubernetes.io/component: submarine-operator
+    app.kubernetes.io/managed-by: helm
 spec:
   group: submarine.apache.org
-  version: v1alpha1
   names:
     kind: Submarine
+    listKind: SubmarineList
     plural: submarines
+    singular: submarine
+    shortNames:
+    - sm
+    categories:
+    - all
   scope: Namespaced
-  validation:
-    openAPIV3Schema:
-      type: object
-      required: ["spec"]
-      properties:
-        spec:
-          type: object
-          required:
-            - version
-          properties:
-            version: # submarine docker image version
-              type: string
-            server:
-              type: object
-              properties:
-                image: # Use this to overwrite the image when development
-                  type: string
-                replicas:
-                  type: integer
-                  minimum: 1
-            database:
-              type: object
-              properties:
-                image: # Use this to overwrite the image when development
-                  type: string
-                replicas:
-                  type: integer
-                  minimum: 1
-                storageSize:
-                  type: string
-                mysqlRootPasswordSecret:
-                  type: string
-            tensorboard:
-              type: object
-              properties:
-                enabled:
-                  type: boolean
-                storageSize:
-                  type: string
-            mlflow:
-              type: object
-              properties:
-                enabled:
-                  type: boolean
-                storageSize:
-                  type: string
-            minio:
-              type: object
-              properties:
-                enabled:
-                  type: boolean
-                storageSize:
-                  type: string
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        type: object
+        required: ["spec"]
+        properties:
+          spec:
+            type: object
+            required:
+              - version
+            properties:
+              version: 
+                description: submarine docker image version
+                type: string
+              server:
+                type: object
+                properties:
+                  image: 
+                    description: Use this to overwrite the image when development
+                    type: string
+                  replicas:
+                    type: integer
+                    minimum: 1
+              database:
+                type: object
+                properties:
+                  image: 
+                    description: Use this to overwrite the image when development
+                    type: string
+                  replicas:
+                    type: integer
+                    minimum: 1
+                  storageSize:
+                    type: string
+                  mysqlRootPasswordSecret:
+                    type: string
+              tensorboard:
+                type: object
+                properties:
+                  enabled:
+                    type: boolean
+                  storageSize:
+                    type: string
+              mlflow:
+                type: object
+                properties:
+                  enabled:
+                    type: boolean
+                  storageSize:
+                    type: string
+              minio:
+                type: object
+                properties:
+                  enabled:
+                    type: boolean
+                  storageSize:
+                    type: string
+    served: true
+    storage: true

--- a/helm-charts/submarine/templates/rbac.yaml
+++ b/helm-charts/submarine/templates/rbac.yaml
@@ -85,6 +85,7 @@ rules:
       - apiextensions.k8s.io
     resources:
       - customresourcedefinitions
+      - customresourcedefinitions/status
     verbs:
       - "*"
 ---

--- a/helm-charts/submarine/templates/rbac.yaml
+++ b/helm-charts/submarine/templates/rbac.yaml
@@ -24,6 +24,7 @@ rules:
       - submarine.apache.org
     resources:
       - submarines
+      - submarines/status
     verbs:
       - "*"
   - apiGroups:

--- a/submarine-cloud-v2/pkg/controller/controller.go
+++ b/submarine-cloud-v2/pkg/controller/controller.go
@@ -324,7 +324,8 @@ func (c *Controller) updateSubmarineStatus(submarine, submarineCopy *v1alpha1.Su
 		return nil
 	}
 
-	_, err = c.submarineclientset.SubmarineV1alpha1().Submarines(submarine.Namespace).Update(context.TODO(), submarineCopy, metav1.UpdateOptions{})
+	// Update submarine status
+	_, err = c.submarineclientset.SubmarineV1alpha1().Submarines(submarine.Namespace).UpdateStatus(context.TODO(), submarineCopy, metav1.UpdateOptions{})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
### What is this PR for?
Update Submarine Operator CRD:
* Unify the CRD (upgrade apiextensions.k8s.io/v1beta1 to apiextensions.k8s.io/v1)
* Add some details to support the new CRD (The adjusted CRD can support multiple CRDs to share group resources)

### What type of PR is it?
Refactoring

### Todos
* [x] - Update Submarine Operator CRD

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-1223

### How should this be tested?
Can be tested by exists cicd.

### Screenshots (if appropriate)
No

### Questions:
* Do the license files need updating? No
* Are there breaking changes for older versions? No
* Does this need new documentation? No
