### PR TITLE
SUBMARINE-1226. Update the Kubernetes version in other Documents

### DIFF
--- a/submarine-cloud-v2/README.md
+++ b/submarine-cloud-v2/README.md
@@ -31,7 +31,7 @@ Golang version: `1.16.2`
 # Install dependencies
 go mod vendor
 # Run the cluster
-minikube start --vm-driver=docker  --kubernetes-version v1.15.11
+minikube start --vm-driver=docker --cpus 8 --memory 4096 --kubernetes-version v1.21.2
 ```
 
 ## Set up storage class fields

--- a/website/docs/gettingStarted/localDeployment.md
+++ b/website/docs/gettingStarted/localDeployment.md
@@ -31,7 +31,7 @@ under the License.
 ## Deploy Kubernetes Cluster
 
 ```
-$ minikube start --vm-driver=docker --cpus 8 --memory 4096 --disk-size=20G --kubernetes-version v1.15.11
+$ minikube start --vm-driver=docker --cpus 8 --memory 4096 --disk-size=20G --kubernetes-version v1.21.2
 ```
 
 ## Install Submarine on Kubernetes


### PR DESCRIPTION
### What is this PR for?
We had replaced Kubernetes version in `quickstart.md` by PR https://github.com/apache/submarine/pull/843
We also need update the kind cluster Kubernetes version from v1.15.12 to v1.21.2 in `localDeployment.md` and `operator/README.md`

### What type of PR is it?
Documentation 

### Todos
* [x] - Update the kind cluster Kubernetes version from v1.15.12 to v1.21.2 in `localDeployment.md` and `operator/README.md`

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-1226

### How should this be tested?
No test

### Screenshots (if appropriate)
No

### Questions:
* Do the license files need updating? No
* Are there breaking changes for older versions? No
* Does this need new documentation? No
