### PR TITLE
SUBMARINE-1231. Fix notebook image conda version problem

### DIFF
--- a/dev-support/docker-images/jupyter-gpu/Dockerfile
+++ b/dev-support/docker-images/jupyter-gpu/Dockerfile
@@ -89,12 +89,11 @@ RUN wget --quiet https://repo.continuum.io/miniconda/Miniconda3-py37_${MINICONDA
     conda config --system --prepend channels conda-forge && \
     conda config --system --set auto_update_conda false && \
     conda config --system --set show_channel_urls true && \
-    conda config --system --set channel_priority strict && \
-    if [ ! $PYTHON_VERSION = 'default' ]; then conda install --yes python=$PYTHON_VERSION; fi && \
+    conda config --system --set channel_priority flexible && \
+    if [ ! $PYTHON_VERSION = 'default' ]; then conda install --freeze-installed --yes python=$PYTHON_VERSION; fi && \
     conda list python | grep '^python ' | tr -s ' ' | cut -d '.' -f 1,2 | sed 's/$/.*/' >> $CONDA_DIR/conda-meta/pinned && \
     # nodejs is used for jupyter lab build
-    conda install nodejs && \
-    conda install -c conda-forge jupyterlab jupyterlab-git cvxpy==1.0.21 && \
+    conda install --freeze-installed -c conda-forge nodejs jupyterlab jupyterlab-git cvxpy==1.0.21 && \
     jupyter lab build && \
     # remove node_modules
     rm -rf /home/$NB_USER/.cache/yarn && \

--- a/dev-support/docker-images/jupyter/Dockerfile
+++ b/dev-support/docker-images/jupyter/Dockerfile
@@ -89,14 +89,13 @@ RUN wget --quiet https://repo.continuum.io/miniconda/Miniconda3-py37_${MINICONDA
     conda config --system --prepend channels conda-forge && \
     conda config --system --set auto_update_conda false && \
     conda config --system --set show_channel_urls true && \
-    conda config --system --set channel_priority strict && \
-    if [ ! $PYTHON_VERSION = 'default' ]; then conda install --yes python=$PYTHON_VERSION; fi && \
+    conda config --system --set channel_priority flexible && \
+    if [ ! $PYTHON_VERSION = 'default' ]; then conda install --freeze-installed --yes python=$PYTHON_VERSION; fi && \
     conda list python | grep '^python ' | tr -s ' ' | cut -d '.' -f 1,2 | sed 's/$/.*/' >> $CONDA_DIR/conda-meta/pinned && \
     conda init bash && \
     source ~/.bashrc && conda activate && \
     # it is used for jupyter lab build
-    conda install nodejs && \
-    conda install -c conda-forge jupyterlab jupyterlab-git cvxpy==1.0.21 && \
+    conda install --freeze-installed -c conda-forge nodejs jupyterlab jupyterlab-git cvxpy==1.0.21 && \
     jupyter lab build && \
     # remove node_modules
     rm -rf /home/$NB_USER/.cache/yarn && \


### PR DESCRIPTION
### What is this PR for?
Keep notebook image conda version to 4.11.0 to avoid problems during container startup.
The `install` operation of conda will automatically update conda to latest version (4.12), which will lead to an error in judging the version of conda (<= 4.11).

The [freeze-installed](https://docs.conda.io/projects/conda/en/latest/commands/install.html) command is mainly used to keep conda version. 
Meanwhile, replace [channel_priority](https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-channels.html#strict-channel-priority)  from `strict` to `flexible` to avoid some conda version check.

### What type of PR is it?
Bug Fix

### Todos
* [x] - fix jupyter image
* [x] - fix jupyter-gpu image

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-1231

### How should this be tested?
Can test by container starting in k8s.

### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/12069428/159492398-c5cff68c-b003-4d8c-9c40-6c159cbe6ba5.png)


### Questions:
* Do the license files need updating? No
* Are there breaking changes for older versions? No
* Does this need new documentation? No
