### PR TITLE
add more event type to handle to present notebook status correctly

### DIFF
--- a/submarine-server/server-submitter/submarine-k8s-agent/src/main/java/org/apache/submarine/server/k8s/agent/handler/NotebookHandler.java
+++ b/submarine-server/server-submitter/submarine-k8s-agent/src/main/java/org/apache/submarine/server/k8s/agent/handler/NotebookHandler.java
@@ -35,7 +35,6 @@ import io.kubernetes.client.util.generic.GenericKubernetesApi;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-
 import io.kubernetes.client.openapi.ApiException;
 import io.kubernetes.client.openapi.models.CoreV1Event;
 import io.kubernetes.client.util.Watch.Response;
@@ -106,7 +105,6 @@ public class NotebookHandler extends CustomResourceHandler {
     while (true) {
       for (Response<CoreV1Event> event: watcher) {
         String reason = event.object.getReason();
-      
         Object object = null;
         try {
           switch (reason) {
@@ -118,11 +116,13 @@ public class NotebookHandler extends CustomResourceHandler {
               restClient.callStatusUpdate(CustomResourceType.Notebook, this.resourceId, notebook);
               break;
             case "Started":
+            case "Pulled":
               object = notebookCRClient.get(namespace, crName).throwsApiException().getObject();
               notebook = NotebookUtils.parseObject(object, NotebookUtils.ParseOpt.PARSE_OPT_GET);
               notebook.setStatus(Notebook.Status.STATUS_RUNNING.getValue());
               restClient.callStatusUpdate(CustomResourceType.Notebook, this.resourceId, notebook);
               break;
+            case "BackOff":
             case "Failed":
               object = notebookCRClient.get(namespace, crName).throwsApiException().getObject();
               notebook = NotebookUtils.parseObject(object, NotebookUtils.ParseOpt.PARSE_OPT_GET);


### PR DESCRIPTION
### What is this PR for?
We found out the root cause of incorrect status display is there's couple event type we skip before in notebook handler's processing, so I added them in the switch case in this PR. For now on, the notebook status would be
`creating -> pulling -> running -> failed -> pulling -> running -> failed -> pulling .....`.
I also noticed that running status of second or third time retry may missed, but looks like this is some kind of bug from k8s, because running state is also be jump through when I used `kubectl describe` to get the status of pods.
btw, I can't simulate the deleting failed case, so the issue hadn't been handled in this pr.

### What type of PR is it?
Bug Fix

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-1022
### How should this be tested?
should pass all existing tests.
### Screenshots (if appropriate)

https://user-images.githubusercontent.com/5687317/159927060-0b5e9587-a399-450a-ba1f-4dc6bcfaa765.mov


### Questions:
* Do the license files need updating?No
* Are there breaking changes for older versions?No
* Does this need new documentation?No
