### PR TITLE
SUBMARINE-1227. Fix the operator nil error by the conflict of deployment name

### DIFF
--- a/submarine-cloud-v2/pkg/controller/controller.go
+++ b/submarine-cloud-v2/pkg/controller/controller.go
@@ -473,6 +473,8 @@ func (c *Controller) checkSubmarineDependentsReady(submarine *v1alpha1.Submarine
 		deployment, err := c.getDeployment(submarine.Namespace, name)
 		if err != nil {
 			return false, err
+		} else if deployment == nil {
+			return false, nil
 		}
 		// check if deployment replicas failed
 		for _, condition := range deployment.Status.Conditions {


### PR DESCRIPTION
### What is this PR for?
When there has been a deployment called `submarine-server` in the same namespace,  create a new submarine CR in this namespace will cause nil exception. After several crash downs of the operator, the operator will not be available.

### What type of PR is it?
Bug Fix

### Todos
* [x] - Handle the error that the object is nil when get deployment by name

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-1227

### How should this be tested?
<!--
* First time? Setup Travis CI as described on https://submarine.apache.org/contribution/contributions.html#continuous-integration
* Strongly recommended: add automated unit tests for any new or changed behavior
* Outline any manual steps to test the PR here.
-->
### Screenshots (if appropriate)
No

### Questions:
* Do the license files need updating? No
* Are there breaking changes for older versions? No
* Does this need new documentation? No
