### PR TITLE
SUBMARINE-1236. Fix patch strategy

### DIFF
--- a/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/K8sSubmitter.java
+++ b/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/K8sSubmitter.java
@@ -320,10 +320,10 @@ public class K8sSubmitter implements Submitter {
       mlJob.getMetadata().setNamespace(getServerNamespace());
       Object object = mlJob.getPlural().equals(TFJob.CRD_TF_PLURAL_V1)
               ? tfJobClient.patch(getServerNamespace(), mlJob.getMetadata().getName(),
-              V1Patch.PATCH_FORMAT_JSON_PATCH,
+              V1Patch.PATCH_FORMAT_APPLY_YAML,
               new V1Patch(new Gson().toJson(((TFJob) mlJob).getSpec()))).throwsApiException().getObject()
               : pyTorchJobClient.patch(getServerNamespace(), mlJob.getMetadata().getName(),
-              V1Patch.PATCH_FORMAT_JSON_PATCH,
+              V1Patch.PATCH_FORMAT_APPLY_YAML,
               new V1Patch(new Gson().toJson(((PyTorchJob) mlJob).getSpec()))).throwsApiException().getObject()
               ;
       experiment = parseExperimentResponseObject(object, ParseOp.PARSE_OP_RESULT);
@@ -341,12 +341,12 @@ public class K8sSubmitter implements Submitter {
     try {
       MLJob mlJob = ExperimentSpecParser.parseJob(spec);
       mlJob.getMetadata().setNamespace(getServerNamespace());
-      
+
       AgentPod agentPod = new AgentPod(getServerNamespace(), spec.getMeta().getName(),
               mlJob.getPlural().equals(TFJob.CRD_TF_PLURAL_V1)
               ? CustomResourceType.TFJob : CustomResourceType.PyTorchJob,
               spec.getMeta().getExperimentId());
-      
+
       Object object = mlJob.getPlural().equals(TFJob.CRD_TF_PLURAL_V1)
               ? tfJobClient.delete(getServerNamespace(), mlJob.getMetadata().getName(),
               MLJobConverter.toDeleteOptionsFromMLJob(mlJob))
@@ -354,7 +354,7 @@ public class K8sSubmitter implements Submitter {
               : pyTorchJobClient.delete(getServerNamespace(), mlJob.getMetadata().getName(),
               MLJobConverter.toDeleteOptionsFromMLJob(mlJob))
               .throwsApiException().getStatus();
-      
+
       LOG.info(String.format("Experiment:%s had been deleted, start to delete agent pod:%s",
               spec.getMeta().getName(), agentPod.getMetadata().getName()));
       podClient.delete(agentPod.getMetadata().getNamespace(), agentPod.getMetadata().getName());


### PR DESCRIPTION
### What is this PR for?
There are four patch strategies in the k8s generic API. Replace the `PATCH_FORMAT_JSON_PATCH` with `PATCH_FORMAT_APPLY_YAML`.

### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-1236

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* Do the license files need updating? No
* Are there breaking changes for older versions? No
* Does this need new documentation? No
