### PR TITLE
SUBMARINE-1249. Github action python-sdk check-style failed

### DIFF
--- a/dev-support/style-check/python/lint-requirements.txt
+++ b/dev-support/style-check/python/lint-requirements.txt
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+click==8.0.4 # For black to work properly. See SUBMARINE-1249.
 black[jupyter]==21.8b0
 flake8==3.9.2
 isort==5.9.3


### PR DESCRIPTION
### What is this PR for?
Github action python-sdk check-style failed due to 'click', one of the dependencies of 'black', updated to a newer version and broke 'black'.

Related 'black' issue: https://github.com/psf/black/issues/2964

![image-2022-03-29-21-21-46-314](https://user-images.githubusercontent.com/47914085/160622858-35274c16-3d73-409c-bceb-7aeb0c0622f6.png)

### What type of PR is it?
[Bug Fix]

### Todos
* [x] - Fix click version to 8.0.4

### What is the Jira issue?
https://issues.apache.org/jira/projects/SUBMARINE/issues/SUBMARINE-1249

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* Do the license files need updating? No
* Are there breaking changes for older versions? No
* Does this need new documentation? No
