### PR TITLE
SUBMARINE-1229. Fix minio initContainer pod (mlflow and server) not working error

### DIFF
--- a/submarine-cloud-v2/artifacts/submarine/submarine-mlflow.yaml
+++ b/submarine-cloud-v2/artifacts/submarine/submarine-mlflow.yaml
@@ -69,7 +69,7 @@ spec:
         image: "minio/mc"
         command: ["/bin/bash", "-c",
         "cnt=0;
-        while ! /bin/bash -c 'mc config host add minio http://submarine-minio-service:9000
+        while ! /bin/bash -c 'mc --config-dir /root/.mc config host add minio http://submarine-minio-service:9000
         submarine_minio submarine_minio' 2>&1;
         do
           sleep 15;
@@ -79,11 +79,14 @@ spec:
             exit 1;
           fi;
         done;
-        if /bin/bash -c 'mc ls minio/mlflow' >/dev/null 2>&1; then
+        if /bin/bash -c 'mc --config-dir /root/.mc ls minio/mlflow' >/dev/null 2>&1; then
           echo 'Bucket minio/mlflow already exists, skipping creation.';
         else
-          /bin/bash -c 'mc mb minio/mlflow';
+          /bin/bash -c 'mc --config-dir /root/.mc mb minio/mlflow';
         fi;"]
+        volumeMounts:
+          - name: mc-config-vol
+            mountPath: /root/.mc
       containers:
       - name: submarine-mlflow-container
         image: apache/submarine:mlflow-0.7.0
@@ -103,6 +106,8 @@ spec:
         - name: "volume"
           persistentVolumeClaim:
             claimName: "submarine-mlflow-pvc"
+        - name: mc-config-vol
+          emptyDir: { }
 ---
 # Source: submarine/templates/submarine-mlflow.yaml
 apiVersion: traefik.containo.us/v1alpha1

--- a/submarine-cloud-v2/artifacts/submarine/submarine-server.yaml
+++ b/submarine-cloud-v2/artifacts/submarine/submarine-server.yaml
@@ -65,7 +65,7 @@ spec:
         image: "minio/mc"
         command: ["/bin/bash", "-c",
         "cnt=0;
-        while ! /bin/bash -c 'mc config host add minio http://submarine-minio-service:9000
+        while ! /bin/bash -c 'mc --config-dir /root/.mc config host add minio http://submarine-minio-service:9000
         submarine_minio submarine_minio' 2>&1;
         do
           sleep 15;
@@ -75,11 +75,17 @@ spec:
             exit 1;
           fi;
         done;
-        if /bin/bash -c 'mc ls minio/submarine' >/dev/null 2>&1; then
+        if /bin/bash -c 'mc --config-dir /root/.mc ls minio/submarine' >/dev/null 2>&1; then
           echo 'Bucket minio/submarine already exists, skipping creation.';
         else
-          /bin/bash -c 'mc mb minio/submarine';
+          /bin/bash -c 'mc --config-dir /root/.mc mb minio/submarine';
         fi;"]
+        volumeMounts:
+          - name: mc-config-vol
+            mountPath: /root/.mc
+      volumes:
+        - name: mc-config-vol
+          emptyDir: { }
       containers:
       - name: "submarine-server"
         env:


### PR DESCRIPTION
### What is this PR for?
Minio initContainer pod always shows that it cannot end correctly in OpenShift.
```
mc: <ERROR> Unable to save new mc config. mkdir /.mc: permission denied.
mc: <ERROR> Unable to save new mc config. mkdir /.mc: permission denied.
```
Pod cannot create the specified directory because it is not granted the permission to `runAsAnyuid`. At present, we can create a temporary volume for mc config so that mini can initialize and execute commands correctly.
The `mc --config-dir` command part is a reference for https://github.com/helm/charts/pull/20766/files

### What type of PR is it?
Bug Fix

### Todos
* [x] - Create an empty volume for mc config and set `config-dir`

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-1229

### How should this be tested?
Current, No

### Screenshots (if appropriate)
Current, No

### Questions:
* Do the license files need updating? No
* Are there breaking changes for older versions? No
* Does this need new documentation? No
