### PR TITLE
Add PodSecurityPolicies/SecurityContextConstraints support for RunAsAnyUser in submarine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,6 +86,8 @@ submarine-cloud/bin/*
 submarine-cloud-v2/vendor/*
 submarine-cloud-v2/submarine-operator
 submarine-cloud-v2/helm-charts/submarine-operator/charts/*
+# add operator docker build tmp
+dev-support/docker-images/operator/tmp/
 
 # vscode file
 .project

--- a/dev-support/docker-images/operator/Dockerfile
+++ b/dev-support/docker-images/operator/Dockerfile
@@ -27,4 +27,4 @@ ADD tmp/submarine-cloud-v2/artifacts /usr/src/artifacts
 WORKDIR /usr/src
 COPY --from=build-image /usr/src/submarine-operator /usr/src/submarine-operator
 
-CMD ["/usr/src/submarine-operator", "-incluster=true"]
+CMD ["/usr/src/submarine-operator", "-incluster=true", "-clustertype=${SUBMARINE_CLUSTER_TYPE}", "-createpsp=${SUBMARINE_POD_SECURITY_POLICY_ENABLE}"]

--- a/dev-support/docker-images/operator/Dockerfile
+++ b/dev-support/docker-images/operator/Dockerfile
@@ -14,17 +14,20 @@
 # limitations under the License.
 
 FROM golang:1.16.2 AS build-image
-MAINTAINER Apache Software Foundation <dev@submarine.apache.org>
 
 ADD tmp/submarine-cloud-v2 /usr/src
 
 WORKDIR /usr/src
 
-RUN GOOS=linux go build -o submarine-operator
+# use CGO_ENABLED=0 to support alpine image
+RUN GOOS=linux CGO_ENABLED=0 go build -o submarine-operator
 
-FROM gcr.io/distroless/base-debian10
+# we use alpine to support shell params
+FROM alpine
+MAINTAINER Apache Software Foundation <dev@submarine.apache.org>
+
 ADD tmp/submarine-cloud-v2/artifacts /usr/src/artifacts
 WORKDIR /usr/src
 COPY --from=build-image /usr/src/submarine-operator /usr/src/submarine-operator
 
-CMD ["/usr/src/submarine-operator", "-incluster=true", "-clustertype=${SUBMARINE_CLUSTER_TYPE}", "-createpsp=${SUBMARINE_POD_SECURITY_POLICY_ENABLE}"]
+CMD /usr/src/submarine-operator -incluster=true -clustertype=${SUBMARINE_CLUSTER_TYPE:kubernetes} -createpsp=${SUBMARINE_POD_SECURITY_POLICY_ENABLE:-true}

--- a/helm-charts/submarine/templates/psp.yaml
+++ b/helm-charts/submarine/templates/psp.yaml
@@ -14,31 +14,26 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
-{{/*
-Set up storage class fields
-*/}}
-{{ define "storageClass.fields" }}
-{{ with .Values.storageClass }}
-reclaimPolicy: {{ .reclaimPolicy | default "Delete" }}
-volumeBindingMode: {{ .volumeBindingMode | default "Immediate" }}
-provisioner: {{ .provisioner | default "k8s.io/minikube-hostpath" }}
-{{ if .parameters }}
-parameters:
-  {{ range $key, $val := .parameters }}
-  {{ $key }}: {{ $val | quote }}
-  {{ end }}
-{{ end }}
-{{ end }}
-{{ end }}
-
-{{/*
-Return the apiVersion for PodSecurityPolicy.
-*/}}
-{{- define "podSecurityPolicy.apiVersion" -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-{{- print "policy/v1beta1" -}}
-{{- else -}}
-{{- print "extensions/v1beta1" -}}
-{{- end -}}
-{{- end -}}
+{{- if .Values.podSecurityPolicy.create }}
+kind: PodSecurityPolicy
+apiVersion: {{ template "podSecurityPolicy.apiVersion" . }}
+metadata:
+  name: submarine-anyuid
+spec:
+  volumes:
+    - configMap
+    - downwardAPI
+    - emptyDir
+    - persistentVolumeClaim
+    - projected
+    - secret
+  seLinux:
+    rule: RunAsAny
+  runAsUser:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  fsGroup:
+    rule: RunAsAny
+  allowPrivilegeEscalation: false
+{{- end }}

--- a/helm-charts/submarine/templates/rbac.yaml
+++ b/helm-charts/submarine/templates/rbac.yaml
@@ -25,6 +25,7 @@ rules:
     resources:
       - submarines
       - submarines/status
+      - submarines/finalizers
     verbs:
       - "*"
   - apiGroups:

--- a/helm-charts/submarine/templates/submarine-operator.yaml
+++ b/helm-charts/submarine/templates/submarine-operator.yaml
@@ -42,6 +42,11 @@ spec:
           name: "{{ .Values.name }}"
           resources: {}
           imagePullPolicy: IfNotPresent
+          env:
+            - name: SUBMARINE_POD_SECURITY_POLICY_ENABLE
+              value: "{{ .Values.podSecurityPolicy.create }}"
+            - name: SUBMARINE_CLUSTER_TYPE
+              value: {{ .Values.clusterType }}
       serviceAccountName: submarine-operator
 status: {}
 {{ end }}

--- a/helm-charts/submarine/values.yaml
+++ b/helm-charts/submarine/values.yaml
@@ -30,3 +30,13 @@ storageClass:
   provisioner: k8s.io/minikube-hostpath
   # parameters describe volumes belonging to the storage class
   parameters:
+
+# k8s cluster type. can be: kubernetes or openshift
+clusterType: kubernetes
+
+# PodSecurityPolicy configuration
+# ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/
+podSecurityPolicy:
+  # Specifies whether a PodSecurityPolicy should be created,
+  # This configuration enables the database/minio/server to set securityContext.runAsUser
+  create: true

--- a/submarine-cloud-v2/artifacts/submarine/submarine-database.yaml
+++ b/submarine-cloud-v2/artifacts/submarine/submarine-database.yaml
@@ -60,6 +60,7 @@ spec:
       labels:
         app: "submarine-database"
     spec:
+      serviceAccountName: "submarine-storage"
       containers:
         - name: "submarine-database"
           image: "apache/submarine:database-0.7.0"

--- a/submarine-cloud-v2/artifacts/submarine/submarine-minio.yaml
+++ b/submarine-cloud-v2/artifacts/submarine/submarine-minio.yaml
@@ -57,6 +57,7 @@ spec:
       labels:
         app: submarine-minio
     spec:
+      serviceAccountName: "submarine-storage"
       containers:
       - name: submarine-minio-container
         image: minio/minio:RELEASE.2021-02-14T04-01-33Z

--- a/submarine-cloud-v2/artifacts/submarine/submarine-storage-rbac.yaml
+++ b/submarine-cloud-v2/artifacts/submarine/submarine-storage-rbac.yaml
@@ -1,3 +1,5 @@
+---
+# Source: submarine/templates/rbac.yaml
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
@@ -15,30 +17,25 @@
 # limitations under the License.
 #
 
-{{/*
-Set up storage class fields
-*/}}
-{{ define "storageClass.fields" }}
-{{ with .Values.storageClass }}
-reclaimPolicy: {{ .reclaimPolicy | default "Delete" }}
-volumeBindingMode: {{ .volumeBindingMode | default "Immediate" }}
-provisioner: {{ .provisioner | default "k8s.io/minikube-hostpath" }}
-{{ if .parameters }}
-parameters:
-  {{ range $key, $val := .parameters }}
-  {{ $key }}: {{ $val | quote }}
-  {{ end }}
-{{ end }}
-{{ end }}
-{{ end }}
-
-{{/*
-Return the apiVersion for PodSecurityPolicy.
-*/}}
-{{- define "podSecurityPolicy.apiVersion" -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-{{- print "policy/v1beta1" -}}
-{{- else -}}
-{{- print "extensions/v1beta1" -}}
-{{- end -}}
-{{- end -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: "submarine-storage"
+rules: []
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: submarine-storage
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: "submarine-storage"
+subjects:
+  - kind: ServiceAccount
+    name: "submarine-storage"
+roleRef:
+  kind: Role
+  name: "submarine-storage"
+  apiGroup: rbac.authorization.k8s.io

--- a/submarine-cloud-v2/main.go
+++ b/submarine-cloud-v2/main.go
@@ -38,9 +38,11 @@ import (
 )
 
 var (
-	masterURL  string
-	kubeconfig string
-	incluster  bool
+	masterURL               string
+	kubeconfig              string
+	incluster               bool
+	clusterType             string
+	createPodSecurityPolicy bool
 )
 
 func initKubeConfig() (*rest.Config, error) {
@@ -88,6 +90,8 @@ func main() {
 	// Create a Submarine operator
 	submarineController := NewSubmarineController(
 		incluster,
+		clusterType,
+		createPodSecurityPolicy,
 		kubeClient,
 		submarineClient,
 		traefikClient,
@@ -110,6 +114,8 @@ func main() {
 
 func NewSubmarineController(
 	incluster bool,
+	clusterType string,
+	createPodSecurityPolicy bool,
 	kubeClient *kubernetes.Clientset,
 	submarineClient *clientset.Clientset,
 	traefikClient *traefikclientset.Clientset,
@@ -120,6 +126,8 @@ func NewSubmarineController(
 	bc := controller.NewControllerBuilderConfig()
 	bc.
 		InCluster(incluster).
+		WithClusterType(clusterType).
+		WithCreatePodSecurityPolicy(createPodSecurityPolicy).
 		WithKubeClientset(kubeClient).
 		WithSubmarineClientset(submarineClient).
 		WithTraefikClientset(traefikClient).
@@ -143,4 +151,6 @@ func init() {
 	flag.BoolVar(&incluster, "incluster", false, "Run submarine-operator in-cluster")
 	flag.StringVar(&kubeconfig, "kubeconfig", os.Getenv("HOME")+"/.kube/config", "Path to a kubeconfig. Only required if out-of-cluster.")
 	flag.StringVar(&masterURL, "master", "", "The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.")
+	flag.StringVar(&clusterType, "clustertype", "kubernetes", "K8s cluster type, can be kubernetes or openshift")
+	flag.BoolVar(&createPodSecurityPolicy, "createpsp", true, "Specifies whether a PodSecurityPolicy should be created. This configuration enables the database/minio/server to set securityContext.runAsUser")
 }

--- a/submarine-cloud-v2/pkg/controller/controller_builder.go
+++ b/submarine-cloud-v2/pkg/controller/controller_builder.go
@@ -63,6 +63,8 @@ func (cb *ControllerBuilder) initialize() *ControllerBuilder {
 	workqueue := workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "Submarines")
 
 	cb.controller.incluster = cb.config.incluster
+	cb.controller.clusterType = cb.config.clusterType
+	cb.controller.createPodSecurityPolicy = cb.config.createPodSecurityPolicy
 	cb.controller.recorder = recorder
 	cb.controller.workqueue = workqueue
 

--- a/submarine-cloud-v2/pkg/controller/controller_builder_config.go
+++ b/submarine-cloud-v2/pkg/controller/controller_builder_config.go
@@ -31,6 +31,8 @@ import (
 
 type BuilderConfig struct {
 	incluster                     bool
+	clusterType                   string
+	createPodSecurityPolicy       bool
 	kubeclientset                 kubernetes.Interface
 	submarineclientset            clientset.Interface
 	traefikclientset              traefik.Interface
@@ -55,6 +57,20 @@ func (bc *BuilderConfig) InCluster(
 	incluster bool,
 ) *BuilderConfig {
 	bc.incluster = incluster
+	return bc
+}
+
+func (bc *BuilderConfig) WithClusterType(
+	clusterType string,
+) *BuilderConfig {
+	bc.clusterType = clusterType
+	return bc
+}
+
+func (bc *BuilderConfig) WithCreatePodSecurityPolicy(
+	createPodSecurityPolicy bool,
+) *BuilderConfig {
+	bc.createPodSecurityPolicy = createPodSecurityPolicy
 	return bc
 }
 

--- a/submarine-cloud-v2/pkg/controller/submarine_observer_rbac.go
+++ b/submarine-cloud-v2/pkg/controller/submarine_observer_rbac.go
@@ -57,7 +57,7 @@ func newSubmarineObserverRoleBinding(submarine *v1alpha1.Submarine) *rbacv1.Role
 // createSubmarineObserverRBAC is a function to create RBAC for submarine-observer which will be binded on service account: default.
 // Reference: https://github.com/apache/submarine/blob/master/helm-charts/submarine/templates/rbac.yaml
 func (c *Controller) createSubmarineObserverRBAC(submarine *v1alpha1.Submarine) error {
-	klog.Info("[createSubmarineServerRBAC]")
+	klog.Info("[createSubmarineObserverRBAC]")
 
 	// Step1: Create Role
 	role, err := c.roleLister.Roles(submarine.Namespace).Get(observerName)

--- a/submarine-cloud-v2/pkg/controller/submarine_storage_rbac.go
+++ b/submarine-cloud-v2/pkg/controller/submarine_storage_rbac.go
@@ -1,0 +1,135 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controller
+
+import (
+	"context"
+	"fmt"
+	v1alpha1 "github.com/apache/submarine/submarine-cloud-v2/pkg/apis/submarine/v1alpha1"
+
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
+)
+
+func newSubmarineStorageRole(c *Controller, submarine *v1alpha1.Submarine) *rbacv1.Role {
+	role, err := ParseRoleYaml(storageRbacYamlPath)
+	if err != nil {
+		klog.Info("[Error] ParseRole", err)
+	}
+	role.ObjectMeta.OwnerReferences = []metav1.OwnerReference{
+		*metav1.NewControllerRef(submarine, v1alpha1.SchemeGroupVersion.WithKind("Submarine")),
+	}
+
+	// If cluster type is openshift and need create pod security policy, we need add anyuid scc, or we add k8s psp
+	if c.clusterType == "openshift" {
+		role.Rules = append(role.Rules, openshiftAnyuidRoleRule)
+	} else {
+		role.Rules = append(role.Rules, k8sAnyuidRoleRule)
+	}
+
+	return role
+}
+
+func newSubmarineStorageRoleBinding(submarine *v1alpha1.Submarine) *rbacv1.RoleBinding {
+	roleBinding, err := ParseRoleBindingYaml(storageRbacYamlPath)
+	if err != nil {
+		klog.Info("[Error] ParseRoleBinding", err)
+	}
+	roleBinding.ObjectMeta.OwnerReferences = []metav1.OwnerReference{
+		*metav1.NewControllerRef(submarine, v1alpha1.SchemeGroupVersion.WithKind("Submarine")),
+	}
+
+	return roleBinding
+}
+
+func newSubmarineStorageServiceAccount(submarine *v1alpha1.Submarine) *corev1.ServiceAccount {
+	serviceAccount, err := ParseServiceAccountYaml(storageRbacYamlPath)
+	if err != nil {
+		klog.Info("[Error] ParseServiceAccountYaml", err)
+	}
+
+	serviceAccount.ObjectMeta.OwnerReferences = []metav1.OwnerReference{
+		*metav1.NewControllerRef(submarine, v1alpha1.SchemeGroupVersion.WithKind("Submarine")),
+	}
+
+	return serviceAccount
+}
+
+// createSubmarineStorageRBAC is a function to create RBAC for submarine-database and submarine-minio which will be binded on service account: submarine-storage.
+// Reference: https://github.com/apache/submarine/blob/master/submarine-cloud-v2/artifacts/submarine/submarine-storage-rbac.yaml
+func (c *Controller) createSubmarineStorageRBAC(submarine *v1alpha1.Submarine) error {
+	klog.Info("[createSubmarineStorageRBAC]")
+
+	// Step1: Create ServiceAccount
+	serviceaccount, err := c.serviceaccountLister.ServiceAccounts(submarine.Namespace).Get(storageName)
+	// If the resource doesn't exist, we'll create it
+	if errors.IsNotFound(err) {
+		serviceaccount, err = c.kubeclientset.CoreV1().ServiceAccounts(submarine.Namespace).Create(context.TODO(), newSubmarineStorageServiceAccount(submarine), metav1.CreateOptions{})
+		klog.Info("	Create ServiceAccount: ", serviceaccount.Name)
+	}
+
+	// Step2: Pod Security Policy if needed
+	if c.createPodSecurityPolicy {
+		// Step2.1: Create Role
+		role, err := c.roleLister.Roles(submarine.Namespace).Get(storageName)
+		// If the resource doesn't exist, we'll create it
+		if errors.IsNotFound(err) {
+			role, err = c.kubeclientset.RbacV1().Roles(submarine.Namespace).Create(context.TODO(), newSubmarineStorageRole(c, submarine), metav1.CreateOptions{})
+			klog.Info("	Create Role: ", role.Name)
+		}
+
+		// If an error occurs during Get/Create, we'll requeue the item so we can
+		// attempt processing again later. This could have been caused by a
+		// temporary network failure, or any other transient reason.
+		if err != nil {
+			return err
+		}
+
+		if !metav1.IsControlledBy(role, submarine) {
+			msg := fmt.Sprintf(MessageResourceExists, role.Name)
+			c.recorder.Event(submarine, corev1.EventTypeWarning, ErrResourceExists, msg)
+			return fmt.Errorf(msg)
+		}
+
+		// Step2.2: Create Role Binding
+		rolebinding, rolebinding_err := c.rolebindingLister.RoleBindings(submarine.Namespace).Get(storageName)
+		// If the resource doesn't exist, we'll create it
+		if errors.IsNotFound(rolebinding_err) {
+			rolebinding, rolebinding_err = c.kubeclientset.RbacV1().RoleBindings(submarine.Namespace).Create(context.TODO(), newSubmarineStorageRoleBinding(submarine), metav1.CreateOptions{})
+			klog.Info("	Create RoleBinding: ", rolebinding.Name)
+		}
+
+		// If an error occurs during Get/Create, we'll requeue the item so we can
+		// attempt processing again later. This could have been caused by a
+		// temporary network failure, or any other transient reason.
+		if rolebinding_err != nil {
+			return rolebinding_err
+		}
+
+		if !metav1.IsControlledBy(rolebinding, submarine) {
+			msg := fmt.Sprintf(MessageResourceExists, rolebinding.Name)
+			c.recorder.Event(submarine, corev1.EventTypeWarning, ErrResourceExists, msg)
+			return fmt.Errorf(msg)
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
### What is this PR for?
We need to add PodSecurityPolicies(k8s) or SecurityContextConstraints(openshift) to let pod run as a user with default user in docker container. Otherwise, pod may cause permission problems (like no permission error).

### What type of PR is it?
Bug Fix

### Todos
* [x] - Add two params in helm values.yaml: `clusterType` and `podSecurityPolicy.create`
* [x] - Change operator dockerfile to support shell params `SUBMARINE_CLUSTER_TYPE`  and `SUBMARINE_POD_SECURITY_POLICY_ENABLE`
* [x] - Add PodSecurityPolicy (OpenShift has a default scc anyuid so that we need not to add) 
* [x] - The processing of operator is reconstructed: create deployment run after RBAC created 
* [x] - Add RunAsAnyUser policy in database\minio\server


### What is the Jira issue?
https://issues.apache.org/jira/projects/SUBMARINE/issues/SUBMARINE-1179

### How should this be tested?
<!--
* First time? Setup Travis CI as described on https://submarine.apache.org/contribution/contributions.html#continuous-integration
* Strongly recommended: add automated unit tests for any new or changed behavior
* Outline any manual steps to test the PR here.
-->
### Screenshots (if appropriate)

### Questions:
* Do the license files need updating? No
* Are there breaking changes for older versions? Yes
* Does this need new documentation? No
