### PR TITLE
SUBMARINE-1221. Check supported Kubernetes version in GitHub Actions.

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -169,7 +169,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       matrix:
-        k8s-version: ["v1.21.11", "v1.22.8", "v1.23.5"]
+        k8s-version: ["v1.21.10", "v1.22.7", "v1.23.5"]
       fail-fast: false
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - id: set-matrix
         run: |
-          echo "::set-output name=matrix::[\"v1.18.20\", \"v1.19.16\", \"v1.20.15\", \"v1.21.10\", \"v1.22.7\", \"v1.23.5\"]"
+          echo "::set-output name=matrix::[\"v1.18.20\", \"v1.19.16\", \"v1.20.15\", \"v1.21.10\"]"
   submarine-operator-verify-codegen:
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -60,7 +60,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       matrix:
-        k8s-version: ${{fromJSON(needs.generate-k8s-versions-array.outputs.matrix.outputs.matrix)}}
+        k8s-version: ${{fromJSON(needs.generate-k8s-versions-array.outputs.matrix)}}
       fail-fast: false
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -167,6 +167,10 @@ jobs:
   submarine-k8s:
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    strategy:
+      matrix:
+        k8s-version: ["v1.20", "v1.21", "v1.22", "v1.23"]
+      fail-fast: false
     steps:
       - uses: actions/checkout@v2
         with:
@@ -197,7 +201,7 @@ jobs:
           helm version
           kind version
       - name: Create kind cluster
-        run: kind create cluster --config ./.github/config/kind-config-kind.yaml --wait 3m --image kindest/node:${KUBERNETES_VERSION}
+        run: kind create cluster --config ./.github/config/kind-config-kind.yaml --wait 3m --image kindest/node:${{ matrix.k8s-version }}
       - name: Show K8s cluster information
         run: |
           kubectl cluster-info

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -22,9 +22,15 @@ env:
   VERSION: "0.7.0"
   BUILD_FLAG: "clean install -ntp -DskipTests -am"
   TEST_FLAG: "test -DskipRat -ntp"
-  KUBERNETES_VERSION: "v1.21.2"
-
 jobs:
+  generate-k8s-versions-array:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - id: set-matrix
+        run: |
+          echo "::set-output name=matrix::[\"1.21.10\", \"v1.22.7\", \"v1.23.5\"]"
   submarine-operator-verify-codegen:
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -49,8 +55,13 @@ jobs:
         working-directory: ${{ env.working-directory }}/submarine-cloud-v2
         run: ./hack/verify-codegen.sh
   submarine-operator-e2e-test:
+    needs: generate-k8s-versions-array
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    strategy:
+      matrix:
+        k8s-version: ${{fromJSON(needs.generate-k8s-versions-array.outputs.matrix.outputs.matrix)}}
+      fail-fast: false
     steps:
       - uses: actions/checkout@v2
         with:
@@ -81,7 +92,7 @@ jobs:
           helm version
           kind version
       - name: Create kind cluster
-        run: kind create cluster --config ./.github/config/kind-config-kind.yaml --wait 3m --image kindest/node:${KUBERNETES_VERSION}
+        run: kind create cluster --config ./.github/config/kind-config-kind.yaml --wait 3m --image kindest/node:${{ matrix.k8s-version }}
       - name: Show K8s cluster information
         run: |
           kubectl cluster-info
@@ -165,11 +176,12 @@ jobs:
           echo ">>> mvn ${TEST_FLAG} ${TEST_MODULES} -B"
           mvn ${TEST_FLAG} ${TEST_MODULES} -B
   submarine-k8s:
+    needs: generate-k8s-versions-array
     runs-on: ubuntu-latest
     timeout-minutes: 60
     strategy:
       matrix:
-        k8s-version: ["v1.21.10", "v1.22.7", "v1.23.5"]
+        k8s-version: ${{fromJson(needs.generate-k8s-versions-array.outputs.matrix)}}
       fail-fast: false
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - id: set-matrix
         run: |
-          echo "::set-output name=matrix::[\"1.21.10\", \"v1.22.7\", \"v1.23.5\"]"
+          echo "::set-output name=matrix::[\"v1.18.20\", \"v1.19.16\", \"v1.20.15\", \"v1.21.10\", \"v1.22.7\", \"v1.23.5\"]"
   submarine-operator-verify-codegen:
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -169,7 +169,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       matrix:
-        k8s-version: ["v1.20", "v1.21", "v1.22", "v1.23"]
+        k8s-version: ["v1.21.11", "v1.22.8", "v1.23.5"]
       fail-fast: false
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
### What is this PR for?
<!-- A few sentences describing the overall goals of the pull request's commits.
First time? Check out the contributing guide - https://submarine.apache.org/contribution/contributions.html
-->

It is found that the dependencies fail on different Kubernetes versions.
Hence, we want to add check-in GitHub Actions to automatically test the supported Kubernetes version.
It'll check from v1.18 to v1.23.

However, there are changes to custom resources in v1.22 and v1.23, so it will fail in these two versions.

### What type of PR is it?
Improvement

### Todos

None

### What is the Jira issue?
<!-- * Open an issue on Jira https://issues.apache.org/jira/browse/SUBMARINE/
* Put link here, and add [SUBMARINE-*Jira number*] in PR title, eg. `SUBMARINE-23. PR title`
-->

https://issues.apache.org/jira/browse/SUBMARINE-1221

### How should this be tested?
<!--
* First time? Setup Travis CI as described on https://submarine.apache.org/contribution/contributions.html#continuous-integration
* Strongly recommended: add automated unit tests for any new or changed behavior
* Outline any manual steps to test the PR here.
-->

Push your code to GitHub, and GitHub action will handle more versions.

### Screenshots (if appropriate)

![Screen Shot 2022-04-21 at 12 19 27 AM](https://user-images.githubusercontent.com/17617373/164276945-1654c9c2-106d-47fc-951d-1ec576b9d33f.png)

### Questions:
* Do the license files need updating? No
* Are there breaking changes for older versions? No
* Does this need new documentation? No
