### PR TITLE
SUBMARINE-1279. Fix securitycontext problems after importing istio and changing training-operator

### DIFF
--- a/helm-charts/submarine/charts/notebook-controller/templates/cluster-role.yaml
+++ b/helm-charts/submarine/charts/notebook-controller/templates/cluster-role.yaml
@@ -51,6 +51,7 @@ rules:
   - list
   - watch
   - create
+  - patch
 - apiGroups:
   - kubeflow.org
   resources:

--- a/helm-charts/submarine/templates/psp.yaml
+++ b/helm-charts/submarine/templates/psp.yaml
@@ -21,7 +21,10 @@ apiVersion: {{ template "podSecurityPolicy.apiVersion" . }}
 metadata:
   name: submarine-anyuid
 spec:
-  privileged: false
+  privileged: true
+  allowedCapabilities:
+    - NET_ADMIN
+    - NET_RAW
   volumes:
     - configMap
     - downwardAPI

--- a/helm-charts/submarine/templates/rbac-kubeflow.yaml
+++ b/helm-charts/submarine/templates/rbac-kubeflow.yaml
@@ -44,27 +44,14 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: tf-job-operator-anyuid
+  name: training-operator-anyuid
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: kubeflow-operator-anyuid
 subjects:
   - kind: ServiceAccount
-    name: tf-job-operator
-    namespace: {{ .Release.Namespace }}
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: pytorch-operator-anyuid
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: kubeflow-operator-anyuid
-subjects:
-  - kind: ServiceAccount
-    name: pytorch-operator
+    name: training-operator
     namespace: {{ .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
### What is this PR for?
Fix securitycontext problems after importing istio and changing training-operator.

### What type of PR is it?
Bug Fix

### Todos
* [x] - Add NET_ADMIN or NET_RAW in PodSecurityPolicy
* [x] - Replace ClusterRoleBinding in rbac-kubeflow
* [x] - add a `patch` verbs in `events` resource

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-1279

### How should this be tested?
Need to open PodSecurityPolicy option in minikube

### Screenshots (if appropriate)
No

### Questions:
* Do the license files need updating? No
* Are there breaking changes for older versions? No
* Does this need new documentation? No
