### PR TITLE
SUBMARINE-1281. Limit tensorflow protocol package version to <=3.20.1

### DIFF
--- a/submarine-sdk/pysubmarine/README.md
+++ b/submarine-sdk/pysubmarine/README.md
@@ -28,6 +28,12 @@ tracking experiment metrics, parameters.
 git clone https://github.com/apache/submarine.git
 cd submarine/submarine-sdk/pysubmarine
 pip install .
+
+# install extras_require
+## bash
+pip install -e .[tf2,pytorch]
+## zsh
+pip install -e ".[tf2,pytorch]"
 ```
 
 - Install package from pypi

--- a/submarine-sdk/pysubmarine/setup.py
+++ b/submarine-sdk/pysubmarine/setup.py
@@ -47,13 +47,17 @@ setup(
         "pyaml==21.10.1",
     ],
     extras_require={
-        "tf": ["tensorflow==1.15.0"],
+        "tf": [
+            "tensorflow==1.15.0",
+            "protobuf<=3.20.1"
+        ],
         "tf2": [
             "tensorflow==2.6.0",
             "tf_slim==1.1.0",
             "tensorflow-addons==0.14.0",
             "tensorflow-estimator==2.6.0",
             "keras==2.6",
+            "protobuf<=3.20.1"
         ],
         "pytorch": ["torch>=1.5.0", "torchvision>=0.6.0"],
     },

--- a/submarine-sdk/pysubmarine/setup.py
+++ b/submarine-sdk/pysubmarine/setup.py
@@ -47,17 +47,14 @@ setup(
         "pyaml==21.10.1",
     ],
     extras_require={
-        "tf": [
-            "tensorflow==1.15.0",
-            "protobuf<=3.20.1"
-        ],
+        "tf": ["tensorflow==1.15.0", "protobuf<=3.20.1"],
         "tf2": [
             "tensorflow==2.6.0",
             "tf_slim==1.1.0",
             "tensorflow-addons==0.14.0",
             "tensorflow-estimator==2.6.0",
             "keras==2.6",
-            "protobuf<=3.20.1"
+            "protobuf<=3.20.1",
         ],
         "pytorch": ["torch>=1.5.0", "torchvision>=0.6.0"],
     },


### PR DESCRIPTION
### What is this PR for?
The latest submarine-sdk dependent installation will cause workflow CI test failure. 
After checked, it is found that the latest version of protocol has changed:
https://developers.google.com/protocol-buffers/docs/news/2022-05-06#python-updates
https://pypi.org/project/protobuf/#history

We need to limit the protocol package version to <=3.20.1

### What type of PR is it?
Hot Fix

### Todos
* [x] - add extras_require `protobuf<=3.20.1`

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-1281

### How should this be tested?
Submarine Github workflow CI test

### Screenshots (if appropriate)
No

### Questions:
* Do the license files need updating? No
* Are there breaking changes for older versions? No
* Does this need new documentation? No
