### PR TITLE
SUBMARINE-1288. Fix issue that agent can not stop after Kubeflow job is finished

### DIFF
--- a/submarine-server/server-submitter/submarine-k8s-agent/src/main/java/org/apache/submarine/server/k8s/agent/handler/TFJobHandler.java
+++ b/submarine-server/server-submitter/submarine-k8s-agent/src/main/java/org/apache/submarine/server/k8s/agent/handler/TFJobHandler.java
@@ -21,6 +21,7 @@ package org.apache.submarine.server.k8s.agent.handler;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Objects;
 
 import org.apache.submarine.server.api.common.CustomResourceType;
 import org.apache.submarine.server.api.experiment.Experiment;
@@ -92,7 +93,7 @@ public class TFJobHandler extends CustomResourceHandler {
           LOG.info(String.format("current status of tfjob:%s is %s", resourceId, experiment.getStatus()));
 
           // The reason value can refer to https://github.com/kubeflow/common/blob/master/pkg/util/status.go
-          switch (lastCondition.getReason()) {
+          switch (Objects.requireNonNull(lastCondition.getReason())) {
             case "JobSucceeded":
               LOG.info(String.format("TfJob:%s is succeeded, exit", this.resourceId));
               return;

--- a/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/model/AgentPod.java
+++ b/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/model/AgentPod.java
@@ -55,7 +55,8 @@ public class AgentPod extends V1Pod implements K8sResource<AgentPod> {
         .withNamespace(namespace)
         .addToLabels("app", type.toString().toLowerCase())
         // There is no need to add istio sidecar. Otherwise, the pod may not end normally
-        // https://istio.io/latest/docs/setup/additional-setup/sidecar-injection/#controlling-the-injection-policy
+        // https://istio.io/latest/docs/setup/additional-setup/sidecar-injection/
+        // Controlling the injection policy Section
         .addToAnnotations("sidecar.istio.io/inject", "false");
     this.setMetadata(metaBuilder.build());
 


### PR DESCRIPTION
### What is this PR for?
With new training operator replaced, the Kubeflow CRD status conditions reason description has changed. We need to modify the processing of the state, so that the agent can stop correctly.

### What type of PR is it?
Bug Fix

### Todos
* [x] - Change the reason name in training operator

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-1288

### How should this be tested?
<!--
* First time? Setup Travis CI as described on https://submarine.apache.org/contribution/contributions.html#continuous-integration
* Strongly recommended: add automated unit tests for any new or changed behavior
* Outline any manual steps to test the PR here.
-->
### Screenshots (if appropriate)
No

### Questions:
* Do the license files need updating? No
* Are there breaking changes for older versions? No
* Does this need new documentation? No
