### PR TITLE
SUBMARINE-1305. Fix submarine-server-core test error

### DIFF
--- a/submarine-server/server-core/src/test/java/org/apache/submarine/server/security/SubmarineAuthSimpleTest.java
+++ b/submarine-server/server-core/src/test/java/org/apache/submarine/server/security/SubmarineAuthSimpleTest.java
@@ -32,6 +32,7 @@ import org.apache.submarine.server.security.simple.SimpleFilter;
 import org.apache.submarine.server.utils.gson.EnvironmentIdDeserializer;
 import org.apache.submarine.server.utils.gson.EnvironmentIdSerializer;
 import org.apache.submarine.server.utils.response.JsonResponse;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -141,6 +142,11 @@ public class SubmarineAuthSimpleTest {
     filterTest.doFilter(mockRequest, mockResponse, mockFilterChain);
     verify(mockFilterChain).doFilter(mockRequest, mockResponse);
     assertNotNull(mockRequest.getAttribute(Pac4jConstants.USER_PROFILES));
+  }
+
+  @After
+  public void after() {
+    conf.updateConfiguration("submarine.auth.type", "none");
   }
 
 }


### PR DESCRIPTION
### What is this PR for?
Currently, the test case class `SubmarineAuthSimpleTest` in `submarine-server-core` does not reset `submarine.auth.type` to `none` at the end (@After), which will cause subsequent test cases to be blocked.

### What type of PR is it?
Bug Fix

### Todos
* [x] - Reset `submarine.auth.type` to `none` after test passed.

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-1305

### How should this be tested?
Have fixed.

### Screenshots (if appropriate)
No

### Questions:
* Do the license files need updating? No
* Are there breaking changes for older versions? No
* Does this need new documentation? No
