### PR TITLE
SUBMARINE-1324. Fix the experiment pods label selector after using the new training operator

### DIFF
--- a/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/model/mljob/MLJobFactory.java
+++ b/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/model/mljob/MLJobFactory.java
@@ -52,4 +52,12 @@ public class MLJobFactory {
     }
   }
 
+  /**
+   * Get ml job labelSelector.
+   * The new training-operator has unified label.
+   */
+  public static String getJobLabelSelector(ExperimentSpec experimentSpec) {
+    return String.format("job-name=%s", experimentSpec.getMeta().getExperimentId());
+  }
+
 }

--- a/submarine-server/server-submitter/submitter-k8s/src/test/java/org/apache/submarine/server/submitter/k8s/ExperimentSpecParserTest.java
+++ b/submarine-server/server-submitter/submitter-k8s/src/test/java/org/apache/submarine/server/submitter/k8s/ExperimentSpecParserTest.java
@@ -83,6 +83,13 @@ public class ExperimentSpecParserTest extends SpecBuilder {
   }
 
   @Test
+  public void testValidLabel() throws IOException, URISyntaxException {
+    ExperimentSpec experimentSpec = (ExperimentSpec) buildFromJsonFile(ExperimentSpec.class, tfJobReqFile);
+    String label = MLJobFactory.getJobLabelSelector(experimentSpec);
+    Assert.assertEquals("job-name=" + experimentSpec.getMeta().getExperimentId(), label);
+  }
+
+  @Test
   public void testValidTensorFlowExperiment() throws IOException,
       URISyntaxException, InvalidSpecException {
     ExperimentSpec experimentSpec = (ExperimentSpec) buildFromJsonFile(ExperimentSpec.class, tfJobReqFile);


### PR DESCRIPTION
### What is this PR for?
After updated to new training operator, the metrics/logs/params of the experiment cannot be shown, which is found that the pod label had changed to `job-name`.

### What type of PR is it?
Bug Fix

### Todos
* [x] - Change label to job-name

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-1324

### How should this be tested?
Consider adding after refactoring.

### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/12069428/189625495-7e640088-b6b8-4e04-85b3-3659f923256b.png)


### Questions:
* Do the license files need updating? No
* Are there breaking changes for older versions? No
* Does this need new documentation? No
