### PR TITLE
SUBMARINE-1329. Improve test coverage of submarine.artifacts module

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -16,7 +16,13 @@
 name: Submarine
 
 # Trigger the workflow on push or pull request
-on: [push, pull_request]
+# on: [push, pull_request]
+# TODO: restore
+on:
+pull_request:
+push:
+  branches:
+    - main
 
 env:
   VERSION: "0.8.0-SNAPSHOT"
@@ -560,7 +566,7 @@ jobs:
         with:
           path: |
             ./submarine-server/server-submitter/target/jacoco.exec
-          key: ${{ runner.os }}-docker-${{ github.sha }}      
+          key: ${{ runner.os }}-docker-${{ github.sha }}
       - name: Cache submitter-k8s jacoco.exec
         uses: actions/cache@v2
         with:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -16,13 +16,7 @@
 name: Submarine
 
 # Trigger the workflow on push or pull request
-# on: [push, pull_request]
-# TODO: restore
-on:
-pull_request:
-push:
-  branches:
-    - main
+on: [push, pull_request]
 
 env:
   VERSION: "0.8.0-SNAPSHOT"

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -16,13 +16,7 @@
 name: python-sdk
 
 # Trigger the workflow on push or pull request
-# on: [push, pull_request]
-# TODO: restore
-on:
-  pull_request:
-  push:
-    branches:
-      - main
+on: [push, pull_request]
 
 env:
   KUBERNETES_VERSION: "v1.21.2"

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -42,22 +42,19 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        # TODO: restore
-        python-version: ['3.10']
-        tf-version: ['2.9.0']
-        # python-version: ['3.7', '3.8', '3.9', '3.10']
-        # tf-version: ['1.15.0', '2.6.0', '2.7.0', '2.8.0', '2.9.0']
-        # exclude:
-        #  - python-version: '3.8'
-        #      tf-version: '1.15.0'
-        #  - python-version: '3.9'
-        #      tf-version: '1.15.0'
-        #  - python-version: '3.10'
-        #      tf-version: '1.15.0'
-        #  - python-version: '3.10'
-        #      tf-version: '2.6.0'
-        #  - python-version: '3.10'
-        #      tf-version: '2.7.0'
+        python-version: ['3.7', '3.8', '3.9', '3.10']
+        tf-version: ['1.15.0', '2.6.0', '2.7.0', '2.8.0', '2.9.0']
+        exclude:
+          - python-version: '3.8'
+            tf-version: '1.15.0'
+          - python-version: '3.9'
+            tf-version: '1.15.0'
+          - python-version: '3.10'
+            tf-version: '1.15.0'
+          - python-version: '3.10'
+            tf-version: '2.6.0'
+          - python-version: '3.10'
+            tf-version: '2.7.0'
       fail-fast: false
     steps:
       - uses: actions/checkout@v3
@@ -81,29 +78,26 @@ jobs:
       - name: List installed packages
         run: pip list
       - name: Run unit test
-        run: pytest -m "not e2e"
+        run: pytest --cov=submarine -vs -m "not e2e"
 
   integration:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     strategy:
       matrix:
-        # TODO: restore
-        python-version: ['3.10']
-        tf-version: ['2.9.0']
-        # python-version: ['3.7', '3.8', '3.9', '3.10']
-        # tf-version: ['1.15.0', '2.6.0', '2.7.0', '2.8.0', '2.9.0']
-        # exclude:
-        #  - python-version: '3.8'
-        #      tf-version: '1.15.0'
-        #  - python-version: '3.9'
-        #      tf-version: '1.15.0'
-        #  - python-version: '3.10'
-        #      tf-version: '1.15.0'
-        #  - python-version: '3.10'
-        #      tf-version: '2.6.0'
-        #  - python-version: '3.10'
-        #      tf-version: '2.7.0'
+        python-version: ['3.7', '3.8', '3.9', '3.10']
+        tf-version: ['1.15.0', '2.6.0', '2.7.0', '2.8.0', '2.9.0']
+        exclude:
+          - python-version: '3.8'
+            tf-version: '1.15.0'
+          - python-version: '3.9'
+            tf-version: '1.15.0'
+          - python-version: '3.10'
+            tf-version: '1.15.0'
+          - python-version: '3.10'
+            tf-version: '2.6.0'
+          - python-version: '3.10'
+            tf-version: '2.7.0'
       fail-fast: false
     steps:
       - uses: actions/checkout@v3
@@ -174,7 +168,7 @@ jobs:
           submarine config list
       - name: Run integration test
         working-directory: ./submarine-sdk/pysubmarine
-        run: pytest -m "e2e"
+        run: pytest --cov=submarine -vs -m "e2e"
       - name: Failure status
         run: |
           kubectl describe nodes

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -78,7 +78,7 @@ jobs:
       - name: List installed packages
         run: pip list
       - name: Run unit test
-        run: pytest --cov=submarine -vs -m "not e2e"
+        run: pytest -m "not e2e"
 
   integration:
     runs-on: ubuntu-latest
@@ -168,7 +168,7 @@ jobs:
           submarine config list
       - name: Run integration test
         working-directory: ./submarine-sdk/pysubmarine
-        run: pytest --cov=submarine -vs -m "e2e"
+        run: pytest -m "e2e"
       - name: Failure status
         run: |
           kubectl describe nodes

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -78,7 +78,7 @@ jobs:
       - name: List installed packages
         run: pip list
       - name: Run unit test
-        run: pytest --cov=submarine -vs -m "not e2e"
+        run: pytest --cov=submarine --cov-report term-missing -vs -m "not e2e"
 
   integration:
     runs-on: ubuntu-latest
@@ -168,7 +168,7 @@ jobs:
           submarine config list
       - name: Run integration test
         working-directory: ./submarine-sdk/pysubmarine
-        run: pytest --cov=submarine -vs -m "e2e"
+        run: pytest --cov=submarine --cov-report term-missing -vs -m "e2e"
       - name: Failure status
         run: |
           kubectl describe nodes

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -42,19 +42,22 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10']
-        tf-version: ['1.15.0', '2.6.0', '2.7.0', '2.8.0', '2.9.0']
-        exclude:
-          - python-version: '3.8'
-            tf-version: '1.15.0'
-          - python-version: '3.9'
-            tf-version: '1.15.0'
-          - python-version: '3.10'
-            tf-version: '1.15.0'
-          - python-version: '3.10'
-            tf-version: '2.6.0'
-          - python-version: '3.10'
-            tf-version: '2.7.0'
+        # TODO: restore
+        python-version: ['3.10']
+        tf-version: ['2.9.0']
+        # python-version: ['3.7', '3.8', '3.9', '3.10']
+        # tf-version: ['1.15.0', '2.6.0', '2.7.0', '2.8.0', '2.9.0']
+        # exclude:
+        #  - python-version: '3.8'
+        #      tf-version: '1.15.0'
+        #  - python-version: '3.9'
+        #      tf-version: '1.15.0'
+        #  - python-version: '3.10'
+        #      tf-version: '1.15.0'
+        #  - python-version: '3.10'
+        #      tf-version: '2.6.0'
+        #  - python-version: '3.10'
+        #      tf-version: '2.7.0'
       fail-fast: false
     steps:
       - uses: actions/checkout@v3
@@ -85,19 +88,22 @@ jobs:
     timeout-minutes: 60
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10']
-        tf-version: ['1.15.0', '2.6.0', '2.7.0', '2.8.0', '2.9.0']
-        exclude:
-          - python-version: '3.8'
-            tf-version: '1.15.0'
-          - python-version: '3.9'
-            tf-version: '1.15.0'
-          - python-version: '3.10'
-            tf-version: '1.15.0'
-          - python-version: '3.10'
-            tf-version: '2.6.0'
-          - python-version: '3.10'
-            tf-version: '2.7.0'
+        # TODO: restore
+        python-version: ['3.10']
+        tf-version: ['2.9.0']
+        # python-version: ['3.7', '3.8', '3.9', '3.10']
+        # tf-version: ['1.15.0', '2.6.0', '2.7.0', '2.8.0', '2.9.0']
+        # exclude:
+        #  - python-version: '3.8'
+        #      tf-version: '1.15.0'
+        #  - python-version: '3.9'
+        #      tf-version: '1.15.0'
+        #  - python-version: '3.10'
+        #      tf-version: '1.15.0'
+        #  - python-version: '3.10'
+        #      tf-version: '2.6.0'
+        #  - python-version: '3.10'
+        #      tf-version: '2.7.0'
       fail-fast: false
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -81,7 +81,7 @@ jobs:
       - name: List installed packages
         run: pip list
       - name: Run unit test
-        run: pytest --cov=submarine --cov-report term-missing -vs -m "not e2e"
+        run: pytest -m "not e2e"
 
   integration:
     runs-on: ubuntu-latest
@@ -174,7 +174,7 @@ jobs:
           submarine config list
       - name: Run integration test
         working-directory: ./submarine-sdk/pysubmarine
-        run: pytest --cov=submarine --cov-report term-missing -vs -m "e2e"
+        run: pytest -m "e2e"
       - name: Failure status
         run: |
           kubectl describe nodes

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -16,7 +16,13 @@
 name: python-sdk
 
 # Trigger the workflow on push or pull request
-on: [push, pull_request]
+# on: [push, pull_request]
+# TODO: restore
+on:
+  pull_request:
+  push:
+    branches:
+      - main
 
 env:
   KUBERNETES_VERSION: "v1.21.2"

--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,6 @@ dev-support/docker-images/operator/tmp/
 
 # installation binary
 submarine-serve/installation/istioctl
+
+# mypy
+.mypy_cache/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,3 @@ skip-string-normalization = true
 [tool.mypy]
 plugins = "sqlalchemy.ext.mypy.plugin"
 ignore_missing_imports = true  # suppress `Cannot find implementation or library stub` error
-
-[tool.pytest.ini_options]
-addopts = "--strict-markers"
-markers = ["e2e"]

--- a/submarine-sdk/pysubmarine/github-actions/test-requirements.txt
+++ b/submarine-sdk/pysubmarine/github-actions/test-requirements.txt
@@ -15,6 +15,7 @@
 
 certifi>=14.05.14
 freezegun==1.2.2
+moto[s3]==4.0.5
 pandas>=1.2.0,<=1.3.5  # 1.4.x does not support cp37
 pylint==2.15.2
 PyMySQL==1.0.2
@@ -22,6 +23,6 @@ pytest==7.1.3
 pytest-cov==3.0.0
 pytest-localserver==0.7.0
 python_dateutil>=2.5.3
-scikit-learn>=0.24.2,<=1.0.2  # 1.1.x doest not support cp37
+scikit-learn>=0.24.2,<=1.0.2  # 1.1.x does not support cp37
 setuptools>=21.0.0
 urllib3>=1.15.1

--- a/submarine-sdk/pysubmarine/pyproject.toml
+++ b/submarine-sdk/pysubmarine/pyproject.toml
@@ -1,0 +1,3 @@
+[tool.pytest.ini_options]
+markers = ["e2e"]
+addopts = "-vs --strict-markers --cov submarine --cov-report term-missing"

--- a/submarine-sdk/pysubmarine/pyproject.toml
+++ b/submarine-sdk/pysubmarine/pyproject.toml
@@ -1,3 +1,0 @@
-[tool.pytest.ini_options]
-markers = ["e2e"]
-addopts = "-vs --strict-markers --cov submarine --cov-report term-missing"

--- a/submarine-sdk/pysubmarine/pytest.ini
+++ b/submarine-sdk/pysubmarine/pytest.ini
@@ -1,3 +1,17 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 [pytest]
 markers =
     e2e

--- a/submarine-sdk/pysubmarine/pytest.ini
+++ b/submarine-sdk/pysubmarine/pytest.ini
@@ -1,17 +1,20 @@
-# Licensed to the Apache Software Foundation (ASF) under one or more
-# contributor license agreements. See the NOTICE file distributed with
-# this work for additional information regarding copyright ownership.
-# The ASF licenses this file to You under the Apache License, Version 2.0
-# (the "License"); you may not use this file except in compliance with
-# the License. You may obtain a copy of the License at
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
 #
-# http://www.apache.org/licenses/LICENSE-2.0
+#   http://www.apache.org/licenses/LICENSE-2.0
 #
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 [pytest]
 markers =
     e2e

--- a/submarine-sdk/pysubmarine/pytest.ini
+++ b/submarine-sdk/pysubmarine/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+markers =
+    e2e
+addopts = -vs --strict-markers --cov submarine --cov-report term-missing

--- a/submarine-sdk/pysubmarine/setup.py
+++ b/submarine-sdk/pysubmarine/setup.py
@@ -33,7 +33,7 @@ setup(
         "sqlalchemy>=1.4.0",
         "sqlparse",
         "pymysql",
-        "requests",
+        "requests>=2.26.0",  # SUBMARINE-922. avoid GPL dependency.
         "urllib3>=1.15.1",
         "certifi>=14.05.14",
         "python-dateutil>=2.5.3",

--- a/submarine-sdk/pysubmarine/tests/artifacts/__init__.py
+++ b/submarine-sdk/pysubmarine/tests/artifacts/__init__.py
@@ -1,0 +1,14 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/submarine-sdk/pysubmarine/tests/artifacts/__init__.py
+++ b/submarine-sdk/pysubmarine/tests/artifacts/__init__.py
@@ -1,14 +1,16 @@
-# Licensed to the Apache Software Foundation (ASF) under one or more
-# contributor license agreements. See the NOTICE file distributed with
-# this work for additional information regarding copyright ownership.
-# The ASF licenses this file to You under the Apache License, Version 2.0
-# (the "License"); you may not use this file except in compliance with
-# the License. You may obtain a copy of the License at
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
 #
-# http://www.apache.org/licenses/LICENSE-2.0
+#   http://www.apache.org/licenses/LICENSE-2.0
 #
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/submarine-sdk/pysubmarine/tests/artifacts/test_repository.py
+++ b/submarine-sdk/pysubmarine/tests/artifacts/test_repository.py
@@ -1,3 +1,17 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 import pathlib
 import shutil
 

--- a/submarine-sdk/pysubmarine/tests/artifacts/test_repository.py
+++ b/submarine-sdk/pysubmarine/tests/artifacts/test_repository.py
@@ -1,17 +1,20 @@
-# Licensed to the Apache Software Foundation (ASF) under one or more
-# contributor license agreements. See the NOTICE file distributed with
-# this work for additional information regarding copyright ownership.
-# The ASF licenses this file to You under the Apache License, Version 2.0
-# (the "License"); you may not use this file except in compliance with
-# the License. You may obtain a copy of the License at
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
 #
-# http://www.apache.org/licenses/LICENSE-2.0
+#   http://www.apache.org/licenses/LICENSE-2.0
 #
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 import pathlib
 import shutil
 

--- a/submarine-sdk/pysubmarine/tests/artifacts/test_repository.py
+++ b/submarine-sdk/pysubmarine/tests/artifacts/test_repository.py
@@ -1,0 +1,80 @@
+import pathlib
+
+import boto3
+from moto import mock_s3
+
+from submarine.artifacts import Repository
+
+
+@mock_s3
+def test_log_artifact():
+    s3 = boto3.resource("s3")
+    s3.create_bucket(Bucket="submarine")
+
+    local_file = pathlib.Path(__file__).parent / "text.txt"
+    with local_file.open("w", encoding="utf-8") as file:
+        file.write("test")
+
+    repo = Repository()
+    dest_path = "folder01/subfolder01"
+    repo.log_artifact(dest_path=dest_path, local_file=str(local_file))
+    local_file.unlink()
+
+    common_prefixes = repo.list_artifact_subfolder("folder01")
+    print(common_prefixes)
+    assert common_prefixes == [{"Prefix": "folder01/subfolder01/"}]
+
+
+@mock_s3
+def test_log_artifacts():
+    s3 = boto3.resource("s3")
+    s3.create_bucket(Bucket="submarine")
+
+    local_dir = pathlib.Path(__file__).parent / "data"
+    local_dir.mkdir(parents=True, exist_ok=True)
+    local_file1 = local_dir / "text1.txt"
+    with local_file1.open("w", encoding="utf-8") as file:
+        file.write("test")
+    local_file2 = local_dir / "text2.txt"
+    with local_file2.open("w", encoding="utf-8") as file:
+        file.write("test")
+
+    repo = Repository()
+    s3_folder_name = repo.log_artifacts(
+        dest_path="folder01/data", local_dir=str(local_dir)
+    )
+
+    for item in local_dir.iterdir():
+        item.unlink()
+    local_dir.rmdir()
+
+    assert s3_folder_name == "s3://submarine/folder01/data"
+
+    common_prefixes = repo.list_artifact_subfolder("folder01")
+    print(common_prefixes)
+    assert common_prefixes == [{"Prefix": "folder01/data/"}]
+
+
+@mock_s3
+def test_delete_folder():
+    s3 = boto3.resource("s3")
+    s3.create_bucket(Bucket="submarine")
+
+    local_file = pathlib.Path(__file__).parent / "text.txt"
+    with local_file.open("w", encoding="utf-8") as file:
+        file.write("test")
+
+    s3.meta.client.upload_file(
+        str(local_file), "submarine", "folder01/subfolder01/text.txt"
+    )
+    s3.meta.client.upload_file(
+        str(local_file), "submarine", "folder01/subfolder02/text.txt"
+    )
+    local_file.unlink()
+
+    repo = Repository()
+    repo.delete_folder("folder01/subfolder01")
+
+    common_prefixes = repo.list_artifact_subfolder("folder01")
+    print(common_prefixes)
+    assert common_prefixes == [{"Prefix": "folder01/subfolder02/"}]

--- a/submarine-sdk/pysubmarine/tests/artifacts/test_repository.py
+++ b/submarine-sdk/pysubmarine/tests/artifacts/test_repository.py
@@ -40,9 +40,7 @@ def test_log_artifacts():
         file.write("test")
 
     repo = Repository()
-    s3_folder_name = repo.log_artifacts(
-        dest_path="folder01/data", local_dir=str(local_dir)
-    )
+    s3_folder_name = repo.log_artifacts(dest_path="folder01/data", local_dir=str(local_dir))
 
     for item in local_dir.iterdir():
         item.unlink()
@@ -64,12 +62,8 @@ def test_delete_folder():
     with local_file.open("w", encoding="utf-8") as file:
         file.write("test")
 
-    s3.meta.client.upload_file(
-        str(local_file), "submarine", "folder01/subfolder01/text.txt"
-    )
-    s3.meta.client.upload_file(
-        str(local_file), "submarine", "folder01/subfolder02/text.txt"
-    )
+    s3.meta.client.upload_file(str(local_file), "submarine", "folder01/subfolder01/text.txt")
+    s3.meta.client.upload_file(str(local_file), "submarine", "folder01/subfolder02/text.txt")
     local_file.unlink()
 
     repo = Repository()

--- a/submarine-sdk/pysubmarine/tests/artifacts/test_repository.py
+++ b/submarine-sdk/pysubmarine/tests/artifacts/test_repository.py
@@ -21,7 +21,6 @@ def test_log_artifact():
     local_file.unlink()
 
     common_prefixes = repo.list_artifact_subfolder("folder01")
-    print(common_prefixes)
     assert common_prefixes == [{"Prefix": "folder01/subfolder01/"}]
 
 
@@ -49,7 +48,6 @@ def test_log_artifacts():
     assert s3_folder_name == "s3://submarine/folder01/data"
 
     common_prefixes = repo.list_artifact_subfolder("folder01")
-    print(common_prefixes)
     assert common_prefixes == [{"Prefix": "folder01/data/"}]
 
 
@@ -70,5 +68,4 @@ def test_delete_folder():
     repo.delete_folder("folder01/subfolder01")
 
     common_prefixes = repo.list_artifact_subfolder("folder01")
-    print(common_prefixes)
     assert common_prefixes == [{"Prefix": "folder01/subfolder02/"}]


### PR DESCRIPTION
### What is this PR for?

We lack tests in the `submodule.artifacts` module. We should add tests and aim for at least 90% test coverage for this module.

**Additionally**, this PR also fix SUBMARINE-922 issue since #994 accidentally modify the code.

### What type of PR is it?

Improvement

### Todos

### What is the Jira issue?

<https://issues.apache.org/jira/browse/SUBMARINE-1329>

### How should this be tested?

```bash
cd submarine-sdk/pysubmarine
python3 -m venv .venv
source .venv/bin/activate
pip install -U pip setuptools wheel
pip install -e .[tf2,pytorch]
pip install -r github-actions/test-requirements.txt
```

```bash
$ pytest -m 'not e2e'

...
---------- coverage: platform linux, python 3.7.14-final-0 -----------
Name                                                        Stmts   Miss  Cover   Missing
-----------------------------------------------------------------------------------------
submarine/__init__.py                                           9      0   100%
submarine/artifacts/__init__.py                                 2      0   100%
submarine/artifacts/repository.py                              30      0   100%
submarine/cli/__init__.py                                       2      0   100%
...
-----------------------------------------------------------------------------------------
TOTAL                                                        4725   2621    45%

============================================================================ 42 passed, 7 skipped, 31 deselected, 10 warnings in 23.88s ============================================================================
```

### Screenshots (if appropriate)

### Questions:
* Do the license files need updating? Yes/No
* Are there breaking changes for older versions? Yes/No
* Does this need new documentation? Yes/No
