### PR TITLE
SUBMARINE-1333. Replace legacy tmpdir with tmp_path

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -78,6 +78,7 @@ jobs:
       - name: List installed packages
         run: pip list
       - name: Run unit test
+        working-directory: ./submarine-sdk/pysubmarine
         run: pytest -m "not e2e"
 
   integration:

--- a/submarine-sdk/pysubmarine/tests/ml/pytorch/model/conftest.py
+++ b/submarine-sdk/pysubmarine/tests/ml/pytorch/model/conftest.py
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-
 import pytest
 
 # noqa
@@ -32,22 +30,22 @@ LIBSVM_DATA = """0 0:0 1:0 2:0 3:0 4:0 5:0 6:0 7:0 8:0 9:0 10:0 11:0 12:0 13:0 1
 
 
 @pytest.fixture
-def get_model_param(tmpdir):
-    data_file = os.path.join(str(tmpdir), "libsvm.txt")
-    save_model_dir = os.path.join(str(tmpdir), "experiment")
-    os.mkdir(save_model_dir)
+def get_model_param(tmp_path):
+    data_file = tmp_path / "libsvm.txt"
+    save_model_dir = tmp_path / "experiment"
+    save_model_dir.mkdir()
 
-    with open(data_file, "wt") as writer:
+    with data_file.open("wt") as writer:
         writer.write(LIBSVM_DATA)
 
     params = {
         "input": {
-            "train_data": data_file,
-            "valid_data": data_file,
-            "test_data": data_file,
+            "train_data": str(data_file),
+            "valid_data": str(data_file),
+            "test_data": str(data_file),
             "type": "libsvm",
         },
-        "output": {"save_model_dir": save_model_dir, "metric": "roc_auc"},
+        "output": {"save_model_dir": str(save_model_dir), "metric": "roc_auc"},
         "training": {
             "batch_size": 4,
             "num_epochs": 1,
@@ -77,4 +75,4 @@ def get_model_param(tmpdir):
     }
 
     yield params
-    os.remove(data_file)
+    data_file.unlink()

--- a/submarine-sdk/pysubmarine/tests/ml/tensorflow/model/conftest.py
+++ b/submarine-sdk/pysubmarine/tests/ml/tensorflow/model/conftest.py
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-
 import pytest
 
 LIBSVM_DATA = """1 1:0 2:0.051495 3:0.5 4:0.1 5:0.113437 6:0.874 7:0.01 8:0.08 9:0.028 10:0
@@ -29,22 +27,22 @@ LIBSVM_DATA = """1 1:0 2:0.051495 3:0.5 4:0.1 5:0.113437 6:0.874 7:0.01 8:0.08 9
 
 
 @pytest.fixture
-def get_model_param(tmpdir):
-    data_file = os.path.join(str(tmpdir), "libsvm.txt")
-    save_model_dir = os.path.join(str(tmpdir), "experiment")
-    with open(data_file, "wt") as writer:
+def get_model_param(tmp_path):
+    data_file = tmp_path / "libsvm.txt"
+    save_model_dir = tmp_path / "experiment"
+    with data_file.open("wt") as writer:
         writer.write(LIBSVM_DATA)
 
     params = {
         "input": {
-            "train_data": data_file,
-            "valid_data": data_file,
-            "test_data": data_file,
+            "train_data": str(data_file),
+            "valid_data": str(data_file),
+            "test_data": str(data_file),
             "type": "libsvm",
         },
-        "output": {"save_model_dir": save_model_dir, "metric": "auc"},
+        "output": {"save_model_dir": str(save_model_dir), "metric": "auc"},
         "training": {"batch_size": 256, "num_epochs": 1, "field_size": 10, "feature_size": 1000},
     }
 
     yield params
-    os.remove(data_file)
+    data_file.unlink()

--- a/submarine-sdk/pysubmarine/tests/ml/tensorflow_v2/model/conftest.py
+++ b/submarine-sdk/pysubmarine/tests/ml/tensorflow_v2/model/conftest.py
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-
 import pytest
 
 LIBSVM_DATA = """1 1:0 2:0.051495 3:0.5 4:0.1 5:0.113437 6:0.874 7:0.01 8:0.08 9:0.028 10:0
@@ -29,22 +27,22 @@ LIBSVM_DATA = """1 1:0 2:0.051495 3:0.5 4:0.1 5:0.113437 6:0.874 7:0.01 8:0.08 9
 
 
 @pytest.fixture
-def get_model_param(tmpdir):
-    data_file = os.path.join(str(tmpdir), "libsvm.txt")
-    save_model_dir = os.path.join(str(tmpdir), "experiment")
-    with open(data_file, "wt") as writer:
+def get_model_param(tmp_path):
+    data_file = tmp_path / "libsvm.txt"
+    save_model_dir = tmp_path / "experiment"
+    with data_file.open("wt") as writer:
         writer.write(LIBSVM_DATA)
 
     params = {
         "input": {
-            "train_data": data_file,
-            "valid_data": data_file,
-            "test_data": data_file,
+            "train_data": str(data_file),
+            "valid_data": str(data_file),
+            "test_data": str(data_file),
             "type": "libsvm",
         },
-        "output": {"save_model_dir": save_model_dir, "metric": "auc"},
+        "output": {"save_model_dir": str(save_model_dir), "metric": "auc"},
         "training": {"batch_size": 256, "num_epochs": 1, "field_size": 10, "feature_size": 1000},
     }
 
     yield params
-    os.remove(data_file)
+    data_file.unlink()


### PR DESCRIPTION
### What is this PR for?
<!-- A few sentences describing the overall goals of the pull request's commits.
First time? Check out the contributing guide - https://submarine.apache.org/contribution/contributions.html
-->

Pytest provides both `tmp_path` and `tmpdir` fixtures to indicate the temporary directory.

Nowadays, it's preferred to use the `tmp_path` fixture which returns a `pathlib.Path` instead of the legacy `tmpdir` which returns `py.path.local`.

### What type of PR is it?

Improvement

### Todos

### What is the Jira issue?
<!-- * Open an issue on Jira https://issues.apache.org/jira/browse/SUBMARINE/
* Put link here, and add [SUBMARINE-*Jira number*] in PR title, eg. `SUBMARINE-23. PR title`
-->

<https://issues.apache.org/jira/browse/SUBMARINE-1333>

### How should this be tested?
<!--
* First time? Setup Travis CI as described on https://submarine.apache.org/contribution/contributions.html#continuous-integration
* Strongly recommended: add automated unit tests for any new or changed behavior
* Outline any manual steps to test the PR here.
-->

This PR modified the following conftest files:

```text
submarine-sdk/pysubmarine/tests/ml/pytorch/model/conftest.py
submarine-sdk/pysubmarine/tests/ml/tensorflow/model/conftest.py
submarine-sdk/pysubmarine/tests/ml/tensorflow_v2/model/conftest.py
```

Then, run pytest on ` tests/ml/` to validate the changes:

```bash
cd submarine-sdk/pysubmarine
python3 -m venv .venv
source .venv/bin/activate
pip install -U pip setuptools wheel
pip install -r github-actions/test-requirements.txt
pip install -e '.[tf2,pytorch]'

pytest tests/ml/
```

### Screenshots (if appropriate)

### Questions:
* Do the license files need updating? No
* Are there breaking changes for older versions? No
* Does this need new documentation? No
