### PR TITLE
SUBMARINE-1334. Optimising notebook asynchronous refresh handling

### DIFF
--- a/submarine-workbench/workbench-web/src/app/pages/workbench/notebook/notebook-home/notebook-form/notebook-form.component.ts
+++ b/submarine-workbench/workbench-web/src/app/pages/workbench/notebook/notebook-home/notebook-form/notebook-form.component.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { Component, OnInit } from '@angular/core';
+import { Component, EventEmitter, OnInit, Output } from '@angular/core';
 import { FormArray, FormControl, FormGroup, Validators, FormBuilder } from '@angular/forms';
 import { ExperimentValidatorService } from '@submarine/services/experiment.validator.service';
 import { EnvironmentService } from '@submarine/services/environment-services/environment.service';
@@ -44,6 +44,9 @@ export class NotebookFormComponent implements OnInit {
   // Form
   notebookForm: FormGroup;
   MEMORY_UNITS = ['M', 'Gi'];
+
+  // refresh notebook list function
+  @Output() private refreshNotebook = new EventEmitter<boolean>();
 
   constructor(
     private fb: FormBuilder,
@@ -212,6 +215,8 @@ export class NotebookFormComponent implements OnInit {
           nzPauseOnHover: true,
         });
         this.isVisible = false;
+        // refresh list after created a new notebook
+        this.refreshNotebook.emit(true);
       },
     });
   }

--- a/submarine-workbench/workbench-web/src/app/pages/workbench/notebook/notebook-home/notebook-home.component.html
+++ b/submarine-workbench/workbench-web/src/app/pages/workbench/notebook/notebook-home/notebook-home.component.html
@@ -34,5 +34,5 @@
     [notebookList]="notebookList"
     (deleteNotebook)="onDeleteNotebook($event)"
   ></submarine-notebook-list>
-  <submarine-notebook-form #form></submarine-notebook-form>
+  <submarine-notebook-form #form (refreshNotebook)="refreshNotebook($event)" ></submarine-notebook-form>
 </div>


### PR DESCRIPTION
### What is this PR for?
Notebook currently does not fetch list information on first load.
Notebook's asynchronous refresh will cancel the confirmation tooltip for the delete button.

### What type of PR is it?
Improvement

### Todos
* [x] - List loaded immediately after page initialisation
* [x] - Adjust the asynchronous refresh logic to update only the changed values

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-1334

### How should this be tested?
No

### Screenshots (if appropriate)

https://user-images.githubusercontent.com/12069428/193764732-8246a266-013c-4b4e-bfe4-755f37525f5e.mov


### Questions:
* Do the license files need updating? No
* Are there breaking changes for older versions? No
* Does this need new documentation? No
