### PR TITLE
SUBMARINE-1335. Fix jira version filter exception

### DIFF
--- a/dev-support/cicd/merge_submarine_pr.py
+++ b/dev-support/cicd/merge_submarine_pr.py
@@ -255,9 +255,9 @@ def resolve_jira_issue(merge_branches, comment, default_jira_id=""):
 
     versions = asf_jira.project_versions("SUBMARINE")
     versions = sorted(versions, key=lambda x: x.name, reverse=True)
-    versions = filter(lambda x: x.raw["released"] is False, versions)
+    versions = list(filter(lambda x: x.raw["released"] is False, versions))
     # Consider only x.y.z versions
-    versions = filter(lambda x: re.match(r"\d+\.\d+\.\d+", x.name), versions)
+    versions = list(filter(lambda x: re.match(r"\d+\.\d+\.\d+", x.name), versions))
 
     default_fix_versions: List = list(
         map(lambda x: fix_version_from_branch(x, list(versions)).name, merge_branches)


### PR DESCRIPTION
### What is this PR for?
The filter that currently handles version information within the merge pr code is not converted to a list, which can lead to errors later in the processing of versions.

### What type of PR is it?
Bug Fix

### Todos
* [x] - Add `list()` to filter

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-1335

### How should this be tested?
No.

### Screenshots (if appropriate)
No.

### Questions:
* Do the license files need updating? No
* Are there breaking changes for older versions? No
* Does this need new documentation? No
