### PR TITLE
SUBMARINE-1349. Fix the syntax error reported in sonarcloud and add init value for apiversion in XGboostjobList.java

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -436,6 +436,7 @@ jobs:
           TEST_MODULES: "-pl :submarine-server-core"
         run: |
           echo ">>> mvn $TEST_FLAG $TEST_MODULES -B"
+          export SUBMARINE_S3_ENDPOINT=http://localhost:9000
           mvn $TEST_FLAG $TEST_MODULES -B
       - name: Build submarine-serve
         env:

--- a/submarine-server/server-core/src/main/java/org/apache/submarine/server/manager/ModelManager.java
+++ b/submarine-server/server-core/src/main/java/org/apache/submarine/server/manager/ModelManager.java
@@ -56,13 +56,12 @@ public class ModelManager {
    *
    * @return object
    */
+  private static class ModelManagerHolder {
+    private static ModelManager manager = new ModelManager(SubmitterManager.loadSubmitter(), ModelVersionService.getInstance());
+  }
+
   public static ModelManager getInstance() {
-    if (manager == null) {
-      synchronized (ModelManager.class) {
-        manager = new ModelManager(SubmitterManager.loadSubmitter(), new ModelVersionService());
-      }
-    }
-    return manager;
+    return ModelManager.ModelManagerHolder.manager;
   }
 
   /**
@@ -141,7 +140,7 @@ public class ModelManager {
   }
 
   private void transferDescription(ServeSpec spec) {
-    Client s3Client = new Client();
+    Client s3Client = Client.getInstance();
     String modelUniquePath = String.format("%s-%d-%s",
         spec.getModelName(), spec.getModelVersion(), spec.getModelId());
     String res  = new String(s3Client.downloadArtifact(String.format("registry/%s/%s/%d/description.json",

--- a/submarine-server/server-core/src/main/java/org/apache/submarine/server/manager/ModelManager.java
+++ b/submarine-server/server-core/src/main/java/org/apache/submarine/server/manager/ModelManager.java
@@ -57,7 +57,8 @@ public class ModelManager {
    * @return object
    */
   private static class ModelManagerHolder {
-    private static ModelManager manager = new ModelManager(SubmitterManager.loadSubmitter(), ModelVersionService.getInstance());
+    private static ModelManager manager = new ModelManager(SubmitterManager.loadSubmitter(),
+                                                            ModelVersionService.getInstance());
   }
 
   public static ModelManager getInstance() {

--- a/submarine-server/server-core/src/main/java/org/apache/submarine/server/manager/ModelVersionManager.java
+++ b/submarine-server/server-core/src/main/java/org/apache/submarine/server/manager/ModelVersionManager.java
@@ -50,12 +50,13 @@ public class ModelVersionManager {
    *
    * @return object
    */
-  public static synchronized ModelVersionManager getInstance() {
-    if (manager == null) {
-      manager = new ModelVersionManager(new ModelVersionService(), new ModelVersionTagService(),
-          new Client());
-    }
-    return manager;
+  private static class ModelVersionManagerHolder {
+    private static ModelVersionManager manager = new ModelVersionManager(ModelVersionService.getInstance(), new ModelVersionTagService(),
+    Client.getInstance());
+  }
+
+  public static ModelVersionManager getInstance() {
+    return ModelVersionManager.ModelVersionManagerHolder.manager;
   }
 
   @VisibleForTesting

--- a/submarine-server/server-core/src/main/java/org/apache/submarine/server/manager/ModelVersionManager.java
+++ b/submarine-server/server-core/src/main/java/org/apache/submarine/server/manager/ModelVersionManager.java
@@ -51,8 +51,9 @@ public class ModelVersionManager {
    * @return object
    */
   private static class ModelVersionManagerHolder {
-    private static ModelVersionManager manager = new ModelVersionManager(ModelVersionService.getInstance(), new ModelVersionTagService(),
-    Client.getInstance());
+    private static ModelVersionManager manager = new ModelVersionManager(ModelVersionService.getInstance(),
+                                                                        new ModelVersionTagService(),
+                                                                        Client.getInstance());
   }
 
   public static ModelVersionManager getInstance() {

--- a/submarine-server/server-core/src/main/java/org/apache/submarine/server/manager/ModelVersionManager.java
+++ b/submarine-server/server-core/src/main/java/org/apache/submarine/server/manager/ModelVersionManager.java
@@ -50,14 +50,10 @@ public class ModelVersionManager {
    *
    * @return object
    */
-  public static ModelVersionManager getInstance() {
+  public static synchronized ModelVersionManager getInstance() {
     if (manager == null) {
-      synchronized (ModelVersionManager.class) {
-        if (manager == null) {
-          manager = new ModelVersionManager(new ModelVersionService(), new ModelVersionTagService(),
-            new Client());
-        }
-      }
+      manager = new ModelVersionManager(new ModelVersionService(), new ModelVersionTagService(),
+          new Client());
     }
     return manager;
   }

--- a/submarine-server/server-core/src/main/java/org/apache/submarine/server/manager/RegisteredModelManager.java
+++ b/submarine-server/server-core/src/main/java/org/apache/submarine/server/manager/RegisteredModelManager.java
@@ -37,7 +37,6 @@ import org.apache.submarine.server.s3.Client;
  * Registered model manager.
  */
 public class RegisteredModelManager {
-  private static RegisteredModelManager manager;
   /* Registered model service */
   private final RegisteredModelService registeredModelService;
 
@@ -54,12 +53,14 @@ public class RegisteredModelManager {
    *
    * @return object
    */
-  public static synchronized RegisteredModelManager getInstance() {
-    if (manager == null) {
-      manager = new RegisteredModelManager(new RegisteredModelService(), new ModelVersionService(),
-          new RegisteredModelTagService(), new Client());
-    }
-    return manager;
+
+  private static class RegisteredModelManagerHolder {
+    private static RegisteredModelManager manager = new RegisteredModelManager(RegisteredModelService.getInstance(), ModelVersionService.getInstance(),
+    RegisteredModelTagService.getInstance(), Client.getInstance());
+  }
+
+  public static RegisteredModelManager getInstance() {
+    return RegisteredModelManager.RegisteredModelManagerHolder.manager;
   }
 
   @VisibleForTesting

--- a/submarine-server/server-core/src/main/java/org/apache/submarine/server/manager/RegisteredModelManager.java
+++ b/submarine-server/server-core/src/main/java/org/apache/submarine/server/manager/RegisteredModelManager.java
@@ -55,7 +55,8 @@ public class RegisteredModelManager {
    */
 
   private static class RegisteredModelManagerHolder {
-    private static RegisteredModelManager manager = new RegisteredModelManager(RegisteredModelService.getInstance(),
+    private static RegisteredModelManager manager = new RegisteredModelManager(
+                                                          RegisteredModelService.getInstance(),
                                                           ModelVersionService.getInstance(),
                                                           RegisteredModelTagService.getInstance(),
                                                           Client.getInstance());

--- a/submarine-server/server-core/src/main/java/org/apache/submarine/server/manager/RegisteredModelManager.java
+++ b/submarine-server/server-core/src/main/java/org/apache/submarine/server/manager/RegisteredModelManager.java
@@ -54,14 +54,10 @@ public class RegisteredModelManager {
    *
    * @return object
    */
-  public static RegisteredModelManager getInstance() {
+  public static synchronized RegisteredModelManager getInstance() {
     if (manager == null) {
-      synchronized (RegisteredModelManager.class) {
-        if (manager == null) {
-          manager = new RegisteredModelManager(new RegisteredModelService(), new ModelVersionService(),
-              new RegisteredModelTagService(), new Client());
-        }
-      }
+      manager = new RegisteredModelManager(new RegisteredModelService(), new ModelVersionService(),
+          new RegisteredModelTagService(), new Client());
     }
     return manager;
   }

--- a/submarine-server/server-core/src/main/java/org/apache/submarine/server/manager/RegisteredModelManager.java
+++ b/submarine-server/server-core/src/main/java/org/apache/submarine/server/manager/RegisteredModelManager.java
@@ -55,8 +55,10 @@ public class RegisteredModelManager {
    */
 
   private static class RegisteredModelManagerHolder {
-    private static RegisteredModelManager manager = new RegisteredModelManager(RegisteredModelService.getInstance(), ModelVersionService.getInstance(),
-    RegisteredModelTagService.getInstance(), Client.getInstance());
+    private static RegisteredModelManager manager = new RegisteredModelManager(RegisteredModelService.getInstance(),
+                                                          ModelVersionService.getInstance(),
+                                                          RegisteredModelTagService.getInstance(),
+                                                          Client.getInstance());
   }
 
   public static RegisteredModelManager getInstance() {

--- a/submarine-server/server-core/src/main/java/org/apache/submarine/server/rest/ExperimentRestApi.java
+++ b/submarine-server/server-core/src/main/java/org/apache/submarine/server/rest/ExperimentRestApi.java
@@ -58,7 +58,7 @@ import org.apache.submarine.server.utils.response.JsonResponse;
 @Produces({MediaType.APPLICATION_JSON + "; " + RestConstants.CHARSET_UTF8})
 public class ExperimentRestApi {
   private ExperimentManager experimentManager = ExperimentManager.getInstance();
-  private final Client minioClient = new Client();
+  private final Client minioClient = Client.getInstance();
 
   @VisibleForTesting
   public void setExperimentManager(ExperimentManager experimentManager) {

--- a/submarine-server/server-core/src/main/java/org/apache/submarine/server/s3/Client.java
+++ b/submarine-server/server-core/src/main/java/org/apache/submarine/server/s3/Client.java
@@ -66,7 +66,7 @@ public enum Client {
     }
   }
 
-  private Client(String endpoint) {
+  Client(String endpoint) {
     this.endpoint = endpoint;
     this.minioClient =  MinioClient.builder()
                         .endpoint(endpoint)
@@ -76,7 +76,7 @@ public enum Client {
                         ).build();
   }
 
-  private Client() {
+  Client() {
     this.endpoint = conf.getString(SubmarineConfVars.ConfVars.SUBMARINE_S3_ENDPOINT);
     this.minioClient =  MinioClient.builder()
                         .endpoint(conf.getString(SubmarineConfVars.ConfVars.SUBMARINE_S3_ENDPOINT))

--- a/submarine-server/server-core/src/main/java/org/apache/submarine/server/s3/Client.java
+++ b/submarine-server/server-core/src/main/java/org/apache/submarine/server/s3/Client.java
@@ -51,12 +51,30 @@ public class Client {
 
   /* minio client */
   public MinioClient minioClient;
+  public static Map<String,Client> clientFactory = new HashMap<String,Client>();
 
-  public Client() {
-    minioClient = MinioClient.builder()
-            .endpoint(S3Constants.ENDPOINT)
-            .credentials(S3Constants.ACCESSKEY, S3Constants.SECRETKEY)
-            .build();
+  public static Client getClient(String endpoint) {
+    Client client = clientFactory.get(endpoint);
+    Map<String,Client> clientLocalFactory = clientFactory;
+
+    if (client == null) {
+      synchronized(Client.class) {
+        if (client == null) {
+          client = new Client(endpoint);
+          clientLocalFactory.put(endpoint, client);
+          clientFactory = clientLocalFactory;
+        }
+      }
+    }
+    return client;
+  }
+
+  public static Client getInstance() {
+    return getClient(S3Constants.ENDPOINT);
+  }
+
+  public static Client getInstance(String endpoint) {
+    return getClient(endpoint);
   }
 
   private Client(String endpoint) {

--- a/submarine-server/server-core/src/main/java/org/apache/submarine/server/s3/Client.java
+++ b/submarine-server/server-core/src/main/java/org/apache/submarine/server/s3/Client.java
@@ -48,18 +48,16 @@ import org.apache.submarine.commons.utils.exception.SubmarineRuntimeException;
  * S3(Minio) default client
  */
 public enum Client {
-  DEFAULT(SubmarineConfVars.ConfVars.SUBMARINE_S3_ENDPOINT), CUSTOMER("http://localhost:9000");
+  /* submarine config */
+  private static final SubmarineConfiguration conf = SubmarineConfiguration.getInstance();
 
   /* minio client */
   private final MinioClient minioClient;
 
-  /* submarine config */
-  private static final SubmarineConfiguration conf = SubmarineConfiguration.getInstance();
-
   public static Map<String, Client> clientFactory = new HashMap<String, Client>();
   private final String endpoint;
 
-
+  DEFAULT(conf.getString(SubmarineConfVars.ConfVars.SUBMARINE_S3_ENDPOINT)), CUSTOMER("http://localhost:9000");
 
   static {
     for (Client clientSingleton : Client.values()) {
@@ -67,7 +65,7 @@ public enum Client {
     }
   }
 
-  Client(String endpoint) {
+  private Client(String endpoint) {
     this.endpoint = endpoint;
     this.minioClient =  MinioClient.builder()
                         .endpoint(endpoint)
@@ -77,8 +75,18 @@ public enum Client {
                         ).build();
   }
 
+  private Client() {
+    this.endpoint = conf.getString(SubmarineConfVars.ConfVars.SUBMARINE_S3_ENDPOINT);
+    this.minioClient =  MinioClient.builder()
+                        .endpoint(conf.getString(SubmarineConfVars.ConfVars.SUBMARINE_S3_ENDPOINT))
+                        .credentials(
+                            conf.getString(SubmarineConfVars.ConfVars.SUBMARINE_S3_ACCESS_KEY_ID),
+                            conf.getString(SubmarineConfVars.ConfVars.SUBMARINE_S3_SECRET_ACCESS_KEY)
+                        ).build();
+  }
+
   public static Client getInstance() {
-    return clientFactory.get(SubmarineConfVars.ConfVars.SUBMARINE_S3_ENDPOINT);
+    return clientFactory.get(SubmarineConfVars.ConfVars.SUBMARINE_S3_ENDPOINT.varValue);
   }
 
   public static Client getInstance(String endpoint) {

--- a/submarine-server/server-core/src/main/java/org/apache/submarine/server/s3/Client.java
+++ b/submarine-server/server-core/src/main/java/org/apache/submarine/server/s3/Client.java
@@ -87,7 +87,8 @@ public enum Client {
   }
 
   public static Client getInstance() {
-    return clientFactory.get(SubmarineConfVars.ConfVars.SUBMARINE_S3_ENDPOINT.varValue);
+    return clientFactory.get(SubmarineConfiguration.getInstance()
+                        .getString(SubmarineConfVars.ConfVars.SUBMARINE_S3_ENDPOINT));
   }
 
   public static Client getInstance(String endpoint) {

--- a/submarine-server/server-core/src/main/java/org/apache/submarine/server/s3/Client.java
+++ b/submarine-server/server-core/src/main/java/org/apache/submarine/server/s3/Client.java
@@ -51,14 +51,14 @@ public class Client {
 
   /* minio client */
   public MinioClient minioClient;
-  public static Map<String,Client> clientFactory = new HashMap<String,Client>();
+  public static Map<String, Client> clientFactory = new HashMap<String, Client>();
 
   public static Client getClient(String endpoint) {
     Client client = clientFactory.get(endpoint);
-    Map<String,Client> clientLocalFactory = clientFactory;
+    Map<String, Client> clientLocalFactory = clientFactory;
 
     if (client == null) {
-      synchronized(Client.class) {
+      synchronized (Client.class) {
         if (client == null) {
           client = new Client(endpoint);
           clientLocalFactory.put(endpoint, client);

--- a/submarine-server/server-core/src/main/java/org/apache/submarine/server/s3/Client.java
+++ b/submarine-server/server-core/src/main/java/org/apache/submarine/server/s3/Client.java
@@ -26,8 +26,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Stack;
 import javax.ws.rs.core.Response;
-import java.util.Map;
-import java.util.HashMap;
 
 import io.minio.CopyObjectArgs;
 import io.minio.CopySource;
@@ -48,8 +46,7 @@ import org.apache.submarine.commons.utils.exception.SubmarineRuntimeException;
  * S3(Minio) default client
  */
 public enum Client {
-  DEFAULT(SubmarineConfiguration.getInstance().getString(SubmarineConfVars.ConfVars.SUBMARINE_S3_ENDPOINT)),
-  CUSTOMER("http://localhost:9000");
+  INSTANCE(SubmarineConfiguration.getInstance().getString(SubmarineConfVars.ConfVars.SUBMARINE_S3_ENDPOINT));
 
   /* submarine config */
   private final SubmarineConfiguration conf = SubmarineConfiguration.getInstance();
@@ -57,17 +54,7 @@ public enum Client {
   /* minio client */
   private final MinioClient minioClient;
 
-  public static Map<String, Client> clientFactory = new HashMap<String, Client>();
-  private final String endpoint;
-
-  static {
-    for (Client clientSingleton : Client.values()) {
-      clientFactory.put(clientSingleton.endpoint, clientSingleton);
-    }
-  }
-
   Client(String endpoint) {
-    this.endpoint = endpoint;
     this.minioClient =  MinioClient.builder()
                         .endpoint(endpoint)
                         .credentials(
@@ -76,28 +63,8 @@ public enum Client {
                         ).build();
   }
 
-  Client() {
-    this.endpoint = conf.getString(SubmarineConfVars.ConfVars.SUBMARINE_S3_ENDPOINT);
-    this.minioClient =  MinioClient.builder()
-                        .endpoint(conf.getString(SubmarineConfVars.ConfVars.SUBMARINE_S3_ENDPOINT))
-                        .credentials(
-                            conf.getString(SubmarineConfVars.ConfVars.SUBMARINE_S3_ACCESS_KEY_ID),
-                            conf.getString(SubmarineConfVars.ConfVars.SUBMARINE_S3_SECRET_ACCESS_KEY)
-                        ).build();
-  }
-
   public static Client getInstance() {
-    return clientFactory.get(SubmarineConfiguration.getInstance()
-                        .getString(SubmarineConfVars.ConfVars.SUBMARINE_S3_ENDPOINT));
-  }
-
-  public static Client getInstance(String endpoint) {
-    try {
-      return clientFactory.get(endpoint);
-    } catch (Exception e) {
-      throw new SubmarineRuntimeException(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(),
-          e.getMessage());
-    }
+    return INSTANCE;
   }
 
   /**

--- a/submarine-server/server-core/src/main/java/org/apache/submarine/server/s3/Client.java
+++ b/submarine-server/server-core/src/main/java/org/apache/submarine/server/s3/Client.java
@@ -52,7 +52,7 @@ public enum Client {
   CUSTOMER("http://localhost:9000");
 
   /* submarine config */
-  private static final SubmarineConfiguration conf = SubmarineConfiguration.getInstance();
+  private final SubmarineConfiguration conf = SubmarineConfiguration.getInstance();
 
   /* minio client */
   private final MinioClient minioClient;

--- a/submarine-server/server-core/src/main/java/org/apache/submarine/server/s3/Client.java
+++ b/submarine-server/server-core/src/main/java/org/apache/submarine/server/s3/Client.java
@@ -48,6 +48,9 @@ import org.apache.submarine.commons.utils.exception.SubmarineRuntimeException;
  * S3(Minio) default client
  */
 public enum Client {
+  DEFAULT(SubmarineConfiguration.getInstance().getString(SubmarineConfVars.ConfVars.SUBMARINE_S3_ENDPOINT)),
+  CUSTOMER("http://localhost:9000");
+
   /* submarine config */
   private static final SubmarineConfiguration conf = SubmarineConfiguration.getInstance();
 
@@ -56,8 +59,6 @@ public enum Client {
 
   public static Map<String, Client> clientFactory = new HashMap<String, Client>();
   private final String endpoint;
-
-  DEFAULT(conf.getString(SubmarineConfVars.ConfVars.SUBMARINE_S3_ENDPOINT)), CUSTOMER("http://localhost:9000");
 
   static {
     for (Client clientSingleton : Client.values()) {

--- a/submarine-server/server-core/src/main/java/org/apache/submarine/server/s3/Client.java
+++ b/submarine-server/server-core/src/main/java/org/apache/submarine/server/s3/Client.java
@@ -26,6 +26,8 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Stack;
 import javax.ws.rs.core.Response;
+import java.util.Map;
+import java.util.HashMap;
 
 import io.minio.CopyObjectArgs;
 import io.minio.CopySource;
@@ -50,25 +52,18 @@ public class Client {
   /* minio client */
   public MinioClient minioClient;
 
-  /* submarine config */
-  private static final SubmarineConfiguration conf = SubmarineConfiguration.getInstance();
-
   public Client() {
     minioClient = MinioClient.builder()
-        .endpoint(conf.getString(SubmarineConfVars.ConfVars.SUBMARINE_S3_ENDPOINT))
-        .credentials(
-            conf.getString(SubmarineConfVars.ConfVars.SUBMARINE_S3_ACCESS_KEY_ID),
-            conf.getString(SubmarineConfVars.ConfVars.SUBMARINE_S3_SECRET_ACCESS_KEY)
-        ).build();
+            .endpoint(S3Constants.ENDPOINT)
+            .credentials(S3Constants.ACCESSKEY, S3Constants.SECRETKEY)
+            .build();
   }
 
-  public Client(String endpoint) {
+  private Client(String endpoint) {
     minioClient = MinioClient.builder()
         .endpoint(endpoint)
-        .credentials(
-            conf.getString(SubmarineConfVars.ConfVars.SUBMARINE_S3_ACCESS_KEY_ID),
-            conf.getString(SubmarineConfVars.ConfVars.SUBMARINE_S3_SECRET_ACCESS_KEY)
-        ).build();
+        .credentials(S3Constants.ACCESSKEY, S3Constants.SECRETKEY)
+        .build();
   }
 
   /**

--- a/submarine-server/server-core/src/main/java/org/apache/submarine/server/s3/Client.java
+++ b/submarine-server/server-core/src/main/java/org/apache/submarine/server/s3/Client.java
@@ -44,13 +44,21 @@ import org.apache.submarine.commons.utils.SubmarineConfVars;
 import org.apache.submarine.commons.utils.SubmarineConfiguration;
 import org.apache.submarine.commons.utils.exception.SubmarineRuntimeException;
 
-
+/**
+ * S3(Minio) default client
+ */
 public enum Client {
-  DEFAULT(S3Constants.ENDPOINT), CUSTOMER("http://localhost:9000");
+  DEFAULT(SubmarineConfVars.ConfVars.SUBMARINE_S3_ENDPOINT), CUSTOMER("http://localhost:9000");
+
+  /* minio client */
+  private final MinioClient minioClient;
+
+  /* submarine config */
+  private static final SubmarineConfiguration conf = SubmarineConfiguration.getInstance();
 
   public static Map<String, Client> clientFactory = new HashMap<String, Client>();
   private final String endpoint;
-  private final MinioClient minioClient;
+
 
 
   static {
@@ -61,14 +69,16 @@ public enum Client {
 
   Client(String endpoint) {
     this.endpoint = endpoint;
-    this.minioClient = MinioClient.builder()
-    .endpoint(endpoint)
-    .credentials(S3Constants.ACCESSKEY, S3Constants.SECRETKEY)
-    .build();
+    this.minioClient =  MinioClient.builder()
+                        .endpoint(endpoint)
+                        .credentials(
+                          conf.getString(SubmarineConfVars.ConfVars.SUBMARINE_S3_ACCESS_KEY_ID),
+                          conf.getString(SubmarineConfVars.ConfVars.SUBMARINE_S3_SECRET_ACCESS_KEY)
+                        ).build();
   }
 
   public static Client getInstance() {
-    return clientFactory.get(S3Constants.ENDPOINT);
+    return clientFactory.get(SubmarineConfVars.ConfVars.SUBMARINE_S3_ENDPOINT);
   }
 
   public static Client getInstance(String endpoint) {

--- a/submarine-server/server-core/src/test/java/org/apache/submarine/server/rest/ModelVersionRestApiTest.java
+++ b/submarine-server/server-core/src/test/java/org/apache/submarine/server/rest/ModelVersionRestApiTest.java
@@ -55,9 +55,9 @@ public class ModelVersionRestApiTest {
   private final String modelVersionModelType = "experiment_123";
   private final String modelVersionTag = "testTag";
 
-  private final RegisteredModelService registeredModelService = new RegisteredModelService();
+  private final RegisteredModelService registeredModelService = RegisteredModelService.getInstance();
 
-  private final ModelVersionService modelVersionService = new ModelVersionService();
+  private final ModelVersionService modelVersionService = ModelVersionService.getInstance();
 
   private static final GsonBuilder gsonBuilder = new GsonBuilder()
       .registerTypeAdapter(ExperimentId.class, new ExperimentIdSerializer())

--- a/submarine-server/server-core/src/test/java/org/apache/submarine/server/rest/RegisteredModelRestApiTest.java
+++ b/submarine-server/server-core/src/test/java/org/apache/submarine/server/rest/RegisteredModelRestApiTest.java
@@ -39,7 +39,7 @@ import org.apache.submarine.server.utils.gson.ExperimentIdDeserializer;
 import org.apache.submarine.server.utils.gson.ExperimentIdSerializer;
 
 public class RegisteredModelRestApiTest {
-  private final RegisteredModelService registeredModelService = new RegisteredModelService();
+  private final RegisteredModelService registeredModelService = RegisteredModelService.getInstance();
   private final String registeredModelName = "testRegisteredModel";
   private final String newRegisteredModelName = "newTestRegisteredModel";
   private final String registeredModelDescription = "test registered model description";

--- a/submarine-server/server-core/src/test/java/org/apache/submarine/server/s3/ClientTest.java
+++ b/submarine-server/server-core/src/test/java/org/apache/submarine/server/s3/ClientTest.java
@@ -54,41 +54,41 @@ public class ClientTest {
     Assert.assertArrayEquals(content, response);
   }
 
- @Test
- public void testListAndDeleteArtifactByExperimentId() {
-   byte[] content = "0123456789".getBytes();
+  @Test
+  public void testListAndDeleteArtifactByExperimentId() {
+    byte[] content = "0123456789".getBytes();
 
-   String[] artifactPaths = {
-       String.format("experiment/%s/1", testExperimentId),
-       String.format("experiment/%s/2", testExperimentId)
-   };
-   String[] actualResults = {
-       String.format("s3://%s/experiment/%s/1", S3Constants.BUCKET, testExperimentId),
-       String.format("s3://%s/experiment/%s/2", S3Constants.BUCKET, testExperimentId)
-   };
-   client.logArtifact(artifactPaths[0], content);
-   client.logArtifact(artifactPaths[1], content);
-   List<String> results = client.listArtifact(String.format("experiment/%s", testExperimentId));
-   Assert.assertArrayEquals(actualResults, results.toArray());
+    String[] artifactPaths = {
+        String.format("experiment/%s/1", testExperimentId),
+        String.format("experiment/%s/2", testExperimentId)
+    };
+    String[] actualResults = {
+        String.format("s3://%s/experiment/%s/1", S3Constants.BUCKET, testExperimentId),
+        String.format("s3://%s/experiment/%s/2", S3Constants.BUCKET, testExperimentId)
+    };
+    client.logArtifact(artifactPaths[0], content);
+    client.logArtifact(artifactPaths[1], content);
+    List<String> results = client.listArtifact(String.format("experiment/%s", testExperimentId));
+    Assert.assertArrayEquals(actualResults, results.toArray());
 
-   client.deleteArtifactsByExperiment(testExperimentId);
-   results = client.listArtifact(testExperimentId);
-   Assert.assertArrayEquals(new String[0], results.toArray());
- }
+    client.deleteArtifactsByExperiment(testExperimentId);
+    results = client.listArtifact(testExperimentId);
+    Assert.assertArrayEquals(new String[0], results.toArray());
+  }
 
- @Test
- public void testCopyObject() {
-   String path = "sample_folder/sample_file";
-   byte[] content = "0123456789".getBytes();
-   client.logArtifact(path, content);
-   byte[] response = client.downloadArtifact(path);
-   Assert.assertArrayEquals(content, response);
+  @Test
+  public void testCopyObject() {
+    String path = "sample_folder/sample_file";
+    byte[] content = "0123456789".getBytes();
+    client.logArtifact(path, content);
+    byte[] response = client.downloadArtifact(path);
+    Assert.assertArrayEquals(content, response);
 
-   String copyPath = "sample_folder_copy/sample_file";
-   client.copyArtifact(copyPath, path);
-   response = client.downloadArtifact(copyPath);
-   Assert.assertArrayEquals(content, response);
- }
+    String copyPath = "sample_folder_copy/sample_file";
+    client.copyArtifact(copyPath, path);
+    response = client.downloadArtifact(copyPath);
+    Assert.assertArrayEquals(content, response);
+  }
 
   @Test
   public void testSingleton() {

--- a/submarine-server/server-core/src/test/java/org/apache/submarine/server/s3/ClientTest.java
+++ b/submarine-server/server-core/src/test/java/org/apache/submarine/server/s3/ClientTest.java
@@ -27,7 +27,7 @@ import java.util.List;
 
 
 public class ClientTest {
-  private final Client client = Client.getInstance("http://localhost:9000");
+  private final Client client = Client.getInstance();
   private final String testExperimentId = "experiment-sample";
 
   @After
@@ -78,5 +78,11 @@ public class ClientTest {
     client.copyArtifact(copyPath, path);
     response = client.downloadArtifact(copyPath);
     Assert.assertArrayEquals(content, response);
+  }
+
+  @Test
+  public void testSingleton() {
+    Client testClient = Client.getInstance();
+    Assert.assertEquals(testClient, client);
   }
 }

--- a/submarine-server/server-core/src/test/java/org/apache/submarine/server/s3/ClientTest.java
+++ b/submarine-server/server-core/src/test/java/org/apache/submarine/server/s3/ClientTest.java
@@ -19,9 +19,13 @@
 
 package org.apache.submarine.server.s3;
 
+import org.apache.submarine.commons.utils.SubmarineConfVars;
+import org.apache.submarine.commons.utils.SubmarineConfiguration;
+
+import org.junit.BeforeClass;
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Test;
+import org.junit.Assert;
 
 import java.util.List;
 
@@ -35,6 +39,12 @@ public class ClientTest {
     client.deleteAllArtifacts();
   }
 
+  @BeforeClass
+  public static void init() {
+    SubmarineConfiguration conf = SubmarineConfiguration.getInstance();
+    conf.setString(SubmarineConfVars.ConfVars.SUBMARINE_S3_ENDPOINT, "http://localhost:8000");
+  }
+
   @Test
   public void testLogArtifactAndDownloadArtifact() {
     String path = "sample_folder/sample_file";
@@ -44,41 +54,41 @@ public class ClientTest {
     Assert.assertArrayEquals(content, response);
   }
 
-  @Test
-  public void testListAndDeleteArtifactByExperimentId() {
-    byte[] content = "0123456789".getBytes();
+ @Test
+ public void testListAndDeleteArtifactByExperimentId() {
+   byte[] content = "0123456789".getBytes();
 
-    String[] artifactPaths = {
-        String.format("experiment/%s/1", testExperimentId),
-        String.format("experiment/%s/2", testExperimentId)
-    };
-    String[] actualResults = {
-        String.format("s3://%s/experiment/%s/1", S3Constants.BUCKET, testExperimentId),
-        String.format("s3://%s/experiment/%s/2", S3Constants.BUCKET, testExperimentId)
-    };
-    client.logArtifact(artifactPaths[0], content);
-    client.logArtifact(artifactPaths[1], content);
-    List<String> results = client.listArtifact(String.format("experiment/%s", testExperimentId));
-    Assert.assertArrayEquals(actualResults, results.toArray());
+   String[] artifactPaths = {
+       String.format("experiment/%s/1", testExperimentId),
+       String.format("experiment/%s/2", testExperimentId)
+   };
+   String[] actualResults = {
+       String.format("s3://%s/experiment/%s/1", S3Constants.BUCKET, testExperimentId),
+       String.format("s3://%s/experiment/%s/2", S3Constants.BUCKET, testExperimentId)
+   };
+   client.logArtifact(artifactPaths[0], content);
+   client.logArtifact(artifactPaths[1], content);
+   List<String> results = client.listArtifact(String.format("experiment/%s", testExperimentId));
+   Assert.assertArrayEquals(actualResults, results.toArray());
 
-    client.deleteArtifactsByExperiment(testExperimentId);
-    results = client.listArtifact(testExperimentId);
-    Assert.assertArrayEquals(new String[0], results.toArray());
-  }
+   client.deleteArtifactsByExperiment(testExperimentId);
+   results = client.listArtifact(testExperimentId);
+   Assert.assertArrayEquals(new String[0], results.toArray());
+ }
 
-  @Test
-  public void testCopyObject() {
-    String path = "sample_folder/sample_file";
-    byte[] content = "0123456789".getBytes();
-    client.logArtifact(path, content);
-    byte[] response = client.downloadArtifact(path);
-    Assert.assertArrayEquals(content, response);
+ @Test
+ public void testCopyObject() {
+   String path = "sample_folder/sample_file";
+   byte[] content = "0123456789".getBytes();
+   client.logArtifact(path, content);
+   byte[] response = client.downloadArtifact(path);
+   Assert.assertArrayEquals(content, response);
 
-    String copyPath = "sample_folder_copy/sample_file";
-    client.copyArtifact(copyPath, path);
-    response = client.downloadArtifact(copyPath);
-    Assert.assertArrayEquals(content, response);
-  }
+   String copyPath = "sample_folder_copy/sample_file";
+   client.copyArtifact(copyPath, path);
+   response = client.downloadArtifact(copyPath);
+   Assert.assertArrayEquals(content, response);
+ }
 
   @Test
   public void testSingleton() {

--- a/submarine-server/server-core/src/test/java/org/apache/submarine/server/s3/ClientTest.java
+++ b/submarine-server/server-core/src/test/java/org/apache/submarine/server/s3/ClientTest.java
@@ -31,7 +31,7 @@ import java.util.List;
 
 
 public class ClientTest {
-  private final Client client = Client.getInstance();
+  private static Client client;
   private final String testExperimentId = "experiment-sample";
 
   @After
@@ -42,7 +42,8 @@ public class ClientTest {
   @BeforeClass
   public static void init() {
     SubmarineConfiguration conf = SubmarineConfiguration.getInstance();
-    conf.setString(SubmarineConfVars.ConfVars.SUBMARINE_S3_ENDPOINT, "http://localhost:8000");
+    conf.setString(SubmarineConfVars.ConfVars.SUBMARINE_S3_ENDPOINT, "http://localhost:9000");
+    client = Client.getInstance();
   }
 
   @Test

--- a/submarine-server/server-core/src/test/java/org/apache/submarine/server/s3/ClientTest.java
+++ b/submarine-server/server-core/src/test/java/org/apache/submarine/server/s3/ClientTest.java
@@ -27,7 +27,7 @@ import java.util.List;
 
 
 public class ClientTest {
-  private final Client client = new Client("http://localhost:9000");
+  private final Client client = Client.getInstance("http://localhost:9000");
   private final String testExperimentId = "experiment-sample";
 
   @After

--- a/submarine-server/server-database/src/main/java/org/apache/submarine/server/database/model/service/ModelVersionService.java
+++ b/submarine-server/server-database/src/main/java/org/apache/submarine/server/database/model/service/ModelVersionService.java
@@ -30,6 +30,13 @@ import org.slf4j.LoggerFactory;
 import java.util.List;
 
 public class ModelVersionService {
+  private static class ModelVersionServiceHolder {
+    private static ModelVersionService service = new ModelVersionService();
+  }
+
+  public static ModelVersionService getInstance() {
+    return ModelVersionService.ModelVersionServiceHolder.service;
+  }
 
   private static final Logger LOG = LoggerFactory.getLogger(ModelVersionService.class);
 

--- a/submarine-server/server-database/src/main/java/org/apache/submarine/server/database/model/service/RegisteredModelService.java
+++ b/submarine-server/server-database/src/main/java/org/apache/submarine/server/database/model/service/RegisteredModelService.java
@@ -31,6 +31,14 @@ import java.util.List;
 
 public class RegisteredModelService {
 
+  private static class RegisteredModelServiceHolder {
+    private static RegisteredModelService service = new RegisteredModelService();
+  }
+
+  public static RegisteredModelService getInstance() {
+    return RegisteredModelService.RegisteredModelServiceHolder.service;
+  }
+
   private static final Logger LOG = LoggerFactory.getLogger(RegisteredModelService.class);
 
   public List<RegisteredModelEntity> selectAll() throws SubmarineRuntimeException {

--- a/submarine-server/server-database/src/main/java/org/apache/submarine/server/database/model/service/RegisteredModelTagService.java
+++ b/submarine-server/server-database/src/main/java/org/apache/submarine/server/database/model/service/RegisteredModelTagService.java
@@ -28,6 +28,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class RegisteredModelTagService {
+  private static class RegisteredModelTagServiceHolder {
+    private static RegisteredModelTagService service = new RegisteredModelTagService();
+  }
+
+  public static RegisteredModelTagService getInstance() {
+    return RegisteredModelTagService.RegisteredModelTagServiceHolder.service;
+  }
 
   private static final Logger LOG = LoggerFactory.getLogger(RegisteredModelTagService.class);
 

--- a/submarine-server/server-database/src/test/java/org/apache/submarine/server/database/model/ModelVersionTagTest.java
+++ b/submarine-server/server-database/src/test/java/org/apache/submarine/server/database/model/ModelVersionTagTest.java
@@ -33,8 +33,8 @@ import org.slf4j.LoggerFactory;
 
 public class ModelVersionTagTest {
   private static final Logger LOG = LoggerFactory.getLogger(ModelVersionTagTest.class);
-  RegisteredModelService registeredModelService = new RegisteredModelService();
-  ModelVersionService modelVersionService = new ModelVersionService();
+  RegisteredModelService registeredModelService = RegisteredModelService.getInstance();
+  ModelVersionService modelVersionService = ModelVersionService.getInstance();
   ModelVersionTagService modelVersionTagService = new ModelVersionTagService();
 
 

--- a/submarine-server/server-database/src/test/java/org/apache/submarine/server/database/model/ModelVersionTest.java
+++ b/submarine-server/server-database/src/test/java/org/apache/submarine/server/database/model/ModelVersionTest.java
@@ -31,8 +31,8 @@ import org.apache.submarine.server.database.model.service.ModelVersionService;
 import org.apache.submarine.server.database.model.service.RegisteredModelService;
 
 public class ModelVersionTest {
-  RegisteredModelService registeredModelService = new RegisteredModelService();
-  ModelVersionService modelVersionService = new ModelVersionService();
+  RegisteredModelService registeredModelService = RegisteredModelService.getInstance();
+  ModelVersionService modelVersionService = ModelVersionService.getInstance();
 
   @After
   public void cleanAll() {

--- a/submarine-server/server-database/src/test/java/org/apache/submarine/server/database/model/RegisteredModelServiceTest.java
+++ b/submarine-server/server-database/src/test/java/org/apache/submarine/server/database/model/RegisteredModelServiceTest.java
@@ -29,7 +29,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class RegisteredModelServiceTest {
-  RegisteredModelService registeredModelService = new RegisteredModelService();
+  RegisteredModelService registeredModelService = RegisteredModelService.getInstance();
 
   @After
   public void cleanAll() {

--- a/submarine-server/server-database/src/test/java/org/apache/submarine/server/database/model/RegisteredModelTagServiceTest.java
+++ b/submarine-server/server-database/src/test/java/org/apache/submarine/server/database/model/RegisteredModelTagServiceTest.java
@@ -31,8 +31,8 @@ import org.slf4j.LoggerFactory;
 
 public class RegisteredModelTagServiceTest {
   private static final Logger LOG = LoggerFactory.getLogger(RegisteredModelTagServiceTest.class);
-  RegisteredModelService registeredModelService = new RegisteredModelService();
-  RegisteredModelTagService registeredModelTagService = new RegisteredModelTagService();
+  RegisteredModelService registeredModelService = RegisteredModelService.getInstance();
+  RegisteredModelTagService registeredModelTagService = RegisteredModelTagService.getInstance();
 
   @After
   public void cleanAll() {

--- a/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/model/xgboostjob/XGBoostJobList.java
+++ b/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/model/xgboostjob/XGBoostJobList.java
@@ -30,7 +30,7 @@ public class XGBoostJobList implements KubernetesListObject {
   private String apiVersion = XGBoostJob.CRD_XGBOOST_API_VERSION_V1;
 
   @SerializedName("kind")
-  private String kind;
+  private String kind = XGBoostJob.CRD_XGBOOST_KIND_V1 + "List";
 
   @SerializedName("metadata")
   private V1ListMeta metadata;
@@ -55,6 +55,6 @@ public class XGBoostJobList implements KubernetesListObject {
 
   @Override
   public String getKind() {
-    return XGBoostJob.CRD_XGBOOST_KIND_V1 + "List";
+    return kind;
   }
 }

--- a/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/model/xgboostjob/XGBoostJobList.java
+++ b/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/model/xgboostjob/XGBoostJobList.java
@@ -27,7 +27,7 @@ import io.kubernetes.client.openapi.models.V1ListMeta;
 
 public class XGBoostJobList implements KubernetesListObject {
   @SerializedName("apiVersion")
-  private String apiVersion;
+  private String apiVersion = XGBoostJob.CRD_XGBOOST_API_VERSION_V1;
 
   @SerializedName("kind")
   private String kind;


### PR DESCRIPTION
### What is this PR for?

1. Fix the syntax error reported in sonarcloud
2. Add init value for apiversion in XGboostjobList.java
3. change the following class to a singleton, [ModelVersionService.java](https://github.com/apache/submarine/pull/1020/files#diff-0b498de1dff04b42428e969cc3e0fb1376b75b9f33db4ae8d9740c7e1a2e43be), [RegisteredModelService.java](https://github.com/apache/submarine/pull/1020/files#diff-5894fdc7eea50e5065c43846308e16847562089db57b207ea23ceef86c639668),[RegisteredModelTagService.java](https://github.com/apache/submarine/pull/1020/files#diff-56494d2d82488701eb8e3738e8ff3835a27e7f5add8c9d3421ee35e4e2b09661), and the managers used thems.

### What type of PR is it?
Bug Fix

### Todos
* [ ] - Task

### What is the Jira issue?
[SUBMARINE-1349](https://issues.apache.org/jira/browse/SUBMARINE-1349)
### How should this be tested?
<!--
* First time? Setup Travis CI as described on https://submarine.apache.org/contribution/contributions.html#continuous-integration
* Strongly recommended: add automated unit tests for any new or changed behavior
* Outline any manual steps to test the PR here.
-->
### Screenshots (if appropriate)

### Questions:
* Do the license files need updating? No
* Are there breaking changes for older versions? No
* Does this need new documentation? No
