### PR TITLE
SUBMARINE-1355. Remove seldon graph storage initializerimage dependence

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -465,6 +465,12 @@ jobs:
           path: |
             ./submarine-server/server-core/target/jacoco.exec
           key: ${{ runner.os }}-docker-${{ github.sha }}
+      - name: Cache serve jacoco.exec
+        uses: actions/cache@v2
+        with:
+          path: |
+            ./submarine-serve/target/jacoco.exec
+          key: ${{ runner.os }}-docker-${{ github.sha }}
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
         with:
@@ -503,6 +509,18 @@ jobs:
       - name: Test submarine-server-core
         env:
           TEST_MODULES: "-pl :submarine-server-core"
+        run: |
+          echo ">>> mvn $TEST_FLAG $TEST_MODULES -B"
+          mvn $TEST_FLAG $TEST_MODULES -B
+      - name: Build submarine-serve
+        env:
+          MODULES: "-pl :submarine-serve"
+        run: |
+          echo ">>> mvn $BUILD_FLAG $MODULES -B"
+          mvn $BUILD_FLAG $MODULES -B
+      - name: Test submarine-serve
+        env:
+          TEST_MODULES: "-pl :submarine-serve"
         run: |
           echo ">>> mvn $TEST_FLAG $TEST_MODULES -B"
           mvn $TEST_FLAG $TEST_MODULES -B
@@ -710,6 +728,12 @@ jobs:
         with:
           path: |
             ./submarine-server/server-core/target/jacoco.exec
+          key: ${{ runner.os }}-docker-${{ github.sha }}
+      - name: Cache submarine-serve data
+        uses: actions/cache@v2
+        with:
+          path: |
+            ./submarine-serve/target/jacoco.exec
           key: ${{ runner.os }}-docker-${{ github.sha }}
       - name: Cache submarine-submitter data
         uses: actions/cache@v2

--- a/submarine-serve/src/main/java/org/apache/submarine/serve/seldon/PredictorAnnotations.java
+++ b/submarine-serve/src/main/java/org/apache/submarine/serve/seldon/PredictorAnnotations.java
@@ -37,11 +37,20 @@ public class PredictorAnnotations {
   private String serviceName;
 
   /**
+   * To avoid the problem of the model initializer not being able to access S3(Minio) in the initcontainer
+   * due to the use of istio, a traffic `excludeOutboundPorts` has been added here.
+   * Reference link: Compatibility with application init containers,
+   * https://istio.io/latest/docs/setup/additional-setup/cni/#compatibility-with-application-init-containers
+   */
+  @SerializedName("traffic.sidecar.istio.io/excludeOutboundPorts")
+  @JsonProperty("traffic.sidecar.istio.io/excludeOutboundPorts")
+  private String excludeOutboundPorts = "9000";
+
+  /**
    * Get predictor annotations with custom service name
    */
   public static PredictorAnnotations service(String serviceName) {
-    return new PredictorAnnotations()
-            .setServiceName(serviceName);
+    return new PredictorAnnotations().setServiceName(serviceName);
   }
 
   public String getServiceName() {
@@ -51,5 +60,13 @@ public class PredictorAnnotations {
   public PredictorAnnotations setServiceName(String serviceName) {
     this.serviceName = serviceName;
     return this;
+  }
+
+  public void setExcludeOutboundPorts(String excludeOutboundPorts) {
+    this.excludeOutboundPorts = excludeOutboundPorts;
+  }
+
+  public String getExcludeOutboundPorts() {
+    return excludeOutboundPorts;
   }
 }

--- a/submarine-serve/src/main/java/org/apache/submarine/serve/seldon/SeldonGraph.java
+++ b/submarine-serve/src/main/java/org/apache/submarine/serve/seldon/SeldonGraph.java
@@ -21,15 +21,40 @@ package org.apache.submarine.serve.seldon;
 import com.google.gson.annotations.SerializedName;
 import org.apache.submarine.serve.utils.SeldonConstants;
 
+/**
+ * Seldon graph
+ * <p>
+ * Define the graph of every predictor in `spec.predictors[*].graph`, for more we can see:
+ * <a href="https://docs.seldon.io/projects/seldon-core/en/latest/graph/inference-graph.html">
+ *   Inference Graph
+ * </a>
+ */
 public class SeldonGraph {
+
+  /**
+   * Graph name, we generally order by version, e.g.
+   * version-1, version-2, version-3 ...
+   */
   @SerializedName("name")
   private String name;
+
+  /**
+   * Graph implementation, can be:
+   * TENSORFLOW_SERVER, TRITON_SERVER or XGBOOST_SERVER
+   */
   @SerializedName("implementation")
   private String implementation;
+
+  /**
+   * Model storage path on S3(minio), e.g.
+   * s3://submarine/registry/${model_version_path}/${model_name}
+   */
   @SerializedName("modelUri")
   private String modelUri;
-  @SerializedName("storageInitializerImage")
-  private String storageInitializerImage = SeldonConstants.STORAGE_INITIALIZER_IMAGE;
+
+  /**
+   * S3(minio) secret, We have created `Secret` resource by default when creating the submarine
+   */
   @SerializedName("envSecretRefName")
   private String envSecretRefName = SeldonConstants.ENV_SECRET_REF_NAME;
 
@@ -58,14 +83,6 @@ public class SeldonGraph {
 
   public void setModelUri(String modelUri) {
     this.modelUri = modelUri;
-  }
-
-  public String getStorageInitializerImage() {
-    return storageInitializerImage;
-  }
-
-  public void setStorageInitializerImage(String storageInitializerImage) {
-    this.storageInitializerImage = storageInitializerImage;
   }
 
   public String getEnvSecretRefName() {

--- a/submarine-serve/src/main/java/org/apache/submarine/serve/utils/SeldonConstants.java
+++ b/submarine-serve/src/main/java/org/apache/submarine/serve/utils/SeldonConstants.java
@@ -29,8 +29,6 @@ public class SeldonConstants {
 
   public static final String PLURAL = "seldondeployments";
 
-  public static final String STORAGE_INITIALIZER_IMAGE = "seldonio/rclone-storage-initializer:1.10.0";
-
   public static final String ENV_SECRET_REF_NAME = "submarine-serve-secret";
 
   public static final String SELDON_PROTOCOL = "seldon";

--- a/submarine-serve/src/test/java/org/apache/submarine/serve/seldon/SeldonDeploymentTest.java
+++ b/submarine-serve/src/test/java/org/apache/submarine/serve/seldon/SeldonDeploymentTest.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.submarine.serve.seldon;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class SeldonDeploymentTest {
+
+  private static final Gson gson = new Gson();
+
+  @Test
+  public void testPredictorAnnotations() {
+    PredictorAnnotations annotations = PredictorAnnotations
+            .service("submarine-model-1-c9d95a3881b941148b0e2a6362605c00");
+    JsonObject json = gson.toJsonTree(annotations).getAsJsonObject();
+    Assert.assertEquals(json.size(), 2);
+    Assert.assertEquals(
+            json.get("seldon.io/svc-name").getAsString(),
+            "submarine-model-1-c9d95a3881b941148b0e2a6362605c00"
+    );
+    Assert.assertEquals(
+            json.get("traffic.sidecar.istio.io/excludeOutboundPorts").getAsString(),
+            "9000"
+    );
+  }
+
+}


### PR DESCRIPTION
### What is this PR for?
The installation of seldon-core by helm will specify the storageInitializer image and version by default, so we do not need to hard code this.

### What type of PR is it?
Improvement

### Todos
* [x] - Remove seldonio rclone-storage-initializer image hard code
* [x] - Add serve test case to codecov 

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-1355

### How should this be tested?
NA

### Screenshots (if appropriate)
NA

### Questions:
* Do the license files need updating? No
* Are there breaking changes for older versions? No
* Does this need new documentation? No
