### PR TITLE
SUBMARINE-1354. Fix submarine-server timezone display and calculation error

### DIFF
--- a/conf/submarine-site.xml
+++ b/conf/submarine-site.xml
@@ -113,7 +113,7 @@
   </property>
   <property>
     <name>jdbc.url</name>
-    <value>jdbc:mysql://127.0.0.1:3306/submarine?useUnicode=true&amp;characterEncoding=UTF-8&amp;autoReconnect=true&amp;failOverReadOnly=false&amp;zeroDateTimeBehavior=convertToNull&amp;useSSL=false&amp;allowMultiQueries=true</value>
+    <value>jdbc:mysql://127.0.0.1:3306/submarine?useUnicode=true&amp;characterEncoding=UTF-8&amp;autoReconnect=true&amp;failOverReadOnly=false&amp;zeroDateTimeBehavior=convertToNull&amp;useSSL=false&amp;allowMultiQueries=true&amp;serverTimezone=UTC&amp;useTimezone=true&amp;useLegacyDatetimeCode=true</value>
   </property>
   <property>
     <name>jdbc.username</name>

--- a/dev-support/docker-images/submarine/Dockerfile
+++ b/dev-support/docker-images/submarine/Dockerfile
@@ -23,10 +23,7 @@ MAINTAINER Apache Software Foundation <dev@submarine.apache.org>
 
 # INSTALL openjdk
 RUN apk update && \
-    apk add --no-cache openjdk8 tzdata bash tini&& \
-    cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && \
-    echo Asia/Shanghai > /etc/timezone && \
-    apk del tzdata && \
+    apk add --no-cache openjdk8 bash tini && \
     rm -rf /tmp/* /var/cache/apk/*
 
 ENV JAVA_HOME /usr/lib/jvm/java-1.8-openjdk/jre


### PR DESCRIPTION
### What is this PR for?
The default JDBC configuration of the docker image based on submarine-site.xml is wrong, resulting in time zone problems when performing duration calculations in experiment (e.g. 8 hours more in East 8)

### What type of PR is it?
Bug Fix

### Todos
* [x] - Add timezone params in JDBC url in submarine-site.xml
* [x] - Remove timezone in dockerfile 

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-1354

### How should this be tested?
NA

### Screenshots (if appropriate)

### Questions:
* Do the license files need updating? No
* Are there breaking changes for older versions? No
* Does this need new documentation? No
