### PR TITLE
SUBMARINE-1357. Fix Ubuntu 22 can not support kind(1.18) in github workflow error

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -31,7 +31,7 @@ jobs:
     steps:
       - id: set-matrix
         run: |
-          echo "::set-output name=matrix::[\"v1.19.16\", \"v1.20.15\", \"v1.21.14\", \"v1.22.15\"]"
+          echo "::set-output name=matrix::[\"v1.19.16\", \"v1.20.15\", \"v1.21.14\", \"v1.22.17\", \"v1.23.14\"]"
   submarine-operator-verify-codegen:
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -27,10 +27,11 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
+    # Version updates for k8s can be found at https://kubernetes.io/releases/patch-releases/
     steps:
       - id: set-matrix
         run: |
-          echo "::set-output name=matrix::[\"v1.18.20\", \"v1.19.16\", \"v1.20.15\", \"v1.21.14\"]"
+          echo "::set-output name=matrix::[\"v1.19.16\", \"v1.20.15\", \"v1.21.14\", \"v1.22.15\"]"
   submarine-operator-verify-codegen:
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -31,7 +31,7 @@ jobs:
     steps:
       - id: set-matrix
         run: |
-          echo "::set-output name=matrix::[\"v1.19.16\", \"v1.20.15\", \"v1.21.14\", \"v1.22.17\", \"v1.23.14\"]"
+          echo "::set-output name=matrix::[\"v1.19.16\", \"v1.20.15\", \"v1.21.14\"]"
   submarine-operator-verify-codegen:
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/website/docs/devDocs/Dependencies.md
+++ b/website/docs/devDocs/Dependencies.md
@@ -22,28 +22,23 @@ under the License.
 * These are the dependencies currently used by Apache Submarine.
 
 ## Kubernetes
-| Kubernetes Version   | Support?  |
-| ------------- |:-------------:|
-| 1.14.x (or earlier) | X |
-| 1.15.x - 1.21.x | √ |
-| 1.22.x (or later) | X |
+| Kubernetes Version  | Support?  |
+|---------------------|:-------------:|
+| 1.18.x (or earlier) | X |
+| 1.19.x - 1.21.x     | √ |
+| 1.22.x (or later)   | X |
 
 ## KinD
-| KinD Version   | Support?  |
-| ------------- |:-------------:|
+| KinD Version       | Support?  |
+|--------------------|:-------------:|
 | 0.5.x (or earlier) | X |
-| 0.6.x | √ |
-| 0.7.x | √ |
-| 0.8.x | √ |
-| 0.9.x | √ |
-| 0.10.x | √ |
-| 0.11.x | √ |
+| 0.6.x - 0.17.x     | √ |
 
 ## Java
 | JDK Version   | Support?  |
 | ------------- |:-------------:|
 | 8 | √ |
-| 11 | X |
+| 11 | √ |
 | 17 | X |
 
 ## Maven
@@ -59,11 +54,12 @@ under the License.
 * 14 (or later)
 
 ## Go
-| Go Version   | Support?  |
-| ------------- |:-------------:|
-| 1.15 | X |
-| 1.16 | √ |
-| 1.17 (or later) | To be verified |
+| Go Version      | Support?  |
+|-----------------|:-------------:|
+| 1.15            | X |
+| 1.16            | √ |
+| 1.17            | √ |
+| 1.18 (or later) | To be verified |
 
 ## Python
 


### PR DESCRIPTION
### What is this PR for?
The latest version of ubuntu in github action has recently been updated from 20.0.4 to 22.0.4 (https://github.blog/changelog/2022-12-01-github-actions-larger-runners-using-ubuntu-latest-label-will-now-use-ubuntu-22-04/), which has prevented the creation of the Kind 1.18 cluster in the recent PR commit.
We would remove support for 1.18 as we will be upgrading the supported version of k8s in the future.

### What type of PR is it?
Bug Fix

### Todos
* [x] - Remove 1.18

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-1357

### How should this be tested?
Github action

### Screenshots (if appropriate)
NA

### Questions:
* Do the license files need updating? /No
* Are there breaking changes for older versions? No
* Does this need new documentation? Yes
