### PR TITLE
SUBMARINE-1358. fix the potential timeout issue while building jupyter image

### DIFF
--- a/dev-support/docker-images/jupyter-gpu/Dockerfile
+++ b/dev-support/docker-images/jupyter-gpu/Dockerfile
@@ -118,7 +118,7 @@ RUN git clone --depth=1 https://github.com/apache/submarine && \
     rm submarine -rf
 
 # Add qlib example in notebook
-RUN wget https://raw.githubusercontent.com/microsoft/qlib/main/examples/workflow_by_code.ipynb -P $HOME
+RUN wget https://raw.githubusercontent.com/microsoft/qlib/v0.9.0/examples/workflow_by_code.ipynb -P $HOME
 
 
 EXPOSE $NB_PORT

--- a/dev-support/docker-images/jupyter-gpu/Dockerfile
+++ b/dev-support/docker-images/jupyter-gpu/Dockerfile
@@ -93,8 +93,8 @@ RUN wget --quiet https://repo.continuum.io/miniconda/Miniconda3-py37_${MINICONDA
     if [ ! $PYTHON_VERSION = 'default' ]; then conda install --freeze-installed --yes python=$PYTHON_VERSION; fi && \
     conda list python | grep '^python ' | tr -s ' ' | cut -d '.' -f 1,2 | sed 's/$/.*/' >> $CONDA_DIR/conda-meta/pinned && \
     # nodejs is used for jupyter lab build
-    conda install --freeze-installed -c conda-forge nodejs==14.20.1 jupyterlab jupyterlab-git && \
-    pip install cvxpy && \
+    conda install --freeze-installed -c conda-forge nodejs==14.20.1 jupyterlab==3.5.2 jupyterlab-git==0.41.0 && \
+    pip install cvxpy==1.2.2 && \
     jupyter lab build && \
     # remove node_modules
     rm -rf /home/$NB_USER/.cache/yarn && \
@@ -105,7 +105,7 @@ RUN wget --quiet https://repo.continuum.io/miniconda/Miniconda3-py37_${MINICONDA
     conda clean -a -y
 
 # Install latest stable qlib
-RUN pip --no-cache-dir install pyqlib
+RUN pip --no-cache-dir install pyqlib==0.8.6
 
 # Install latest sumbarine python sdk and notebook
 RUN git clone --depth=1 https://github.com/apache/submarine && \

--- a/dev-support/docker-images/jupyter-gpu/Dockerfile
+++ b/dev-support/docker-images/jupyter-gpu/Dockerfile
@@ -93,7 +93,8 @@ RUN wget --quiet https://repo.continuum.io/miniconda/Miniconda3-py37_${MINICONDA
     if [ ! $PYTHON_VERSION = 'default' ]; then conda install --freeze-installed --yes python=$PYTHON_VERSION; fi && \
     conda list python | grep '^python ' | tr -s ' ' | cut -d '.' -f 1,2 | sed 's/$/.*/' >> $CONDA_DIR/conda-meta/pinned && \
     # nodejs is used for jupyter lab build
-    conda install --freeze-installed -c conda-forge nodejs jupyterlab jupyterlab-git cvxpy==1.0.21 && \
+    conda install --freeze-installed -c conda-forge nodejs==14.20.1 jupyterlab jupyterlab-git && \
+    pip install cvxpy && \
     jupyter lab build && \
     # remove node_modules
     rm -rf /home/$NB_USER/.cache/yarn && \
@@ -104,7 +105,7 @@ RUN wget --quiet https://repo.continuum.io/miniconda/Miniconda3-py37_${MINICONDA
     conda clean -a -y
 
 # Install latest stable qlib
-RUN pip --no-cache-dir install pyqlib==0.6.2
+RUN pip --no-cache-dir install pyqlib
 
 # Install latest sumbarine python sdk and notebook
 RUN git clone --depth=1 https://github.com/apache/submarine && \

--- a/dev-support/docker-images/jupyter-gpu/Dockerfile
+++ b/dev-support/docker-images/jupyter-gpu/Dockerfile
@@ -118,7 +118,7 @@ RUN git clone --depth=1 https://github.com/apache/submarine && \
     rm submarine -rf
 
 # Add qlib example in notebook
-RUN wget https://raw.githubusercontent.com/microsoft/qlib/v0.9.0/examples/workflow_by_code.ipynb -P $HOME
+RUN wget https://raw.githubusercontent.com/microsoft/qlib/v0.8.6/examples/workflow_by_code.ipynb -P $HOME
 
 
 EXPOSE $NB_PORT

--- a/dev-support/docker-images/jupyter/Dockerfile
+++ b/dev-support/docker-images/jupyter/Dockerfile
@@ -95,8 +95,8 @@ RUN wget --quiet https://repo.continuum.io/miniconda/Miniconda3-py37_${MINICONDA
     conda init bash && \
     source ~/.bashrc && conda activate && \
     # it is used for jupyter lab build
-    conda install --freeze-installed -c conda-forge nodejs==14.20.1 jupyterlab jupyterlab-git && \
-    pip install cvxpy && \
+    conda install --freeze-installed -c conda-forge nodejs==14.20.1 jupyterlab==3.5.2 jupyterlab-git==0.41.0 && \
+    pip install cvxpy==1.2.2 && \
     jupyter lab build && \
     # remove node_modules
     rm -rf /home/$NB_USER/.cache/yarn && \
@@ -106,7 +106,7 @@ RUN wget --quiet https://repo.continuum.io/miniconda/Miniconda3-py37_${MINICONDA
     # clear conda to remove index cache, lock files, unused cache packages, and tarballs in /opt/conda/pkgs
     conda clean -a -y
 
-RUN pip --no-cache-dir install pyqlib
+RUN pip --no-cache-dir install pyqlib==0.8.6
 
 # Install latest sumbarine python sdk and notebook
 RUN git clone --depth=1 https://github.com/apache/submarine && \

--- a/dev-support/docker-images/jupyter/Dockerfile
+++ b/dev-support/docker-images/jupyter/Dockerfile
@@ -95,7 +95,8 @@ RUN wget --quiet https://repo.continuum.io/miniconda/Miniconda3-py37_${MINICONDA
     conda init bash && \
     source ~/.bashrc && conda activate && \
     # it is used for jupyter lab build
-    conda install --freeze-installed -c conda-forge nodejs jupyterlab jupyterlab-git cvxpy==1.0.21 && \
+    conda install --freeze-installed -c conda-forge nodejs==14.20.1 jupyterlab jupyterlab-git && \
+    pip install cvxpy && \
     jupyter lab build && \
     # remove node_modules
     rm -rf /home/$NB_USER/.cache/yarn && \
@@ -105,7 +106,7 @@ RUN wget --quiet https://repo.continuum.io/miniconda/Miniconda3-py37_${MINICONDA
     # clear conda to remove index cache, lock files, unused cache packages, and tarballs in /opt/conda/pkgs
     conda clean -a -y
 
-RUN pip --no-cache-dir install pyqlib==0.6.2
+RUN pip --no-cache-dir install pyqlib
 
 # Install latest sumbarine python sdk and notebook
 RUN git clone --depth=1 https://github.com/apache/submarine && \

--- a/dev-support/docker-images/jupyter/Dockerfile
+++ b/dev-support/docker-images/jupyter/Dockerfile
@@ -118,7 +118,7 @@ RUN git clone --depth=1 https://github.com/apache/submarine && \
     rm submarine -rf
 
 # Add qlib example in notebook
-RUN wget https://raw.githubusercontent.com/microsoft/qlib/main/examples/workflow_by_code.ipynb -P $HOME
+RUN wget https://raw.githubusercontent.com/microsoft/qlib/v0.9.0/examples/workflow_by_code.ipynb -P $HOME
 
 ENV MLFLOW_S3_ENDPOINT_URL http://submarine-minio-service:9000
 ENV AWS_ACCESS_KEY_ID submarine_minio

--- a/dev-support/docker-images/jupyter/Dockerfile
+++ b/dev-support/docker-images/jupyter/Dockerfile
@@ -118,7 +118,7 @@ RUN git clone --depth=1 https://github.com/apache/submarine && \
     rm submarine -rf
 
 # Add qlib example in notebook
-RUN wget https://raw.githubusercontent.com/microsoft/qlib/v0.9.0/examples/workflow_by_code.ipynb -P $HOME
+RUN wget https://raw.githubusercontent.com/microsoft/qlib/v0.8.6/examples/workflow_by_code.ipynb -P $HOME
 
 ENV MLFLOW_S3_ENDPOINT_URL http://submarine-minio-service:9000
 ENV AWS_ACCESS_KEY_ID submarine_minio


### PR DESCRIPTION
### What is this PR for?
The github action hit the timeout exception while building the image of jupyter and jupyter-gpu time to time  since the previous days. After couple testing, I found it indeed takes infinite time to install CVXPY with conda. Per the discussion on weekly meeting, I change the way to install CVXPY from conda to pip, and it also bring s some side-effect here like the some dependent package is too old and cause "use_2to3 is invalid" error, so some of the package had also been upgraded as well in this PR.

### What type of PR is it?
Improvement

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-1358?
### How should this be tested?
I build and deploy the image in my local environment and looks like everything is worked.
### Screenshots (if appropriate)

### Questions:
* Do the license files need updating?No
* Are there breaking changes for older versions?No
* Does this need new documentation? No
