### PR TITLE
SUBMARINE-1366. SQLAlchemy 2.0 upgrade causes compilation failure of pysubmarine

### DIFF
--- a/dev-support/style-check/python/mypy-requirements.txt
+++ b/dev-support/style-check/python/mypy-requirements.txt
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 mypy
-sqlalchemy[mypy]
+sqlalchemy[mypy]<2.0.0
 types-certifi
 types-python-dateutil
 types-PyYAML

--- a/submarine-sdk/pysubmarine/setup.py
+++ b/submarine-sdk/pysubmarine/setup.py
@@ -30,7 +30,7 @@ setup(
     install_requires=[
         "numpy",
         "pandas",
-        "sqlalchemy>=1.4.0",
+        "sqlalchemy>=1.4.0, <2.0.0",
         "sqlparse",
         "pymysql",
         "requests>=2.26.0",  # SUBMARINE-922. avoid GPL dependency.


### PR DESCRIPTION
### What is this PR for?
After SQLAlchemy was upgraded to 2.0 some of the syntax was changed, which would cause syntax errors in the pysbumarine. We need to consider whether to keep the version at 1.4.x for now, or update the code and re-test it in light of the syntax issue. 
https://docs.sqlalchemy.org/en/20/changelog/migration_20.html
Action run with exceptions:
https://github.com/apache/submarine/actions/runs/4096688603/jobs/7064519374

### What type of PR is it?
Bug Fix

### Todos
* [x] - Keep SQLAlchemy in 1.4.x

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-1366

### How should this be tested?
cicd

### Screenshots (if appropriate)
No

### Questions:
* Do the license files need updating? Yes
* Are there breaking changes for older versions? Yes
* Does this need new documentation? No
