### PR TITLE
SUBMARINE-1367. Fix submarine-sdk build in Dockerfile

### DIFF
--- a/dev-support/docker-images/jupyter-gpu/Dockerfile
+++ b/dev-support/docker-images/jupyter-gpu/Dockerfile
@@ -111,6 +111,7 @@ RUN pip --no-cache-dir install pyqlib==0.8.6
 RUN git clone --depth=1 https://github.com/apache/submarine && \
     # replace numpy==1.19.2 to numpy>=1.20.0
     sed -i "s/numpy==1.19.2/numpy>=1.20.0/" submarine/submarine-sdk/pysubmarine/setup.py && \
+    pip --no-cache-dir install setuptools==65.7.0 && \
     pip --no-cache-dir install -e submarine/submarine-sdk/pysubmarine[tf,pytorch] && \
     # Add DeepFM example into notebook
     cp submarine/submarine-sdk/pysubmarine/example/submarine_experiment_sdk.ipynb $HOME && \

--- a/dev-support/docker-images/jupyter/Dockerfile
+++ b/dev-support/docker-images/jupyter/Dockerfile
@@ -112,6 +112,7 @@ RUN pip --no-cache-dir install pyqlib==0.8.6
 RUN git clone --depth=1 https://github.com/apache/submarine && \
     # replace numpy==1.19.2 to numpy>=1.20.0
     sed -i "s/numpy==1.19.2/numpy>=1.20.0/" submarine/submarine-sdk/pysubmarine/setup.py && \
+    pip --no-cache-dir install setuptools==65.7.0 && \
     pip --no-cache-dir install submarine/submarine-sdk/pysubmarine[tf,pytorch] && \
     cp submarine/submarine-sdk/pysubmarine/example/submarine_experiment_sdk.ipynb $HOME && \
     cp -r submarine/submarine-sdk/pysubmarine/example/{data,deepfm_example.ipynb,deepfm.json} $HOME && \


### PR DESCRIPTION
### What is this PR for?
According to issue https://issues.apache.org/jira/browse/SUBMARINE-1365
We have fixed some of the problems in the cicd process, but the docker image still build with exceptions.

### What type of PR is it?
Bug Fix

### Todos
* [x] - restrict setuptools to 65.7.0

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-1367

### How should this be tested?
NA

### Screenshots (if appropriate)
NA

### Questions:
* Do the license files need updating? No
* Are there breaking changes for older versions? No
* Does this need new documentation? No
