### PR TITLE
SUBMARINE-1368. Fix SysUserRestApiTest editUserTest test error

### DIFF
--- a/submarine-server/server-core/src/test/java/org/apache/submarine/server/rest/workbench/SysUserRestApiTest.java
+++ b/submarine-server/server-core/src/test/java/org/apache/submarine/server/rest/workbench/SysUserRestApiTest.java
@@ -68,9 +68,13 @@ public class SysUserRestApiTest extends CommonDataTest {
     CommonDataTest.assertUserResponseSuccess(response);
 
     List<SysUserEntity> userList = userService.queryPageList("", null, null, null, null, 0, 10);
+    LOG.info("Get Users {}", userList);
     assertTrue(userList.size() > 0);
+    SysUserEntity checkUser = userList.stream()
+        .filter(user -> user.getId().equals(CommonDataTest.userId))
+        .findFirst()
+        .orElse(null);
 
-    SysUserEntity checkUser = userList.get(0);
     assertEquals(sysUser.getUserName(), checkUser.getUserName());
     assertEquals(sysUser.getRealName(), checkUser.getRealName());
     assertEquals(sysUser.getStatus(), checkUser.getStatus());


### PR DESCRIPTION
### What is this PR for?
There is an exception in the method of obtaining users in SysUserRestApiTest class. If the size of users is greater than 1, the actual test users may not be obtained.
We need to add a filter condition.

### What type of PR is it?
Bug Fix

### Todos
* [x] - Fixed user get list error

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-1368

### How should this be tested?
This test case can be used to verify this problem

### Screenshots (if appropriate)
NA

### Questions:
* Do the license files need updating? No
* Are there breaking changes for older versions? No
* Does this need new documentation? No
