### PR TITLE
SUBMARINE-1371. fix unsafe deserialization via SnakeYaml in YamlEntityProvider

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -206,10 +206,13 @@
 This project bundles some components that are also licensed under the Apache
 License Version 2.0:
 cglib:cglib:2.2.2
-com.fasterxml.jackson.core:jackson-annotations:2.13.4
-com.fasterxml.jackson.core:jackson-databind:2.13.4
-com.fasterxml.jackson.core:jackson-core:2.13.4
-com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.13.4
+com.fasterxml.jackson.core:jackson-annotations:2.14.1
+com.fasterxml.jackson.core:jackson-databind:2.14.1
+com.fasterxml.jackson.core:jackson-core:2.14.1
+com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.10.1
+com.fasterxml.jackson.datatype:jackson-datatype-joda:2.14.1
+com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.10.1
+com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.12.2
 com.fasterxml.woodstox:woodstox-core:5.0.3
 com.github.stephenc.jcip:jcip-annotations:1.0-1
 com.google.code.findbugs:jsr305:3.0.0

--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -301,7 +301,7 @@ org.mortbay.jetty:jetty:6.1.26
 org.mybatis:mybatis:3.2.8
 org.xerial.snappy:snappy-java:1.0.5
 org.xerial.snappy:snappy-java:1.1.1.3
-org.yaml:snakeyaml:1.16
+org.yaml:snakeyaml:1.33
 xerces:xercesImpl:2.9.1
 xml-apis:xml-apis:1.3.04
 

--- a/pom.xml
+++ b/pom.xml
@@ -74,10 +74,10 @@
     <pagehelper.version>5.1.10</pagehelper.version>
 
     <gson.version>2.8.9</gson.version>
-    <jackson-databind.version>2.13.4</jackson-databind.version>
-    <jackson-annotations.version>2.13.4</jackson-annotations.version>
-    <jackson-core.version>2.13.4</jackson-core.version>
-    <jackson-module-jaxb-annotations.version>2.13.4</jackson-module-jaxb-annotations.version>
+    <jackson-databind.version>2.14.1</jackson-databind.version>
+    <jackson-annotations.version>2.14.1</jackson-annotations.version>
+    <jackson-core.version>2.14.1</jackson-core.version>
+    <jackson-module-jaxb-annotations.version>2.14.1</jackson-module-jaxb-annotations.version>
     <commons-configuration.version>1.10</commons-configuration.version>
     <commons-httpclient.version>3.1</commons-httpclient.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@
     <log4j.version>1.2.17</log4j.version>
     <commons.logging.version>1.1.3</commons.logging.version>
     <commons.cli.version>1.2</commons.cli.version>
-    <snakeyaml.version>1.32</snakeyaml.version>
+    <snakeyaml.version>1.33</snakeyaml.version>
     <httpcore.version>4.4.4</httpcore.version>
     <httpclient.version>4.5.2</httpclient.version>
     <commons-lang.version>2.6</commons-lang.version>

--- a/submarine-server/server-core/pom.xml
+++ b/submarine-server/server-core/pom.xml
@@ -293,6 +293,11 @@
       <artifactId>jackson-core</artifactId>
       <version>${jackson-core.version}</version>
     </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-joda</artifactId>
+      <version>${jackson-databind.version}</version>
+    </dependency>
 
     <dependency>
       <groupId>com.google.code.gson</groupId>
@@ -391,7 +396,7 @@
     <dependency>
       <groupId>com.github.wnameless.json</groupId>
       <artifactId>json-flattener</artifactId>
-      <version>0.9.0</version>
+      <version>0.16.1</version>
       <exclusions>
         <exclusion>
           <groupId>org.apache.commons</groupId>

--- a/submarine-server/server-core/src/main/java/org/apache/submarine/server/rest/provider/YamlEntityProvider.java
+++ b/submarine-server/server-core/src/main/java/org/apache/submarine/server/rest/provider/YamlEntityProvider.java
@@ -19,7 +19,9 @@
 
 package org.apache.submarine.server.rest.provider;
 
+import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.SafeConstructor;
 
 import javax.ws.rs.Consumes;
 import javax.ws.rs.Produces;
@@ -35,6 +37,7 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
 import java.util.Scanner;
 
 @Provider
@@ -54,14 +57,15 @@ public class YamlEntityProvider<T> implements MessageBodyWriter<T>, MessageBodyR
       MediaType mediaType,
       MultivaluedMap<String, String> httpHeaders, InputStream entityStream)
       throws WebApplicationException {
-    Yaml yaml = new Yaml();
+    Yaml yaml = new Yaml(new SafeConstructor(new LoaderOptions()));
     T t = yaml.loadAs(toString(entityStream), type);
     return t;
   }
 
   public static String toString(InputStream inputStream) {
-    return new Scanner(inputStream, "UTF-8")
-        .useDelimiter("\\A").next();
+    try (Scanner scanner = new Scanner(inputStream, StandardCharsets.UTF_8)) {
+      return scanner.useDelimiter("\\A").next();
+    }
   }
 
   @Override
@@ -83,9 +87,9 @@ public class YamlEntityProvider<T> implements MessageBodyWriter<T>, MessageBodyR
       Annotation[] annotations,
       MediaType mediaType, MultivaluedMap<String, Object> httpHeaders,
       OutputStream entityStream) throws IOException, WebApplicationException {
-    Yaml yaml = new Yaml();
-    OutputStreamWriter writer = new OutputStreamWriter(entityStream);
-    yaml.dump(t, writer);
-    writer.close();
+    Yaml yaml = new Yaml(new SafeConstructor(new LoaderOptions()));
+    try (OutputStreamWriter writer = new OutputStreamWriter(entityStream)) {
+      yaml.dump(t, writer);
+    }
   }
 }

--- a/submarine-server/server-core/src/main/java/org/apache/submarine/server/rest/provider/YamlEntityProvider.java
+++ b/submarine-server/server-core/src/main/java/org/apache/submarine/server/rest/provider/YamlEntityProvider.java
@@ -19,9 +19,7 @@
 
 package org.apache.submarine.server.rest.provider;
 
-import org.yaml.snakeyaml.LoaderOptions;
-import org.yaml.snakeyaml.Yaml;
-import org.yaml.snakeyaml.constructor.SafeConstructor;
+import org.apache.submarine.server.utils.YamlUtils;
 
 import javax.ws.rs.Consumes;
 import javax.ws.rs.Produces;
@@ -57,8 +55,7 @@ public class YamlEntityProvider<T> implements MessageBodyWriter<T>, MessageBodyR
       MediaType mediaType,
       MultivaluedMap<String, String> httpHeaders, InputStream entityStream)
       throws WebApplicationException {
-    Yaml yaml = new Yaml(new SafeConstructor(new LoaderOptions()));
-    T t = yaml.loadAs(toString(entityStream), type);
+    T t = YamlUtils.readValue(toString(entityStream), type);
     return t;
   }
 
@@ -87,9 +84,8 @@ public class YamlEntityProvider<T> implements MessageBodyWriter<T>, MessageBodyR
       Annotation[] annotations,
       MediaType mediaType, MultivaluedMap<String, Object> httpHeaders,
       OutputStream entityStream) throws IOException, WebApplicationException {
-    Yaml yaml = new Yaml(new SafeConstructor(new LoaderOptions()));
     try (OutputStreamWriter writer = new OutputStreamWriter(entityStream)) {
-      yaml.dump(t, writer);
+      YamlUtils.writeValue(writer, t);
     }
   }
 }

--- a/submarine-server/server-core/src/main/java/org/apache/submarine/server/utils/YamlUtils.java
+++ b/submarine-server/server-core/src/main/java/org/apache/submarine/server/utils/YamlUtils.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.apache.submarine.server.submitter.k8s.util;
+package org.apache.submarine.server.utils;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -29,9 +29,13 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 import com.fasterxml.jackson.datatype.joda.JodaModule;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
+import java.io.IOException;
+import java.io.Writer;
+
 /**
  * Support the conversion of objects to yaml format,
- * so that the resource information can be displayed on the log in a more k8s declarative and readable manner
+ * so that the resource information can be displayed on the log in a more k8s declarative and readable manner,
+ * or used for {@link org.apache.submarine.server.rest.provider.YamlEntityProvider}
  */
 public class YamlUtils {
 
@@ -69,6 +73,17 @@ public class YamlUtils {
       return YAML_MAPPER.readValue(content, tClass);
     } catch (JsonProcessingException ex) {
       throw new RuntimeException("Read yaml failed! " + tClass.getName(), ex);
+    }
+  }
+
+  /**
+   * Write object to writer
+   */
+  public static void writeValue(Writer writer, Object value) {
+    try {
+      YAML_MAPPER.writeValue(writer, value);
+    } catch (IOException ex) {
+      throw new RuntimeException("Write yaml failed! " + value.getClass().getName(), ex);
     }
   }
 }

--- a/submarine-server/server-submitter/submitter-k8s/pom.xml
+++ b/submarine-server/server-submitter/submitter-k8s/pom.xml
@@ -116,12 +116,6 @@
     </dependency>
 
     <dependency>
-      <groupId>com.fasterxml.jackson.datatype</groupId>
-      <artifactId>jackson-datatype-joda</artifactId>
-      <version>${jackson-databind.version}</version>
-    </dependency>
-
-    <dependency>
       <groupId>com.h2database</groupId>
       <artifactId>h2</artifactId>
       <version>${h2-connector-java.version}</version>

--- a/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/model/AgentPod.java
+++ b/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/model/AgentPod.java
@@ -33,7 +33,7 @@ import io.kubernetes.client.openapi.models.V1ObjectMetaBuilder;
 import io.kubernetes.client.openapi.models.V1Pod;
 import io.kubernetes.client.openapi.models.V1PodSpec;
 import org.apache.submarine.server.submitter.k8s.client.K8sClient;
-import org.apache.submarine.server.submitter.k8s.util.YamlUtils;
+import org.apache.submarine.server.utils.YamlUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/model/common/Configmap.java
+++ b/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/model/common/Configmap.java
@@ -31,7 +31,7 @@ import org.apache.submarine.server.submitter.k8s.K8sSubmitter;
 import org.apache.submarine.server.submitter.k8s.model.K8sResource;
 import org.apache.submarine.server.submitter.k8s.util.JsonUtils;
 import org.apache.submarine.server.submitter.k8s.util.OwnerReferenceUtils;
-import org.apache.submarine.server.submitter.k8s.util.YamlUtils;
+import org.apache.submarine.server.utils.YamlUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/model/common/PersistentVolumeClaim.java
+++ b/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/model/common/PersistentVolumeClaim.java
@@ -33,7 +33,7 @@ import org.apache.submarine.server.submitter.k8s.K8sSubmitter;
 import org.apache.submarine.server.submitter.k8s.model.K8sResource;
 import org.apache.submarine.server.submitter.k8s.util.NotebookUtils;
 import org.apache.submarine.server.submitter.k8s.util.OwnerReferenceUtils;
-import org.apache.submarine.server.submitter.k8s.util.YamlUtils;
+import org.apache.submarine.server.utils.YamlUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/model/istio/IstioVirtualService.java
+++ b/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/model/istio/IstioVirtualService.java
@@ -29,7 +29,7 @@ import org.apache.submarine.serve.utils.IstioConstants;
 import org.apache.submarine.server.submitter.k8s.client.K8sClient;
 import org.apache.submarine.server.submitter.k8s.K8sSubmitter;
 import org.apache.submarine.server.submitter.k8s.model.K8sResource;
-import org.apache.submarine.server.submitter.k8s.util.YamlUtils;
+import org.apache.submarine.server.utils.YamlUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/model/notebook/NotebookCR.java
+++ b/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/model/notebook/NotebookCR.java
@@ -34,7 +34,7 @@ import org.apache.submarine.server.submitter.k8s.model.K8sResource;
 import org.apache.submarine.server.submitter.k8s.parser.NotebookSpecParser;
 import org.apache.submarine.server.submitter.k8s.util.NotebookUtils;
 import org.apache.submarine.server.submitter.k8s.util.OwnerReferenceUtils;
-import org.apache.submarine.server.submitter.k8s.util.YamlUtils;
+import org.apache.submarine.server.utils.YamlUtils;
 import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/model/pytorchjob/PyTorchJob.java
+++ b/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/model/pytorchjob/PyTorchJob.java
@@ -39,7 +39,7 @@ import org.apache.submarine.server.submitter.k8s.model.mljob.MLJobReplicaSpec;
 import org.apache.submarine.server.submitter.k8s.parser.ExperimentSpecParser;
 import org.apache.submarine.server.submitter.k8s.util.JsonUtils;
 import org.apache.submarine.server.submitter.k8s.util.MLJobConverter;
-import org.apache.submarine.server.submitter.k8s.util.YamlUtils;
+import org.apache.submarine.server.utils.YamlUtils;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -88,11 +88,11 @@ public class PyTorchJob extends MLJob {
         MLJobReplicaSpec replicaSpec = new MLJobReplicaSpec();
         replicaSpec.setReplicas(taskSpec.getReplicas());
         V1PodTemplateSpec podTemplateSpec = ExperimentSpecParser.parseTemplateSpec(taskSpec, experimentSpec);
-        
+
         if (initContainer != null && replicaType.equals("Master")) {
-          podTemplateSpec.getSpec().addInitContainersItem(initContainer);  
+          podTemplateSpec.getSpec().addInitContainersItem(initContainer);
         }
-        
+
         replicaSpec.setTemplate(podTemplateSpec);
         replicaSpecMap.put(PyTorchJobReplicaType.valueOf(replicaType), replicaSpec);
       } else {

--- a/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/model/seldon/SeldonDeploymentPytorchServing.java
+++ b/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/model/seldon/SeldonDeploymentPytorchServing.java
@@ -27,7 +27,7 @@ import org.apache.submarine.serve.seldon.SeldonDeployment;
 import org.apache.submarine.server.submitter.k8s.client.K8sClient;
 import org.apache.submarine.server.submitter.k8s.model.istio.IstioVirtualService;
 import org.apache.submarine.server.submitter.k8s.util.OwnerReferenceUtils;
-import org.apache.submarine.server.submitter.k8s.util.YamlUtils;
+import org.apache.submarine.server.utils.YamlUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/model/seldon/SeldonDeploymentTFServing.java
+++ b/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/model/seldon/SeldonDeploymentTFServing.java
@@ -26,7 +26,7 @@ import org.apache.submarine.serve.seldon.tensorflow.SeldonTFServing;
 import org.apache.submarine.server.submitter.k8s.client.K8sClient;
 import org.apache.submarine.server.submitter.k8s.model.istio.IstioVirtualService;
 import org.apache.submarine.server.submitter.k8s.util.OwnerReferenceUtils;
-import org.apache.submarine.server.submitter.k8s.util.YamlUtils;
+import org.apache.submarine.server.utils.YamlUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/model/tfjob/TFJob.java
+++ b/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/model/tfjob/TFJob.java
@@ -40,7 +40,7 @@ import org.apache.submarine.server.submitter.k8s.model.mljob.MLJobReplicaSpec;
 import org.apache.submarine.server.submitter.k8s.parser.ExperimentSpecParser;
 import org.apache.submarine.server.submitter.k8s.util.JsonUtils;
 import org.apache.submarine.server.submitter.k8s.util.MLJobConverter;
-import org.apache.submarine.server.submitter.k8s.util.YamlUtils;
+import org.apache.submarine.server.utils.YamlUtils;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -69,7 +69,7 @@ public class TFJob extends MLJob {
     setGroup(CRD_TF_GROUP_V1);
     // set spec
     setSpec(parseTFJobSpec(experimentSpec));
-    
+
     V1Container initContainer = this.getExperimentHandlerContainer(experimentSpec);
     if (initContainer != null) {
       Map<TFJobReplicaType, MLJobReplicaSpec> replicaSet = this.getSpec().getReplicaSpecs();

--- a/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/model/xgboostjob/XGBoostJob.java
+++ b/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/model/xgboostjob/XGBoostJob.java
@@ -39,7 +39,7 @@ import org.apache.submarine.server.submitter.k8s.model.mljob.MLJobReplicaSpec;
 import org.apache.submarine.server.submitter.k8s.parser.ExperimentSpecParser;
 import org.apache.submarine.server.submitter.k8s.util.JsonUtils;
 import org.apache.submarine.server.submitter.k8s.util.MLJobConverter;
-import org.apache.submarine.server.submitter.k8s.util.YamlUtils;
+import org.apache.submarine.server.utils.YamlUtils;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -81,11 +81,11 @@ public class XGBoostJob extends MLJob {
         MLJobReplicaSpec replicaSpec = new MLJobReplicaSpec();
         replicaSpec.setReplicas(taskSpec.getReplicas());
         V1PodTemplateSpec podTemplateSpec = ExperimentSpecParser.parseTemplateSpec(taskSpec, experimentSpec);
-        
+
         if (initContainer != null && replicaType.equals("Master")) {
-          podTemplateSpec.getSpec().addInitContainersItem(initContainer);  
+          podTemplateSpec.getSpec().addInitContainersItem(initContainer);
         }
-        
+
         replicaSpec.setTemplate(podTemplateSpec);
         replicaSpecMap.put(XGBoostJobReplicaType.valueOf(replicaType), replicaSpec);
       } else {

--- a/submarine-server/server-submitter/submitter-k8s/src/test/java/org/apache/submarine/server/submitter/k8s/seldon/SeldonDeploymentResourceTest.java
+++ b/submarine-server/server-submitter/submitter-k8s/src/test/java/org/apache/submarine/server/submitter/k8s/seldon/SeldonDeploymentResourceTest.java
@@ -24,7 +24,7 @@ import org.apache.submarine.server.submitter.k8s.model.seldon.SeldonDeploymentFa
 import org.apache.submarine.server.submitter.k8s.model.seldon.SeldonDeploymentPytorchServing;
 import org.apache.submarine.server.submitter.k8s.model.seldon.SeldonDeploymentTFServing;
 import org.apache.submarine.server.submitter.k8s.model.seldon.SeldonResource;
-import org.apache.submarine.server.submitter.k8s.util.YamlUtils;
+import org.apache.submarine.server.utils.YamlUtils;
 import org.junit.Assert;
 import org.junit.Test;
 


### PR DESCRIPTION
### What is this PR for?
Use SnakeYaml's SafeConstructor to replace default Yaml no arguments constructor to void unsafe deserialization.
Link url: https://nvd.nist.gov/vuln/detail/CVE-2022-1471

### What type of PR is it?
Bug Fix

### Todos
* [x] - Add SafeConstructor

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-1371

### How should this be tested?
NA

### Screenshots (if appropriate)

### Questions:
* Do the license files need updating? Yes
* Are there breaking changes for older versions? No
* Does this need new documentation? No
