### PR TITLE
SUBMARINE-1372. Fix tensorflow 2.6.5 in CI always failed

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -76,7 +76,7 @@ jobs:
           pip install --no-cache-dir -e ./submarine-sdk/pysubmarine/.[tf2,pytorch]
           pip install --no-cache-dir 'tensorflow~=${{ matrix.tf-version }}'
       - name: List installed packages
-        run: pip list
+        run: pip list && pipdeptree
       - name: Run unit test
         working-directory: ./submarine-sdk/pysubmarine
         run: pytest -m "not e2e" --cov-report xml

--- a/submarine-sdk/pysubmarine/github-actions/test-requirements.txt
+++ b/submarine-sdk/pysubmarine/github-actions/test-requirements.txt
@@ -26,3 +26,4 @@ python_dateutil>=2.5.3
 scikit-learn>=0.24.2,<=1.0.2  # 1.1.x does not support cp37
 setuptools>=21.0.0
 urllib3>=1.15.1
+pipdeptree==2.5.2

--- a/submarine-sdk/pysubmarine/setup.py
+++ b/submarine-sdk/pysubmarine/setup.py
@@ -54,7 +54,7 @@ setup(
             "tensorflow-addons==0.17.0",
             "tensorflow-estimator>=2.9.0rc0,<2.10.0",
             "tf_slim==1.1.0",
-            "typeguard<3.0.0"
+            "typeguard<3.0.0",
         ],
         "pytorch": ["torch>=1.5.0,<2.0.0", "torchvision>=0.6.0"],
     },

--- a/submarine-sdk/pysubmarine/setup.py
+++ b/submarine-sdk/pysubmarine/setup.py
@@ -54,6 +54,7 @@ setup(
             "tensorflow-addons==0.17.0",
             "tensorflow-estimator>=2.9.0rc0,<2.10.0",
             "tf_slim==1.1.0",
+            "typeguard<3.0.0"
         ],
         "pytorch": ["torch>=1.5.0,<2.0.0", "torchvision>=0.6.0"],
     },

--- a/submarine-sdk/pysubmarine/setup.py
+++ b/submarine-sdk/pysubmarine/setup.py
@@ -55,7 +55,7 @@ setup(
             "tensorflow-estimator>=2.9.0rc0,<2.10.0",
             "tf_slim==1.1.0",
         ],
-        "pytorch": ["torch>=1.5.0", "torchvision>=0.6.0"],
+        "pytorch": ["torch>=1.5.0,<2.0.0", "torchvision>=0.6.0"],
     },
     classifiers=[
         "Intended Audience :: Developers",

--- a/submarine-sdk/pysubmarine/setup.py
+++ b/submarine-sdk/pysubmarine/setup.py
@@ -60,7 +60,7 @@ setup(
             #                   and will fix version compatibility issues in 0.8.1 or 0.9.0.
             "typeguard<3.0.0",
         ],
-        "pytorch": ["torch>=1.5.0,<2.0.0", "torchvision>=0.6.0"],
+        "pytorch": ["torch>=1.5.0", "torchvision>=0.6.0"],
     },
     classifiers=[
         "Intended Audience :: Developers",

--- a/submarine-sdk/pysubmarine/setup.py
+++ b/submarine-sdk/pysubmarine/setup.py
@@ -54,6 +54,10 @@ setup(
             "tensorflow-addons==0.17.0",
             "tensorflow-estimator>=2.9.0rc0,<2.10.0",
             "tf_slim==1.1.0",
+            # todo(cdmikechen): Based on SUBMARINE-1372, typeguard has recently been upgraded to version 3.0,
+            #                   which will restrict some python syntax and types more tightly.
+            #                   We are not upgrading this in submarine 0.8.0 for now,
+            #                   and will fix version compatibility issues in 0.8.1 or 0.9.0.
             "typeguard<3.0.0",
         ],
         "pytorch": ["torch>=1.5.0,<2.0.0", "torchvision>=0.6.0"],

--- a/submarine-sdk/pysubmarine/submarine/store/model_registry/sqlalchemy_store.py
+++ b/submarine-sdk/pysubmarine/submarine/store/model_registry/sqlalchemy_store.py
@@ -353,7 +353,10 @@ class SqlAlchemyStore(AbstractStore):
 
         def next_version(sql_registered_model: SqlRegisteredModel) -> int:
             if sql_registered_model.model_versions:
-                return max(0 if m.version is None else m.version for m in sql_registered_model.model_versions) + 1
+                return (
+                    max(0 if m.version is None else m.version for m in sql_registered_model.model_versions)
+                    + 1
+                )
             else:
                 return 1
 

--- a/submarine-sdk/pysubmarine/submarine/store/model_registry/sqlalchemy_store.py
+++ b/submarine-sdk/pysubmarine/submarine/store/model_registry/sqlalchemy_store.py
@@ -353,7 +353,7 @@ class SqlAlchemyStore(AbstractStore):
 
         def next_version(sql_registered_model: SqlRegisteredModel) -> int:
             if sql_registered_model.model_versions:
-                return max(m.version for m in sql_registered_model.model_versions) + 1
+                return max(0 if m.version is None else m.version for m in sql_registered_model.model_versions) + 1
             else:
                 return 1
 


### PR DESCRIPTION
### What is this PR for?
Limit torch under 3.0.0 and fix mypy error

### What type of PR is it?
Hot Fix

### Todos
* [x] - Limit typeguard < 3.0.0
* [x] - Fix mypy SQLAlchemy type check
* [x] - Add `pipdeptree` to better trace python dependency issues

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-1372

### How should this be tested?
python CI 

### Screenshots (if appropriate)

### Questions:
* Do the license files need updating? No
* Are there breaking changes for older versions? No
* Does this need new documentation? No
