### PR TITLE
SUBMARINE-1374. Temporary fix for submarine failing to get user info without authentication

### DIFF
--- a/submarine-server/server-core/src/main/java/org/apache/submarine/server/rest/workbench/SysUserRestApi.java
+++ b/submarine-server/server-core/src/main/java/org/apache/submarine/server/rest/workbench/SysUserRestApi.java
@@ -198,6 +198,9 @@ public class SysUserRestApi {
               .role(createDefaultRole()).build();
         }
       }
+    } else {
+      // If no authentication configuration is performed, we retain the default user for the time being
+      userInfo = createDefaultUser();
     }
     if (userInfo == null) { // user not found
       return new JsonResponse.Builder<>(Response.Status.OK).


### PR DESCRIPTION
### What is this PR for?
Getting the user info rest api without authentication mode will fail. We temporarily need to add a default admin user back to the frontend to keep the frontend logic consistent.

### What type of PR is it?
Bug Fix

### Todos
* [x] - Add a method to create a default user when using none auth

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-1374

### How should this be tested?
NA

### Screenshots (if appropriate)
NA

### Questions:
* Do the license files need updating? No
* Are there breaking changes for older versions? No
* Does this need new documentation? No
