### PR TITLE
SUBMARINE-1375. Fix custom resource definition requiring database secret

### DIFF
--- a/.github/scripts/start-submarine.sh
+++ b/.github/scripts/start-submarine.sh
@@ -32,7 +32,7 @@ kubectl label namespace submarine istio-injection=enabled
 kubectl label namespace "$submarine_user_namespace" istio-injection=enabled
 helm dependency update ./helm-charts/submarine
 helm install --wait --set storageClass.provisioner=rancher.io/local-path --set storageClass.volumeBindingMode=WaitForFirstConsumer submarine ./helm-charts/submarine -n submarine
-kubectl apply -f ./submarine-cloud-v2/artifacts/examples/example-submarine.yaml -n "$submarine_user_namespace"
+kubectl apply -f ./submarine-cloud-v3/config/samples/_v1alpha1_submarine.yaml -n "$submarine_user_namespace"
 
 # Polling waiting for the submarine to be in the RUNNING state
 for ((i=0;i<$wait_times;++i)); do

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -258,7 +258,7 @@ jobs:
           echo ">>> mvn ${BUILD_FLAG} -B"
           mvn ${BUILD_FLAG} -B
       - name: Build Image locally
-        run: .github/scripts/build-image-locally.sh
+        run: .github/scripts/build-image-locally-v3.sh
       - name: Start submarine
         run: bash ./.github/scripts/start-submarine.sh
       - name: Test

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -145,7 +145,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
       - name: Build Image locally
-        run: .github/scripts/build-image-locally.sh
+        run: .github/scripts/build-image-locally-v3.sh
       - name: Start submarine
         run: bash ./.github/scripts/start-submarine.sh
       - name: Setup python environment

--- a/helm-charts/submarine/crds/crd.yaml
+++ b/helm-charts/submarine/crds/crd.yaml
@@ -99,7 +99,6 @@ spec:
                       description: StorageSize is the storage size of the database
                       type: string
                   required:
-                    - mysqlRootPasswordSecret
                     - storageSize
                   type: object
                 minio:


### PR DESCRIPTION
### What is this PR for?
The operator-v3 based custom resource already supports automatic secret generation without the database password, so we don't need this config to be required.

### What type of PR is it?
Bug Fix

### Todos
* [x] - Remove mysqlRootPasswordSecret required

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-1375

### How should this be tested?
NA

### Screenshots (if appropriate)
NA

### Questions:
* Do the license files need updating? No
* Are there breaking changes for older versions? No
* Does this need new documentation? No
