### PR TITLE
SUBMARINE-1380. Change the subamrine-sdk naming convention from SNAPSHOT to dev

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Install dependencies
         run: |
-          pip install --upgrade pip setuptools==65.7.0 wheel
+          pip install --upgrade pip setuptools wheel
           pip install -r ./dev-support/style-check/python/lint-requirements.txt
           pip install -r ./dev-support/style-check/python/mypy-requirements.txt
       - name: List installed packages
@@ -64,7 +64,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install requirements
         run: |
-          pip install --upgrade pip setuptools==65.7.0 wheel
+          pip install --upgrade pip setuptools wheel
           pip install -r ./submarine-sdk/pysubmarine/github-actions/test-requirements.txt
       - name: Install pysubmarine with tf1 and pytorch
         if: ${{ matrix.tf-version == '1.15.0' }}
@@ -155,13 +155,13 @@ jobs:
       - name: Install tf1 dependencies
         if: ${{ matrix.tf-version == '1.15.0' }}
         run: |
-          pip install --upgrade pip setuptools==65.7.0 wheel
+          pip install --upgrade pip setuptools wheel
           pip install --no-cache-dir -e ./submarine-sdk/pysubmarine/.[tf,pytorch]
           pip install -r ./submarine-sdk/pysubmarine/github-actions/test-requirements.txt
       - name: Install tf2 dependencies
         if: startsWith(matrix.tf-version, '2.')
         run: |
-          pip install --upgrade pip setuptools==65.7.0 wheel
+          pip install --upgrade pip setuptools wheel
           pip install --no-cache-dir -e ./submarine-sdk/pysubmarine/.[tf2,pytorch]
           pip install --no-cache-dir 'tensorflow~=${{ matrix.tf-version }}'
           pip install -r ./submarine-sdk/pysubmarine/github-actions/test-requirements.txt

--- a/dev-support/docker-images/jupyter-gpu/Dockerfile
+++ b/dev-support/docker-images/jupyter-gpu/Dockerfile
@@ -111,7 +111,6 @@ RUN pip --no-cache-dir install pyqlib==0.8.6
 RUN git clone --depth=1 https://github.com/apache/submarine && \
     # replace numpy==1.19.2 to numpy>=1.20.0
     sed -i "s/numpy==1.19.2/numpy>=1.20.0/" submarine/submarine-sdk/pysubmarine/setup.py && \
-    pip --no-cache-dir install setuptools==65.7.0 && \
     pip --no-cache-dir install -e submarine/submarine-sdk/pysubmarine[tf,pytorch] && \
     # Add DeepFM example into notebook
     cp submarine/submarine-sdk/pysubmarine/example/submarine_experiment_sdk.ipynb $HOME && \

--- a/dev-support/docker-images/jupyter/Dockerfile
+++ b/dev-support/docker-images/jupyter/Dockerfile
@@ -112,7 +112,6 @@ RUN pip --no-cache-dir install pyqlib==0.8.6
 RUN git clone --depth=1 https://github.com/apache/submarine && \
     # replace numpy==1.19.2 to numpy>=1.20.0
     sed -i "s/numpy==1.19.2/numpy>=1.20.0/" submarine/submarine-sdk/pysubmarine/setup.py && \
-    pip --no-cache-dir install setuptools==65.7.0 && \
     pip --no-cache-dir install submarine/submarine-sdk/pysubmarine[tf,pytorch] && \
     cp submarine/submarine-sdk/pysubmarine/example/submarine_experiment_sdk.ipynb $HOME && \
     cp -r submarine/submarine-sdk/pysubmarine/example/{data,deepfm_example.ipynb,deepfm.json} $HOME && \

--- a/submarine-sdk/pysubmarine/setup.py
+++ b/submarine-sdk/pysubmarine/setup.py
@@ -20,7 +20,7 @@ with open("README.md") as f:
 
 setup(
     name="apache-submarine",
-    version="0.8.0-SNAPSHOT",
+    version="0.8.0.dev",
     description="A python SDK for submarine",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
### What is this PR for?
Use [pep-440](https://peps.python.org/pep-0440/) to rename the python-sdk version in order to prevent exceptions when building images and compiling.

### What type of PR is it?
Improvement

### Todos
* [x] - Update setuptools to latest version 
* [x] - rename 0.8.0-SNAPSHOT to 0.8.0.dev 

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-1380

### How should this be tested?
CICD

### Screenshots (if appropriate)

### Questions:
* Do the license files need updating? No
* Are there breaking changes for older versions? No
* Does this need new documentation? No
