### PR TITLE
SUBMARINE-1381. Upgrade java k8s client versions to support 1.25+

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -240,8 +240,12 @@ commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.1.3
 commons-logging:commons-logging:1.1.1
 commons-net:commons-net:3.1
-io.fabric8:kubernetes-server-mock:6.2.0
-io.javaoperatorsdk:operator-framework:4.1.1
+io.fabric8:kubernetes-client:6.6.1
+io.fabric8:kubernetes-server-mock:6.6.1
+io.kubernetes:client-java:17.0.2
+io.kubernetes:client-java-api-fluent:17.0.2
+io.javaoperatorsdk:operator-framework:4.3.2
+io.minio:minio:8.5.3
 io.netty:netty:3.7.0.Final
 io.netty:netty-all:4.0.23.Final
 javax.inject:javax.inject:1
@@ -338,7 +342,7 @@ com.linkedin.tony:tony-core:0.3.21
 BSD 3-Clause
 ------------
 org.hamcrest:hamcrest-core:1.3
-com.google.protobuf:protobuf-java:2.5.0
+com.google.protobuf:protobuf-java:3.21.10
 com.thoughtworks.paranamer:paranamer:2.3
 org.ow2.asm:asm:5.0.4
 asm:asm:3.3.1

--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
     <commons-configuration.version>1.10</commons-configuration.version>
     <commons-httpclient.version>3.1</commons-httpclient.version>
 
-    <minio.version>7.1.4</minio.version>
+    <minio.version>8.5.3</minio.version>
 
     <cglib.version>3.3.0</cglib.version>
     <jboss.logging.version>3.4.2.Final</jboss.logging.version>
@@ -133,10 +133,13 @@
     <jgit.version>5.13.0.202109080827-r</jgit.version>
     <atomix.version>3.1.5</atomix.version>
     <json.version>20211205</json.version>
+
     <!--  Submarine on Kubernetes  -->
-    <k8s.client-java.version>11.0.1</k8s.client-java.version>
-    <k8s.fabric8.version>6.2.0</k8s.fabric8.version>
+    <k8s.client-java.version>17.0.2</k8s.client-java.version>
+    <kotlin-stdlib.version>1.6.20</kotlin-stdlib.version>
+    <k8s.fabric8.version>6.6.1</k8s.fabric8.version>
     <jersey.test-framework>2.27</jersey.test-framework>
+
     <!-- integration test-->
     <plugin.failsafe.version>2.17</plugin.failsafe.version>
     <!--  embedded-ldap-junit  -->
@@ -146,7 +149,7 @@
     <guice-servlet.version>3.0</guice-servlet.version>
     <guice.version>3.0</guice.version>
     <!--  server API  -->
-    <protobuf-java.version>3.14.0</protobuf-java.version>
+    <protobuf-java.version>3.21.10</protobuf-java.version>
     <joda-time.version>2.10.8</joda-time.version>
     <!--  pac4j  -->
     <pac4j.version>5.6.1</pac4j.version>
@@ -203,6 +206,11 @@
       <dependency>
         <groupId>io.kubernetes</groupId>
         <artifactId>client-java</artifactId>
+        <version>${k8s.client-java.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.kubernetes</groupId>
+        <artifactId>client-java-api-fluent</artifactId>
         <version>${k8s.client-java.version}</version>
       </dependency>
 

--- a/submarine-serve/pom.xml
+++ b/submarine-serve/pom.xml
@@ -31,13 +31,26 @@
   <name>Submarine: Serve</name>
 
   <dependencies>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-    </dependency>
+
     <dependency>
       <groupId>io.kubernetes</groupId>
-      <artifactId>client-java</artifactId>
+      <artifactId>client-java-api-fluent</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jetbrains.kotlin</groupId>
+          <artifactId>kotlin-stdlib-common</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.jetbrains.kotlin</groupId>
+          <artifactId>kotlin-stdlib-jdk8</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jetbrains.kotlin</groupId>
+      <artifactId>kotlin-stdlib-common</artifactId>
+      <version>${kotlin-stdlib.version}</version>
     </dependency>
 
     <!--  Unit Tests  -->

--- a/submarine-server/server-core/pom.xml
+++ b/submarine-server/server-core/pom.xml
@@ -432,7 +432,21 @@
           <groupId>com.fasterxml.jackson.core</groupId>
           <artifactId>jackson-annotations</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.jetbrains.kotlin</groupId>
+          <artifactId>kotlin-stdlib-common</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.jetbrains.kotlin</groupId>
+          <artifactId>kotlin-stdlib-jdk8</artifactId>
+        </exclusion>
       </exclusions>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jetbrains.kotlin</groupId>
+      <artifactId>kotlin-stdlib-common</artifactId>
+      <version>${kotlin-stdlib.version}</version>
     </dependency>
 
     <dependency>

--- a/submarine-server/server-submitter/submarine-k8s-agent/pom.xml
+++ b/submarine-server/server-submitter/submarine-k8s-agent/pom.xml
@@ -37,7 +37,7 @@
     <dependency>
       <groupId>io.javaoperatorsdk</groupId>
       <artifactId>operator-framework</artifactId>
-      <version>4.1.1</version>
+      <version>4.3.2</version>
       <exclusions>
         <exclusion>
           <groupId>com.fasterxml.jackson.core</groupId>

--- a/submarine-server/server-submitter/submitter-k8s/pom.xml
+++ b/submarine-server/server-submitter/submitter-k8s/pom.xml
@@ -47,7 +47,53 @@
     <dependency>
       <groupId>io.kubernetes</groupId>
       <artifactId>client-java</artifactId>
-      <version>${k8s.client-java.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>io.kubernetes</groupId>
+          <artifactId>client-java</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.jetbrains.kotlin</groupId>
+          <artifactId>kotlin-stdlib-common</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.jetbrains.kotlin</groupId>
+          <artifactId>kotlin-stdlib-jdk8</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.google.code.gson</groupId>
+          <artifactId>gson</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <dependency>
+      <groupId>io.kubernetes</groupId>
+      <artifactId>client-java-api-fluent</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>io.kubernetes</groupId>
+          <artifactId>client-java</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.jetbrains.kotlin</groupId>
+          <artifactId>kotlin-stdlib-common</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.jetbrains.kotlin</groupId>
+          <artifactId>kotlin-stdlib-jdk8</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.google.code.gson</groupId>
+          <artifactId>gson</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jetbrains.kotlin</groupId>
+      <artifactId>kotlin-stdlib-common</artifactId>
+      <version>${kotlin-stdlib.version}</version>
     </dependency>
 
     <dependency>
@@ -60,6 +106,12 @@
       <groupId>org.apache.submarine</groupId>
       <artifactId>submarine-server-api</artifactId>
       <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+      <version>${gson.version}</version>
     </dependency>
 
     <dependency>

--- a/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/model/notebook/NotebookCR.java
+++ b/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/model/notebook/NotebookCR.java
@@ -35,10 +35,10 @@ import org.apache.submarine.server.submitter.k8s.parser.NotebookSpecParser;
 import org.apache.submarine.server.submitter.k8s.util.NotebookUtils;
 import org.apache.submarine.server.submitter.k8s.util.OwnerReferenceUtils;
 import org.apache.submarine.server.utils.YamlUtils;
-import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.time.OffsetDateTime;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -267,7 +267,7 @@ public class NotebookCR implements KubernetesObject, K8sResource<Notebook> {
     } finally {
       if (notebook == null) {
         // add metadata time info
-        this.getMetadata().setDeletionTimestamp(new DateTime());
+        this.getMetadata().setDeletionTimestamp(OffsetDateTime.now());
         // build notebook response
         notebook = NotebookUtils.buildNotebookResponse(this);
         notebook.setStatus(Notebook.Status.STATUS_NOT_FOUND.getValue());

--- a/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/model/notebook/NotebookCondition.java
+++ b/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/model/notebook/NotebookCondition.java
@@ -19,7 +19,8 @@
 package org.apache.submarine.server.submitter.k8s.model.notebook;
 
 import com.google.gson.annotations.SerializedName;
-import org.joda.time.DateTime;
+
+import java.time.OffsetDateTime;
 
 public class NotebookCondition {
 
@@ -31,7 +32,7 @@ public class NotebookCondition {
   private String type;
 
   @SerializedName("lastProbeTime")
-  private DateTime lastProbeTime;
+  private OffsetDateTime lastProbeTime;
 
   @SerializedName("reason")
   private String reason;

--- a/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/util/MLJobConverter.java
+++ b/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/util/MLJobConverter.java
@@ -19,6 +19,7 @@
 
 package org.apache.submarine.server.submitter.k8s.util;
 
+import java.time.OffsetDateTime;
 import java.util.List;
 import io.kubernetes.client.openapi.models.V1JobCondition;
 import io.kubernetes.client.openapi.models.V1JobStatus;
@@ -27,7 +28,6 @@ import io.kubernetes.client.openapi.models.V1StatusDetails;
 import io.kubernetes.client.util.generic.options.DeleteOptions;
 import org.apache.submarine.server.api.experiment.Experiment;
 import org.apache.submarine.server.submitter.k8s.model.mljob.MLJob;
-import org.joda.time.DateTime;
 
 /**
  * Converter for different types.
@@ -37,7 +37,7 @@ public class MLJobConverter {
   public static Experiment toJobFromMLJob(MLJob mlJob) {
     Experiment experiment = new Experiment();
     experiment.setUid(mlJob.getMetadata().getUid());
-    DateTime dateTime = mlJob.getMetadata().getCreationTimestamp();
+    OffsetDateTime dateTime = mlJob.getMetadata().getCreationTimestamp();
     if (dateTime != null) {
       experiment.setAcceptedTime(dateTime.toString());
       experiment.setStatus(Experiment.Status.STATUS_ACCEPTED.getValue());

--- a/submarine-server/server-submitter/submitter-k8s/src/test/java/org/apache/submarine/server/submitter/k8s/MLJobConverterTest.java
+++ b/submarine-server/server-submitter/submitter-k8s/src/test/java/org/apache/submarine/server/submitter/k8s/MLJobConverterTest.java
@@ -21,6 +21,7 @@ package org.apache.submarine.server.submitter.k8s;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -37,7 +38,6 @@ import org.apache.submarine.server.api.spec.ExperimentSpec;
 import org.apache.submarine.server.submitter.k8s.model.mljob.MLJobFactory;
 import org.apache.submarine.server.submitter.k8s.util.MLJobConverter;
 import org.apache.submarine.server.submitter.k8s.model.mljob.MLJob;
-import org.joda.time.DateTime;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -54,11 +54,11 @@ public class MLJobConverterTest extends SpecBuilder {
     Assert.assertNull(experiment.getStatus());
 
     // Created Status
-    DateTime startTime = new DateTime();
+    OffsetDateTime startTime = OffsetDateTime.now();
     mlJob.getStatus().setStartTime(startTime);
 
     List<V1JobCondition> conditions = new ArrayList<>();
-    DateTime createdTime = new DateTime();
+    OffsetDateTime createdTime = OffsetDateTime.now();
     V1JobCondition condition = new V1JobConditionBuilder().withStatus("True")
         .withType("Created").withLastTransitionTime(createdTime).build();
     conditions.add(condition);
@@ -69,7 +69,7 @@ public class MLJobConverterTest extends SpecBuilder {
     Assert.assertEquals(startTime.toString(), experiment.getCreatedTime());
 
     // Running Status
-    DateTime runningTime = new DateTime();
+    OffsetDateTime runningTime = OffsetDateTime.now();
     condition = new V1JobConditionBuilder().withStatus("True")
         .withType("Running").withLastTransitionTime(runningTime).build();
     conditions.add(condition);
@@ -80,7 +80,7 @@ public class MLJobConverterTest extends SpecBuilder {
     Assert.assertEquals(runningTime.toString(), experiment.getRunningTime());
 
     // Succeeded Status
-    DateTime finishedTime = new DateTime();
+    OffsetDateTime finishedTime = OffsetDateTime.now();
     mlJob.getStatus().setCompletionTime(finishedTime);
     condition = new V1JobConditionBuilder().withStatus("True")
             .withType("Succeeded").withLastTransitionTime(runningTime).build();

--- a/submarine-test/test-k8s/pom.xml
+++ b/submarine-test/test-k8s/pom.xml
@@ -105,7 +105,7 @@
     </dependency>
     <dependency>
       <groupId>io.kubernetes</groupId>
-      <artifactId>client-java</artifactId>
+      <artifactId>client-java-api-fluent</artifactId>
       <version>${k8s.client-java.version}</version>
       <scope>test</scope>
     </dependency>


### PR DESCRIPTION
### What is this PR for?
Upgrade java k8s client versions to support 1.25+.

### What type of PR is it?
Improvement

### Todos
* [x] - `k8s.client-java.version` to 17.0.2
* [x] - `k8s.fabric8.version` to 6.6.1
* [x] - `io.javaoperatorsdk:operator-framework` to 4.3.2

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-1381

### How should this be tested?
CI Test

### Screenshots (if appropriate)

### Questions:
* Do the license files need updating? Yes
* Are there breaking changes for older versions? Yes
* Does this need new documentation? No
