### PR TITLE
SUBMARINE-1379. Fix a bug where tasks from missing k8s resources could not be deleted on the UI

### DIFF
--- a/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/model/notebook/NotebookCR.java
+++ b/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/model/notebook/NotebookCR.java
@@ -294,12 +294,15 @@ public class NotebookCR implements KubernetesObject, K8sResource<Notebook> {
       // The exception that obtaining CRD resources is not necessarily because the CRD is deleted,
       // but maybe due to timeout or API error caused by network and other reasons.
       // Therefore, the status of the notebook should be set to a new enum NOTFOUND.
-      LOG.warn("Get error when submitter is finding notebook: {}", getMetadata().getName());
-      if (notebook == null) {
-        notebook = new Notebook();
-      }
-      notebook.setReason(e.getMessage());
-      notebook.setStatus(Notebook.Status.STATUS_NOT_FOUND.getValue());
+      if (e.getCode() == 404) {
+        LOG.warn(String.format("Get error when submitter is finding notebook: %s",
+            getMetadata().getName()), e);
+        if (notebook == null) {
+          notebook = new Notebook();
+        }
+        notebook.setReason(e.getMessage());
+        notebook.setStatus(Notebook.Status.STATUS_NOT_FOUND.getValue());
+      } else throw new SubmarineRuntimeException(e.getCode(), e.getMessage());
     }
     return resetName(notebook);
   }

--- a/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/model/pytorchjob/PyTorchJob.java
+++ b/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/model/pytorchjob/PyTorchJob.java
@@ -189,10 +189,10 @@ public class PyTorchJob extends MLJob {
       V1Status status = api.getPyTorchJobClient()
           .delete(getMetadata().getNamespace(), getMetadata().getName(),
               MLJobConverter.toDeleteOptionsFromMLJob(this))
-          .throwsApiException().getStatus();
+          .getStatus();
       return parseExperimentResponseStatus(status);
-    } catch (ApiException e) {
-      throw new SubmarineRuntimeException(e.getCode(), e.getMessage());
+    } catch (Exception e) {
+      throw new SubmarineRuntimeException(500, e.getMessage());
     }
   }
 }

--- a/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/model/seldon/SeldonDeploymentPytorchServing.java
+++ b/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/model/seldon/SeldonDeploymentPytorchServing.java
@@ -85,12 +85,11 @@ public class SeldonDeploymentPytorchServing extends SeldonPytorchServing impleme
       }
       api.getSeldonDeploymentClient()
           .delete(getMetadata().getNamespace(), getMetadata().getName(),
-              getDeleteOptions(getApiVersion()))
-          .throwsApiException();
+              getDeleteOptions(getApiVersion()));
       return this;
-    } catch (ApiException e) {
+    } catch (Exception e) {
       LOG.error(e.getMessage(), e);
-      throw new SubmarineRuntimeException(e.getCode(), e.getMessage());
+      throw new SubmarineRuntimeException(500, e.getMessage());
     }
   }
 

--- a/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/model/seldon/SeldonDeploymentTFServing.java
+++ b/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/model/seldon/SeldonDeploymentTFServing.java
@@ -84,12 +84,11 @@ public class SeldonDeploymentTFServing extends SeldonTFServing implements Seldon
       }
       api.getSeldonDeploymentClient()
           .delete(getMetadata().getNamespace(), getMetadata().getName(),
-              getDeleteOptions(getApiVersion()))
-          .throwsApiException();
+              getDeleteOptions(getApiVersion()));
       return this;
-    } catch (ApiException e) {
+    } catch (Exception e) {
       LOG.error(e.getMessage(), e);
-      throw new SubmarineRuntimeException(e.getCode(), e.getMessage());
+      throw new SubmarineRuntimeException(500, e.getMessage());
     }
   }
 

--- a/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/model/tfjob/TFJob.java
+++ b/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/model/tfjob/TFJob.java
@@ -183,7 +183,7 @@ public class TFJob extends MLJob {
               new V1Patch(JsonUtils.toJson(this)), patchOptions)
           .throwsApiException().getObject();
       return parseExperimentResponseObject(tfJob, TFJob.class);
-    }  catch (ApiException e) {
+    } catch (ApiException e) {
       throw new SubmarineRuntimeException(e.getCode(), e.getMessage());
     }
   }
@@ -198,10 +198,10 @@ public class TFJob extends MLJob {
       V1Status status = api.getTfJobClient()
           .delete(getMetadata().getNamespace(), getMetadata().getName(),
               MLJobConverter.toDeleteOptionsFromMLJob(this))
-          .throwsApiException().getStatus();
+          .getStatus();
       return parseExperimentResponseStatus(status);
-    } catch (ApiException e) {
-      throw new SubmarineRuntimeException(e.getCode(), e.getMessage());
+    } catch (Exception e) {
+      throw new SubmarineRuntimeException(500, e.getMessage());
     }
   }
 

--- a/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/model/xgboostjob/XGBoostJob.java
+++ b/submarine-server/server-submitter/submitter-k8s/src/main/java/org/apache/submarine/server/submitter/k8s/model/xgboostjob/XGBoostJob.java
@@ -186,10 +186,10 @@ public class XGBoostJob extends MLJob {
       V1Status status = api.getXGBoostJobClient()
           .delete(getMetadata().getNamespace(), getMetadata().getName(),
               MLJobConverter.toDeleteOptionsFromMLJob(this))
-          .throwsApiException().getStatus();
+          .getStatus();
       return parseExperimentResponseStatus(status);
-    } catch (ApiException e) {
-      throw new SubmarineRuntimeException(e.getCode(), e.getMessage());
+    } catch (Exception e) {
+      throw new SubmarineRuntimeException(500, e.getMessage());
     }
   }
 }

--- a/submarine-workbench/workbench-web/src/app/pages/workbench/experiment/experiment-home/experiment-home.component.ts
+++ b/submarine-workbench/workbench-web/src/app/pages/workbench/experiment/experiment-home/experiment-home.component.ts
@@ -129,7 +129,7 @@ export class ExperimentHomeComponent implements OnInit {
         }
         // Delete redundant rows
         if (currentListSize > newListSize) {
-          this.experimentList = this.experimentList.splice(0, newListSize - currentListSize);
+          this.experimentList = this.experimentList.slice(0, newListSize);
         }
 
         if (!isAutoReload) {

--- a/submarine-workbench/workbench-web/src/app/pages/workbench/notebook/notebook-home/notebook-home.component.ts
+++ b/submarine-workbench/workbench-web/src/app/pages/workbench/notebook/notebook-home/notebook-home.component.ts
@@ -98,7 +98,7 @@ export class NotebookHomeComponent implements OnInit, OnDestroy {
         }
         // Delete redundant rows
         if (currentListSize > newListSize) {
-          this.notebookList = this.notebookList.splice(0, newListSize - currentListSize);
+          this.notebookList = this.notebookList.slice(0, newListSize);
         }
       }
     });


### PR DESCRIPTION
### What is this PR for?
If the backend CR is manually deleted, the submarine-server is not currently checking if the specified resource still exists, resulting in a situation where the experiment cannot be deleted in UI.

### What type of PR is it?
Bug Fix

### Todos
* [x] - Remove `throwsApiException` in Notebook, Experiment and Serve.
* [x] - Fixed a bug where deleting a record on the UI, the entire page data clear

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-1379

### How should this be tested?
CI tests can cover code, but they can only represent processes that handle normal conditions. 
I removed the method of throwing an 404 exception error (`.throwsApiException()`) when the resource does not exist, which results in the return of the status object.
In this way, we can return the result normally, even without this resource

### Screenshots (if appropriate)
NA

### Questions:
* Do the license files need updating? No
* Are there breaking changes for older versions? No
* Does this need new documentation? No
