### PR TITLE
SUBMARINE-1386. Fix mlflow docker image build error 

### DIFF
--- a/dev-support/docker-images/mlflow/Dockerfile
+++ b/dev-support/docker-images/mlflow/Dockerfile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM python:3.7.0-slim
+FROM python:3.7-slim
 
 RUN apt-get update && apt-get -y install --no-install-recommends default-libmysqlclient-dev libpq-dev build-essential wget
 

--- a/dev-support/docker-images/mlflow/Dockerfile
+++ b/dev-support/docker-images/mlflow/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update && apt-get -y install --no-install-recommends default-libmysq
 
 # We temporarily downgrade the protobuf version under 3.20.x.
 # Reference: https://developers.google.com/protocol-buffers/docs/news/2022-05-06#python-updates
-RUN pip install greenlet==1.1.3 mlflow==1.15.0 sqlalchemy==1.4.11 boto3==1.17.58 pymysql==0.9.3 "protobuf<3.20"
+RUN pip install --no-cache-dir greenlet==1.1.3 mlflow==1.15.0 sqlalchemy==1.4.11 boto3==1.17.58 pymysql==0.9.3 "protobuf<3.20" && pip cache purge
 
 COPY start.sh /usr/local/bin
 

--- a/dev-support/docker-images/mlflow/Dockerfile
+++ b/dev-support/docker-images/mlflow/Dockerfile
@@ -17,7 +17,9 @@ FROM python:3.7-slim
 
 RUN apt-get update && apt-get -y install --no-install-recommends default-libmysqlclient-dev libpq-dev build-essential wget
 
-RUN pip install greenlet==1.1.3 mlflow==1.15.0 sqlalchemy==1.4.11 boto3==1.17.58 pymysql==0.9.3
+# We temporarily downgrade the protobuf version under 3.20.x.
+# Reference: https://developers.google.com/protocol-buffers/docs/news/2022-05-06#python-updates
+RUN pip install greenlet==1.1.3 mlflow==1.15.0 sqlalchemy==1.4.11 boto3==1.17.58 pymysql==0.9.3 "protobuf<3.20"
 
 COPY start.sh /usr/local/bin
 


### PR DESCRIPTION
### What is this PR for?

Since [Debian 9/stretch moved to archive.debian.org](https://lists.debian.org/debian-devel-announce/2023/03/msg00006.html), we need to update python image version to latest.
The latest python image has been updated to the new repository in `sources.list`.

### What type of PR is it?
Bug Fix

### Todos
* [x] - Update mlflow dockerfile python image to `python:3.7-slim`

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-1386

### How should this be tested?
CI image build step

### Screenshots (if appropriate)
<img width="1428" alt="image" src="https://github.com/apache/submarine/assets/12069428/b3331507-6821-4bb1-850e-5225ad0bdac8">


### Questions:
* Do the license files need updating? No
* Are there breaking changes for older versions? No
* Does this need new documentation? No
