### PR TITLE
SUBMARINE-1390. Update jupyter gpu image cuda to 12.2.0-base-ubuntu20.04

### DIFF
--- a/dev-support/docker-images/jupyter-gpu/Dockerfile
+++ b/dev-support/docker-images/jupyter-gpu/Dockerfile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM nvidia/cuda:10.2-base-ubuntu18.04
+FROM nvidia/cuda:12.2.0-base-ubuntu20.04
 
 ARG NB_USER="jovyan"
 ARG NB_UID="1000"


### PR DESCRIPTION
### What is this PR for?
`nvidia/cuda:10.2-base-ubuntu18.04` is no longer found on docker hub (https://hub.docker.com/r/nvidia/cuda) and we need to update the dockerfile to latest.

### What type of PR is it?
Hot Fix

### Todos
* [x] - Update `10.2-base-ubuntu18.04` to `12.2.0-base-ubuntu20.04`

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-1390

### How should this be tested?
CI test

### Screenshots (if appropriate)
<img width="1001" alt="image" src="https://github.com/apache/submarine/assets/12069428/af407877-c9d7-4ab2-b747-6f9bcb73c030">


### Questions:
* Do the license files need updating? No
* Are there breaking changes for older versions? No
* Does this need new documentation? No
