### PR TITLE
SUBMARINE-1389. restrict scipy < 1.11.0 for python 3.9 and tensorflow 2.6

### DIFF
--- a/submarine-sdk/pysubmarine/setup.py
+++ b/submarine-sdk/pysubmarine/setup.py
@@ -59,6 +59,11 @@ setup(
             #                   We are not upgrading this in submarine 0.8.0 for now,
             #                   and will fix version compatibility issues in 0.8.1 or 0.9.0.
             "typeguard<3.0.0",
+            # todo(cdmikechen): SUBMARINE-1389. From scipy 1.11.0 (https://github.com/scipy/scipy/releases/tag/v1.11.0), 
+            #                   scipy need numpy 1.21.6 or geater in python 3.9. 
+            #                   So that we need to restrict scipy < 1.11.0 to support tf2.6.
+            #                   From submarine 0.8.1 or 0.9.0, we may no longer support tensorflow 2.6
+            "scipy<1.11.0",
         ],
         "pytorch": ["torch>=1.5.0", "torchvision>=0.6.0"],
     },

--- a/submarine-sdk/pysubmarine/setup.py
+++ b/submarine-sdk/pysubmarine/setup.py
@@ -59,8 +59,8 @@ setup(
             #                   We are not upgrading this in submarine 0.8.0 for now,
             #                   and will fix version compatibility issues in 0.8.1 or 0.9.0.
             "typeguard<3.0.0",
-            # todo(cdmikechen): SUBMARINE-1389. From scipy 1.11.0 (https://github.com/scipy/scipy/releases/tag/v1.11.0), 
-            #                   scipy need numpy 1.21.6 or geater in python 3.9. 
+            # todo(cdmikechen): SUBMARINE-1389. From scipy 1.11.0 (https://github.com/scipy/scipy/releases/tag/v1.11.0),
+            #                   scipy need numpy 1.21.6 or geater in python 3.9.
             #                   So that we need to restrict scipy < 1.11.0 to support tf2.6.
             #                   From submarine 0.8.1 or 0.9.0, we may no longer support tensorflow 2.6
             "scipy<1.11.0",

--- a/submarine-sdk/pysubmarine/setup.py
+++ b/submarine-sdk/pysubmarine/setup.py
@@ -59,7 +59,8 @@ setup(
             #                   We are not upgrading this in submarine 0.8.0 for now,
             #                   and will fix version compatibility issues in 0.8.1 or 0.9.0.
             "typeguard<3.0.0",
-            # todo(cdmikechen): SUBMARINE-1389. From scipy 1.11.0 (https://github.com/scipy/scipy/releases/tag/v1.11.0),
+            # todo(cdmikechen): SUBMARINE-1389. From scipy 1.11.0
+            #                   (https://github.com/scipy/scipy/releases/tag/v1.11.0),
             #                   scipy need numpy 1.21.6 or geater in python 3.9.
             #                   So that we need to restrict scipy < 1.11.0 to support tf2.6.
             #                   From submarine 0.8.1 or 0.9.0, we may no longer support tensorflow 2.6


### PR DESCRIPTION
### What is this PR for?
From scipy 1.11.0 (https://github.com/scipy/scipy/releases/tag/v1.11.0), scipy need numpy 1.21.6 or geater in python 3.9, so that tensorflow 2.6.5 CI will not succeed.
Link: https://github.com/apache/submarine/actions/runs/5486277299/jobs/9996172343

This is because in tensorflow 2.6.5 dependency list, the dependency version of numpy is 1.19 (required: ~=1.19.2), so that we need restrict scipy < 1.11.0.

Also, we will remove support for python 3.7 and TensorFlow 2.6 in subsequent releases (issue: https://issues.apache.org/jira/browse/SUBMARINE-1391). The scipy restrictions may be removed at that time.

### What type of PR is it?
Hot Fix

### Todos
* [x] - scipy < 1.11.0

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-1389

### How should this be tested?
Python CI test

### Screenshots (if appropriate)
NA

### Questions:
* Do the license files need updating? No
* Are there breaking changes for older versions? No
* Does this need new documentation? No
