### PR TITLE
SUBMARINE-1342. Remove experiment template cache in server

### DIFF
--- a/submarine-test/test-k8s/src/test/java/org/apache/submarine/rest/ExperimentTemplateManagerRestApiTest.java
+++ b/submarine-test/test-k8s/src/test/java/org/apache/submarine/rest/ExperimentTemplateManagerRestApiTest.java
@@ -135,7 +135,8 @@ public class ExperimentTemplateManagerRestApiTest extends AbstractSubmarineServe
         gson.fromJson(gson.toJson(jsonResponse.getResult()), new TypeToken<List<ExperimentTemplate>>() {
         }.getType());
 
-    Assert.assertEquals(TPL_NAME, getExperimentTemplates.get(0).getExperimentTemplateSpec().getName());
+    Assert.assertTrue(getExperimentTemplates.stream()
+        .anyMatch(t -> TPL_NAME.equals(t.getExperimentTemplateSpec().getName())));
 
     deleteExperimentTemplate();
   }


### PR DESCRIPTION
### What is this PR for?
The current experimental templates are cached on the submarine-server, so if the deployment replica of the submarine-server is greater than 1 or if the data in the database has changed, the cache cannot be triggered to update.

### What type of PR is it?
Bug Fix

### Todos
* [x] - Remove cache

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-1342

### How should this be tested?
CI Test

### Screenshots (if appropriate)
NA

### Questions:
* Do the license files need updating? No
* Are there breaking changes for older versions? No
* Does this need new documentation? No
