### PR TITLE
SUBMARINE-1392. Modify the description of creating a jira account in the documentation

### DIFF
--- a/website/docs/community/contributing.md
+++ b/website/docs/community/contributing.md
@@ -59,8 +59,8 @@ git remote -v
 ```
 
 ### Step3: Create a new Jira in Submarine project
-* New contributors need privilege to create JIRA issues. Please email kaihsun@apache.org with your Jira username. In addition, the email title should be "[New Submarine Contributor]".
-* Check [Jira issue tracker](https://issues.apache.org/jira/projects/SUBMARINE/issues/SUBMARINE-748?filter=allopenissues) for existing issues.
+* New contributors need privilege to create JIRA issues. Public signup for Apache Jira is disabled, we need to go to [Apache Self serve sign up page](https://selfserve.apache.org/jira-account.html) to request an account.
+* After Jira account created, check [Jira issue tracker](https://issues.apache.org/jira/projects/SUBMARINE/issues?filter=allopenissues) for existing issues.
 * Create a new Jira issue in Submarine project. When the issue is created, a Jira number (eg. SUBMARINE-748) will be assigned to the issue automatically. 
 ![jira_number_example](/img/jira_number_example.png)
 


### PR DESCRIPTION
### What is this PR for?
Modify the documentation in the jira account creation section.
Link: https://submarine.apache.org/docs/next/community/contributing#step3-create-a-new-jira-in-submarine-project

### What type of PR is it?
Documentation 

### Todos
* [x] - jira account creation  document

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-1392

### How should this be tested?
NA

### Screenshots (if appropriate)
![image](https://github.com/apache/submarine/assets/12069428/62de8b5c-6feb-4be3-ab5a-b3d907f7d4b4)


### Questions:
* Do the license files need updating? No
* Are there breaking changes for older versions? No
* Does this need new documentation? No
