### PR TITLE
SUBMARINE-1401. Refactor docker image workflow to avoid no space issues

### DIFF
--- a/.github/workflows/deploy_docker_images.yml
+++ b/.github/workflows/deploy_docker_images.yml
@@ -20,7 +20,7 @@ on:
   push:
     branches: [master]
 jobs:
-  deploy-images:
+  deploy-server:
     if: github.repository == 'apache/submarine'
     runs-on: ubuntu-latest
     timeout-minutes: 240
@@ -64,12 +64,30 @@ jobs:
           docker push apache/submarine:agent-$SUBMARINE_VERSION
           docker rmi apache/submarine:agent-$SUBMARINE_VERSION
 
+      ## TODO(cdmikechen): In the future, we will not include the database as a built-in image 
+      ##                   to facilitate subsequent upgrades.
       - name: Build submarine database
         run: ./dev-support/docker-images/database/build.sh
       - name: Push submarine-database docker image
         run: |
           docker push apache/submarine:database-$SUBMARINE_VERSION
           docker rmi apache/submarine:database-$SUBMARINE_VERSION
+
+  deploy-builtin-images:
+    if: github.repository == 'apache/submarine'
+    runs-on: ubuntu-latest
+    timeout-minutes: 240
+    env:
+      SUBMARINE_VERSION: 0.8.0-SNAPSHOT
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          repository: apache/submarine
+      - uses: docker/login-action@v1
+        name: Login to Docker Hub
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Build submarine jupyter
         run: ./dev-support/docker-images/jupyter/build.sh
@@ -85,13 +103,6 @@ jobs:
           docker push apache/submarine:jupyter-notebook-gpu-$SUBMARINE_VERSION
           docker rmi apache/submarine:jupyter-notebook-gpu-$SUBMARINE_VERSION
 
-      - name: Build submarine operator
-        run: ./dev-support/docker-images/operator-v3/build.sh
-      - name: Push submarine-operator docker image
-        run: |
-          docker push apache/submarine:operator-$SUBMARINE_VERSION
-          docker rmi apache/submarine:operator-$SUBMARINE_VERSION
-
       - name: Build submarine mlflow
         run: ./dev-support/docker-images/mlflow/build.sh
       - name: Push submarine-mlflow docker image
@@ -99,17 +110,35 @@ jobs:
           docker push apache/submarine:mlflow-$SUBMARINE_VERSION
           docker rmi apache/submarine:mlflow-$SUBMARINE_VERSION
 
-      # - name: Build submarine serve
-      #   run: ./dev-support/docker-images/serve/build.sh
-      # - name: Push submarine-serve docker image
-      #   run: docker push apache/submarine:serve-$SUBMARINE_VERSION
-
       - name: Build submarine quickstart
         run: ./dev-support/examples/quickstart/build.sh
       - name: Push submarine quickstart docker image
         run: |
           docker push apache/submarine:quickstart-$SUBMARINE_VERSION
           docker rmi apache/submarine:quickstart-$SUBMARINE_VERSION
+
+  deploy-operator-and-cicd:
+    if: github.repository == 'apache/submarine'
+    runs-on: ubuntu-latest
+    timeout-minutes: 240
+    env:
+      SUBMARINE_VERSION: 0.8.0-SNAPSHOT
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          repository: apache/submarine
+      - uses: docker/login-action@v1
+        name: Login to Docker Hub
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build submarine operator
+        run: ./dev-support/docker-images/operator-v3/build.sh
+      - name: Push submarine-operator docker image
+        run: |
+          docker push apache/submarine:operator-$SUBMARINE_VERSION
+          docker rmi apache/submarine:operator-$SUBMARINE_VERSION
 
       - name: Build submarine cicd
         run: ./dev-support/cicd/build.sh

--- a/.github/workflows/deploy_docker_images.yml
+++ b/.github/workflows/deploy_docker_images.yml
@@ -23,7 +23,7 @@ on: [push, pull_request]
 
 jobs:
   deploy-server:
-    if: github.repository == 'apache/submarine'
+    # if: github.repository == 'apache/submarine'
     runs-on: ubuntu-latest
     timeout-minutes: 240
     env:
@@ -76,7 +76,7 @@ jobs:
       #     docker rmi apache/submarine:database-$SUBMARINE_VERSION
 
   deploy-builtin-images:
-    if: github.repository == 'apache/submarine'
+    # if: github.repository == 'apache/submarine'
     runs-on: ubuntu-latest
     timeout-minutes: 240
     env:
@@ -120,7 +120,7 @@ jobs:
       #     docker rmi apache/submarine:quickstart-$SUBMARINE_VERSION
 
   deploy-cloud-native-and-cicd:
-    if: github.repository == 'apache/submarine'
+    # if: github.repository == 'apache/submarine'
     runs-on: ubuntu-latest
     timeout-minutes: 240
     env:

--- a/.github/workflows/deploy_docker_images.yml
+++ b/.github/workflows/deploy_docker_images.yml
@@ -32,11 +32,11 @@ jobs:
       - uses: actions/checkout@v2
         with:
           repository: apache/submarine
-      - uses: docker/login-action@v1
-        name: Login to Docker Hub
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+      # - uses: docker/login-action@v1
+      #   name: Login to Docker Hub
+      #   with:
+      #     username: ${{ secrets.DOCKER_USERNAME }}
+      #     password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Set up JDK 11
         uses: actions/setup-java@v1
         with:
@@ -85,11 +85,11 @@ jobs:
       - uses: actions/checkout@v2
         with:
           repository: apache/submarine
-      - uses: docker/login-action@v1
-        name: Login to Docker Hub
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+      # - uses: docker/login-action@v1
+      #   name: Login to Docker Hub
+      #   with:
+      #     username: ${{ secrets.DOCKER_USERNAME }}
+      #     password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Build submarine jupyter
         run: ./dev-support/docker-images/jupyter/build.sh
@@ -129,11 +129,11 @@ jobs:
       - uses: actions/checkout@v2
         with:
           repository: apache/submarine
-      - uses: docker/login-action@v1
-        name: Login to Docker Hub
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+      # - uses: docker/login-action@v1
+      #   name: Login to Docker Hub
+      #   with:
+      #     username: ${{ secrets.DOCKER_USERNAME }}
+      #     password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Build submarine operator
         run: ./dev-support/docker-images/operator-v3/build.sh

--- a/.github/workflows/deploy_docker_images.yml
+++ b/.github/workflows/deploy_docker_images.yml
@@ -22,7 +22,7 @@ on:
 
 jobs:
   deploy-server:
-    # if: github.repository == 'apache/submarine'
+    if: github.repository == 'apache/submarine'
     runs-on: ubuntu-latest
     timeout-minutes: 240
     env:

--- a/.github/workflows/deploy_docker_images.yml
+++ b/.github/workflows/deploy_docker_images.yml
@@ -16,9 +16,11 @@
 name: Deploy submarine docker images
 
 # Trigger the workflow on master branch push
-on:
-  push:
-    branches: [master]
+# on:
+#   push:
+#     branches: [master]
+on: [push, pull_request]
+
 jobs:
   deploy-server:
     if: github.repository == 'apache/submarine'
@@ -52,26 +54,26 @@ jobs:
 
       - name: Build submarine server
         run: ./dev-support/docker-images/submarine/build.sh
-      - name: Push submarine-server docker image
-        run: |
-          docker push apache/submarine:server-$SUBMARINE_VERSION
-          docker rmi apache/submarine:server-$SUBMARINE_VERSION
+      # - name: Push submarine-server docker image
+      #   run: |
+      #     docker push apache/submarine:server-$SUBMARINE_VERSION
+      #     docker rmi apache/submarine:server-$SUBMARINE_VERSION
 
       - name: Build submarine agent
         run: ./dev-support/docker-images/agent/build.sh
-      - name: Push submarine-agent docker image
-        run: |
-          docker push apache/submarine:agent-$SUBMARINE_VERSION
-          docker rmi apache/submarine:agent-$SUBMARINE_VERSION
+      # - name: Push submarine-agent docker image
+      #   run: |
+      #     docker push apache/submarine:agent-$SUBMARINE_VERSION
+      #     docker rmi apache/submarine:agent-$SUBMARINE_VERSION
 
       ## TODO(cdmikechen): In the future, we will not include the database as a built-in image 
       ##                   to facilitate subsequent upgrades.
       - name: Build submarine database
         run: ./dev-support/docker-images/database/build.sh
-      - name: Push submarine-database docker image
-        run: |
-          docker push apache/submarine:database-$SUBMARINE_VERSION
-          docker rmi apache/submarine:database-$SUBMARINE_VERSION
+      # - name: Push submarine-database docker image
+      #   run: |
+      #     docker push apache/submarine:database-$SUBMARINE_VERSION
+      #     docker rmi apache/submarine:database-$SUBMARINE_VERSION
 
   deploy-builtin-images:
     if: github.repository == 'apache/submarine'
@@ -91,33 +93,33 @@ jobs:
 
       - name: Build submarine jupyter
         run: ./dev-support/docker-images/jupyter/build.sh
-      - name: Push submarine-jupyter docker image
-        run: |
-          docker push apache/submarine:jupyter-notebook-$SUBMARINE_VERSION
-          docker rmi apache/submarine:jupyter-notebook-$SUBMARINE_VERSION
+      # - name: Push submarine-jupyter docker image
+      #   run: |
+      #     docker push apache/submarine:jupyter-notebook-$SUBMARINE_VERSION
+      #     docker rmi apache/submarine:jupyter-notebook-$SUBMARINE_VERSION
 
       - name: Build submarine jupyter gpu
         run: ./dev-support/docker-images/jupyter-gpu/build.sh
-      - name: Push submarine-jupyter-gpu docker image
-        run: |
-          docker push apache/submarine:jupyter-notebook-gpu-$SUBMARINE_VERSION
-          docker rmi apache/submarine:jupyter-notebook-gpu-$SUBMARINE_VERSION
+      # - name: Push submarine-jupyter-gpu docker image
+      #   run: |
+      #     docker push apache/submarine:jupyter-notebook-gpu-$SUBMARINE_VERSION
+      #     docker rmi apache/submarine:jupyter-notebook-gpu-$SUBMARINE_VERSION
 
       - name: Build submarine mlflow
         run: ./dev-support/docker-images/mlflow/build.sh
-      - name: Push submarine-mlflow docker image
-        run: |
-          docker push apache/submarine:mlflow-$SUBMARINE_VERSION
-          docker rmi apache/submarine:mlflow-$SUBMARINE_VERSION
+      # - name: Push submarine-mlflow docker image
+      #   run: |
+      #     docker push apache/submarine:mlflow-$SUBMARINE_VERSION
+      #     docker rmi apache/submarine:mlflow-$SUBMARINE_VERSION
 
       - name: Build submarine quickstart
         run: ./dev-support/examples/quickstart/build.sh
-      - name: Push submarine quickstart docker image
-        run: |
-          docker push apache/submarine:quickstart-$SUBMARINE_VERSION
-          docker rmi apache/submarine:quickstart-$SUBMARINE_VERSION
+      # - name: Push submarine quickstart docker image
+      #   run: |
+      #     docker push apache/submarine:quickstart-$SUBMARINE_VERSION
+      #     docker rmi apache/submarine:quickstart-$SUBMARINE_VERSION
 
-  deploy-operator-and-cicd:
+  deploy-cloud-native-and-cicd:
     if: github.repository == 'apache/submarine'
     runs-on: ubuntu-latest
     timeout-minutes: 240
@@ -135,14 +137,14 @@ jobs:
 
       - name: Build submarine operator
         run: ./dev-support/docker-images/operator-v3/build.sh
-      - name: Push submarine-operator docker image
-        run: |
-          docker push apache/submarine:operator-$SUBMARINE_VERSION
-          docker rmi apache/submarine:operator-$SUBMARINE_VERSION
+      # - name: Push submarine-operator docker image
+      #   run: |
+      #     docker push apache/submarine:operator-$SUBMARINE_VERSION
+      #     docker rmi apache/submarine:operator-$SUBMARINE_VERSION
 
       - name: Build submarine cicd
         run: ./dev-support/cicd/build.sh
-      - name: Push submarine-cicd docker image
-        run: |
-          docker push apache/submarine:cicd-$SUBMARINE_VERSION
-          docker rmi apache/submarine:cicd-$SUBMARINE_VERSION
+      # - name: Push submarine-cicd docker image
+      #   run: |
+      #     docker push apache/submarine:cicd-$SUBMARINE_VERSION
+      #     docker rmi apache/submarine:cicd-$SUBMARINE_VERSION

--- a/.github/workflows/deploy_docker_images.yml
+++ b/.github/workflows/deploy_docker_images.yml
@@ -16,10 +16,9 @@
 name: Deploy submarine docker images
 
 # Trigger the workflow on master branch push
-# on:
-#   push:
-#     branches: [master]
-on: [push, pull_request]
+on:
+  push:
+    branches: [master]
 
 jobs:
   deploy-server:
@@ -32,11 +31,11 @@ jobs:
       - uses: actions/checkout@v2
         with:
           repository: apache/submarine
-      # - uses: docker/login-action@v1
-      #   name: Login to Docker Hub
-      #   with:
-      #     username: ${{ secrets.DOCKER_USERNAME }}
-      #     password: ${{ secrets.DOCKER_PASSWORD }}
+      - uses: docker/login-action@v1
+        name: Login to Docker Hub
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Set up JDK 11
         uses: actions/setup-java@v1
         with:
@@ -54,29 +53,29 @@ jobs:
 
       - name: Build submarine server
         run: ./dev-support/docker-images/submarine/build.sh
-      # - name: Push submarine-server docker image
-      #   run: |
-      #     docker push apache/submarine:server-$SUBMARINE_VERSION
-      #     docker rmi apache/submarine:server-$SUBMARINE_VERSION
+      - name: Push submarine-server docker image
+        run: |
+          docker push apache/submarine:server-$SUBMARINE_VERSION
+          docker rmi apache/submarine:server-$SUBMARINE_VERSION
 
       - name: Build submarine agent
         run: ./dev-support/docker-images/agent/build.sh
-      # - name: Push submarine-agent docker image
-      #   run: |
-      #     docker push apache/submarine:agent-$SUBMARINE_VERSION
-      #     docker rmi apache/submarine:agent-$SUBMARINE_VERSION
+      - name: Push submarine-agent docker image
+        run: |
+          docker push apache/submarine:agent-$SUBMARINE_VERSION
+          docker rmi apache/submarine:agent-$SUBMARINE_VERSION
 
       ## TODO(cdmikechen): In the future, we will not include the database as a built-in image 
       ##                   to facilitate subsequent upgrades.
       - name: Build submarine database
         run: ./dev-support/docker-images/database/build.sh
-      # - name: Push submarine-database docker image
-      #   run: |
-      #     docker push apache/submarine:database-$SUBMARINE_VERSION
-      #     docker rmi apache/submarine:database-$SUBMARINE_VERSION
+      - name: Push submarine-database docker image
+        run: |
+          docker push apache/submarine:database-$SUBMARINE_VERSION
+          docker rmi apache/submarine:database-$SUBMARINE_VERSION
 
   deploy-builtin-images:
-    # if: github.repository == 'apache/submarine'
+    if: github.repository == 'apache/submarine'
     runs-on: ubuntu-latest
     timeout-minutes: 240
     env:
@@ -85,42 +84,42 @@ jobs:
       - uses: actions/checkout@v2
         with:
           repository: apache/submarine
-      # - uses: docker/login-action@v1
-      #   name: Login to Docker Hub
-      #   with:
-      #     username: ${{ secrets.DOCKER_USERNAME }}
-      #     password: ${{ secrets.DOCKER_PASSWORD }}
+      - uses: docker/login-action@v1
+        name: Login to Docker Hub
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Build submarine jupyter
         run: ./dev-support/docker-images/jupyter/build.sh
-      # - name: Push submarine-jupyter docker image
-      #   run: |
-      #     docker push apache/submarine:jupyter-notebook-$SUBMARINE_VERSION
-      #     docker rmi apache/submarine:jupyter-notebook-$SUBMARINE_VERSION
+      - name: Push submarine-jupyter docker image
+        run: |
+          docker push apache/submarine:jupyter-notebook-$SUBMARINE_VERSION
+          docker rmi apache/submarine:jupyter-notebook-$SUBMARINE_VERSION
 
       - name: Build submarine jupyter gpu
         run: ./dev-support/docker-images/jupyter-gpu/build.sh
-      # - name: Push submarine-jupyter-gpu docker image
-      #   run: |
-      #     docker push apache/submarine:jupyter-notebook-gpu-$SUBMARINE_VERSION
-      #     docker rmi apache/submarine:jupyter-notebook-gpu-$SUBMARINE_VERSION
+      - name: Push submarine-jupyter-gpu docker image
+        run: |
+          docker push apache/submarine:jupyter-notebook-gpu-$SUBMARINE_VERSION
+          docker rmi apache/submarine:jupyter-notebook-gpu-$SUBMARINE_VERSION
 
       - name: Build submarine mlflow
         run: ./dev-support/docker-images/mlflow/build.sh
-      # - name: Push submarine-mlflow docker image
-      #   run: |
-      #     docker push apache/submarine:mlflow-$SUBMARINE_VERSION
-      #     docker rmi apache/submarine:mlflow-$SUBMARINE_VERSION
+      - name: Push submarine-mlflow docker image
+        run: |
+          docker push apache/submarine:mlflow-$SUBMARINE_VERSION
+          docker rmi apache/submarine:mlflow-$SUBMARINE_VERSION
 
       - name: Build submarine quickstart
         run: ./dev-support/examples/quickstart/build.sh
-      # - name: Push submarine quickstart docker image
-      #   run: |
-      #     docker push apache/submarine:quickstart-$SUBMARINE_VERSION
-      #     docker rmi apache/submarine:quickstart-$SUBMARINE_VERSION
+      - name: Push submarine quickstart docker image
+        run: |
+          docker push apache/submarine:quickstart-$SUBMARINE_VERSION
+          docker rmi apache/submarine:quickstart-$SUBMARINE_VERSION
 
   deploy-cloud-native-and-cicd:
-    # if: github.repository == 'apache/submarine'
+    if: github.repository == 'apache/submarine'
     runs-on: ubuntu-latest
     timeout-minutes: 240
     env:
@@ -129,22 +128,22 @@ jobs:
       - uses: actions/checkout@v2
         with:
           repository: apache/submarine
-      # - uses: docker/login-action@v1
-      #   name: Login to Docker Hub
-      #   with:
-      #     username: ${{ secrets.DOCKER_USERNAME }}
-      #     password: ${{ secrets.DOCKER_PASSWORD }}
+      - uses: docker/login-action@v1
+        name: Login to Docker Hub
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Build submarine operator
         run: ./dev-support/docker-images/operator-v3/build.sh
-      # - name: Push submarine-operator docker image
-      #   run: |
-      #     docker push apache/submarine:operator-$SUBMARINE_VERSION
-      #     docker rmi apache/submarine:operator-$SUBMARINE_VERSION
+      - name: Push submarine-operator docker image
+        run: |
+          docker push apache/submarine:operator-$SUBMARINE_VERSION
+          docker rmi apache/submarine:operator-$SUBMARINE_VERSION
 
       - name: Build submarine cicd
         run: ./dev-support/cicd/build.sh
-      # - name: Push submarine-cicd docker image
-      #   run: |
-      #     docker push apache/submarine:cicd-$SUBMARINE_VERSION
-      #     docker rmi apache/submarine:cicd-$SUBMARINE_VERSION
+      - name: Push submarine-cicd docker image
+        run: |
+          docker push apache/submarine:cicd-$SUBMARINE_VERSION
+          docker rmi apache/submarine:cicd-$SUBMARINE_VERSION


### PR DESCRIPTION
### What is this PR for?
The docker image push fails at the last few stages due to no space, and the build process needs to be split up a bit to avoid this problem.

Link: https://github.com/apache/submarine/actions/runs/5760002365/job/15615121566

 
### What type of PR is it?
Refactor

### Todos
* [x] - deploy_docker_images.yml

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-1401

### How should this be tested?

We can view this action:
https://github.com/cdmikechen/submarine/actions/runs/5809697567

### Screenshots (if appropriate)

### Questions:
* Do the license files need updating? YNo
* Are there breaking changes for older versions? No
* Does this need new documentation? No
