### PR TITLE
SUBMARINE-1402. Update serving to work with k8s 1.25

### DIFF
--- a/helm-charts/submarine/Chart.yaml
+++ b/helm-charts/submarine/Chart.yaml
@@ -29,6 +29,6 @@ dependencies:
     version: "0.8.0"
     condition: notebook-controller.enabled
   - name: seldon-core-operator
-    version: "1.15.1"
+    version: "1.17.1"
     repository: https://storage.googleapis.com/seldon-charts
     condition: seldon-core-operator.enabled


### PR DESCRIPTION
### What is this PR for?
Some of the serving resource api's are outdated in k8s 1.25 and need to be upgraded. 
```
no matches for kind "HorizontalPodAutoscaler" in version "autoscaling/v2beta1"
```
### What type of PR is it?
Hot Fix

### Todos
* [x] - Update seldon to 1.17.1

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-1402

### How should this be tested?
NA

### Screenshots (if appropriate)
NA

### Questions:
* Do the license files need updating? No
* Are there breaking changes for older versions? No
* Does this need new documentation? No
