### PR TITLE
SUBMARINE-1408. Fix ubuntu low disk space issue

### DIFF
--- a/.github/scripts/free-disk-space.sh
+++ b/.github/scripts/free-disk-space.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# Reference from 
+# https://github.com/apache/flink/blob/master/tools/azure-pipelines/free_disk_space.sh
+# There is a lot of extra space in ubuntu that is not being used.
+# Therefore, we can remove these unused packages
+
+echo "=============================================================================="
+echo "Freeing up disk space on CI system"
+echo "=============================================================================="
+
+echo "Listing 100 largest packages"
+dpkg-query -Wf '${Installed-Size}\t${Package}\n' | sort -n | tail -n 100
+df -h
+
+echo "Removing large packages"
+sudo apt-get remove -y '^dotnet-.*'
+sudo apt-get remove -y '^llvm-.*'
+sudo apt-get remove -y 'php.*'
+sudo apt-get remove -y '^mongodb-.*'
+sudo apt-get remove -y '^mysql-.*'
+sudo apt-get remove -y azure-cli google-cloud-sdk hhvm google-chrome-stable firefox powershell mono-devel libgl1-mesa-dri
+sudo apt-get autoremove -y
+sudo apt-get clean
+df -h
+
+echo "Removing large directories"
+sudo rm -rf /usr/share/dotnet/
+sudo rm -rf /usr/local/graalvm/
+sudo rm -rf /usr/local/.ghcup/
+sudo rm -rf /usr/local/share/powershell
+sudo rm -rf /usr/local/share/chromium
+sudo rm -rf /usr/local/lib/android
+sudo rm -rf /usr/local/lib/node_modules
+df -h
+
+echo "Removing docker images"
+sudo docker image prune --all --force
+df -h

--- a/.github/scripts/start-submarine.sh
+++ b/.github/scripts/start-submarine.sh
@@ -32,6 +32,10 @@ kubectl label namespace submarine istio-injection=enabled
 kubectl label namespace "$submarine_user_namespace" istio-injection=enabled
 helm dependency update ./helm-charts/submarine
 helm install --wait --set storageClass.provisioner=rancher.io/local-path --set storageClass.volumeBindingMode=WaitForFirstConsumer submarine ./helm-charts/submarine -n submarine
+
+# replace storage size
+sed -i '' 's/10Gi/1Gi/' ./submarine-cloud-v3/config/samples/_v1_submarine.yaml
+# install submarine
 kubectl apply -f ./submarine-cloud-v3/config/samples/_v1_submarine.yaml -n "$submarine_user_namespace"
 
 # Polling waiting for the submarine to be in the RUNNING state

--- a/.github/scripts/start-submarine.sh
+++ b/.github/scripts/start-submarine.sh
@@ -34,7 +34,9 @@ helm dependency update ./helm-charts/submarine
 helm install --wait --set storageClass.provisioner=rancher.io/local-path --set storageClass.volumeBindingMode=WaitForFirstConsumer submarine ./helm-charts/submarine -n submarine
 
 # replace storage size
-sed -i '' 's/10Gi/1Gi/' ./submarine-cloud-v3/config/samples/_v1_submarine.yaml
+sed -i "s/10Gi/1Gi/" ./submarine-cloud-v3/config/samples/_v1_submarine.yaml
+cat ./submarine-cloud-v3/config/samples/_v1_submarine.yaml
+
 # install submarine
 kubectl apply -f ./submarine-cloud-v3/config/samples/_v1_submarine.yaml -n "$submarine_user_namespace"
 

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -214,7 +214,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          fetch-depth: 50
+          fetch-depth: 1
+      - name: Free Disk Space
+        run: bash ./.github/scripts/free-disk-space.sh
       - name: Cache jacoco.exec
         uses: actions/cache@v2
         with:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -109,7 +109,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          fetch-depth: 50
+          fetch-depth: 1
+      - name: Free Disk Space
+        run: bash ./.github/scripts/free-disk-space.sh
       - name: Setup python environment
         uses: actions/setup-python@v4
         with:

--- a/submarine-server/server-database/src/main/resources/org/apache/submarine/database/mappers/ExperimentMapper.xml
+++ b/submarine-server/server-database/src/main/resources/org/apache/submarine/database/mappers/ExperimentMapper.xml
@@ -61,7 +61,7 @@
   <insert id="insert" parameterType="org.apache.submarine.server.database.experiment.entity.ExperimentEntity">
     insert into experiment (id, experiment_spec, create_by, create_time, update_by, update_time, experiment_status, accepted_time, running_time, finished_time, uid)
     values (#{id,jdbcType=VARCHAR}, #{experimentSpec,jdbcType=VARCHAR},
-            #{createBy,jdbcType=VARCHAR}, now(), #{updateBy,jdbcType=VARCHAR}, now(), #{experimentStatus,jdbcType=VARCHAR},
+            #{createBy,jdbcType=VARCHAR}, #{acceptedTime,jdbcType=TIMESTAMP}, #{updateBy,jdbcType=VARCHAR}, now(), #{experimentStatus,jdbcType=VARCHAR},
             #{acceptedTime,jdbcType=TIMESTAMP}, #{runningTime,jdbcType=TIMESTAMP}, #{finishedTime,jdbcType=TIMESTAMP}, #{uid,jdbcType=VARCHAR})
   </insert>
 
@@ -84,7 +84,7 @@
 
   <update id="create" >
     update experiment
-    set experiment_status='Created', accepted_time=#{acceptedTime,jdbcType=TIMESTAMP}, update_time=now()
+    set experiment_status='Created', update_time=now()
     where id = #{id,jdbcType=VARCHAR}
   </update>
 


### PR DESCRIPTION
### What is this PR for?
Recently, in the github actions, there is less and less space left in ubuntu, which leads to a no disk space exception in one of the steps of the workflow. 
Therefore, we need to remove unneeded packages and files from the ubuntu to make as much space as possible for python packages, docker images, and k8s.

### What type of PR is it?
Hot Fix

### Todos
* [x] - Reduce ubuntu disk space.
* [x] - don't update `accpted_time` while agent is processing to avoid unit test errors on ·accpted_time·.

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-1408

### How should this be tested?
CI test

### Screenshots (if appropriate)
Before:
<img width="478" alt="image" src="https://github.com/apache/submarine/assets/12069428/eea00bd5-8ddb-4759-918e-06e4ed821916">
After:
<img width="421" alt="image" src="https://github.com/apache/submarine/assets/12069428/5aac5f25-16bb-43a5-b93d-7e9729e9c55e">


### Questions:
* Do the license files need updating? No
* Are there breaking changes for older versions? No
* Does this need new documentation? No
