### PR TITLE
SUBMARINE-1412. Add the missing 0.8.0 download page

### DIFF
--- a/website/i18n/zh-cn/docusaurus-plugin-content-pages/releases/submarine-release-0.8.0.md
+++ b/website/i18n/zh-cn/docusaurus-plugin-content-pages/releases/submarine-release-0.8.0.md
@@ -1,0 +1,31 @@
+<!--
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# Apache Submarine Release 0.8.0
+
+Apache Submarine 社区很高兴地宣布 `0.8.0` 版本已经发布。
+
+自上次发布以来，社区投入了大量精力来改进 Apache Submarine。
+总计有 115 个用于改进和错误修复的补丁。  
+
+新特性如下：
+- Submarine UI 支持 i18n (英文和中文)
+- 更新 `Submarine-Cloud-V2` 到 `Submarine-Cloud-V3`
+- 支持 `OIDC` 的 SSO 认证, 删除无认证的登录和REST服务 
+- 删除 `Submarine-Python-SDK` Python2.7 和 Python3.6 的支持
+- 更新从 1.22 到 1.25 的 K8s 支持
+
+我们推荐 [下载](../docs/download) 最新版本进行体验和使用，并非常欢迎通过 [邮件列表](../docs/community/) 提供反馈。
+
+您还可以访问 [问题跟踪器](https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12322824&version=12351377) 以获取已解决问题的完整列表。

--- a/website/versioned_docs/version-0.8.0/download.md
+++ b/website/versioned_docs/version-0.8.0/download.md
@@ -21,7 +21,36 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-The latest release of Apache Submarine is `0.7.0`.
+The latest release of Apache Submarine is `0.8.0`.
+
+- Apache Submarine `0.8.0` released on September 23, 2023 ([release notes](https://submarine.apache.org/releases/submarine-release-0.8.0)) ([git tag](https://github.com/apache/submarine/tree/rel/release-0.8.0))
+  - Binary package:
+    [submarine-dist-0.8.0.tar.gz](https://www.apache.org/dyn/closer.cgi/submarine/0.8.0/submarine-dist-0.8.0.tar.gz) (126 MB, [checksum](https://www.apache.org/dist/submarine/0.8.0/submarine-dist-0.8.0.tar.gz.sha512), [signature](https://www.apache.org/dist/submarine/0.8.0/submarine-dist-0.8.0.tar.gz.asc))
+  - Source:
+    [apache-submarine-0.8.0-src.tar.gz](https://www.apache.org/dyn/closer.cgi/submarine/0.8.0/apache-submarine-0.8.0-src.tar.gz) (9.7 MB, [checksum](https://www.apache.org/dist/submarine/0.8.0/apache-submarine-0.8.0-src.tar.gz.sha512), [signature](https://www.apache.org/dist/submarine/0.8.0/apache-submarine-0.8.0-src.tar.gz.asc))
+  - Docker images:
+    - [submarine server](https://hub.docker.com/layers/apache/submarine/server-0.8.0/images/sha256-3885aadbf8e7806c3e9f08f025856d851036e881d617d2b08eaedbe0c92c2fcf) `docker pull apache/submarine:server-0.8.0`
+    - [submarine database](https://hub.docker.com/layers/apache/submarine/database-0.8.0/images/sha256-c13466bd95c92e9abdb1d507ce6a57f26ec00e6e75a474d65ead1e3f7e8b34aa) `docker pull apache/submarine:database-0.8.0`
+    - [submarine jupyter-notebook](https://hub.docker.com/layers/apache/submarine/jupyter-notebook-0.8.0/images/sha256-44d1e768fa85180ede8b05517f5a9749ce68905147100763a44cca54fa5f25ea) `docker pull apache/submarine:jupyter-notebook-0.8.0`
+    - [submarine jupyter-notebook-gpu](https://hub.docker.com/layers/apache/submarine/jupyter-notebook-gpu-0.8.0/images/sha256-8154a754b1741e4667e74bf6532904c5b3e2687e543b8847f549e1392a4ad196) `docker pull apache/submarine:jupyter-notebook-gpu-0.8.0`
+    - [submarine quickstart](https://hub.docker.com/layers/apache/submarine/quickstart-0.8.0/images/sha256-45d04388ec03f5111af112eb4cb55faa99e2db0e530fe37785f96ae0195dc9de) `docker pull apache/submarine:quickstart-0.8.0`
+    - [submarine mlflow](https://hub.docker.com/layers/apache/submarine/mlflow-0.8.0/images/sha256-a80817973c16a830a5c1ff3258dab7f852820e246b8444d9cdbb800009097b6e) `docker pull apache/submarine:mlflow-0.8.0`
+    - [submarine operator](https://hub.docker.com/layers/apache/submarine/operator-0.8.0/images/sha256-e4e055ea2a209a261e72b72dc09f65a932654f9037bac1ebeb521f7d9d84dbf6) `docker pull apache/submarine:operator-0.8.0`
+    - [submarine agent](https://hub.docker.com/layers/apache/submarine/agent-0.8.0/images/sha256-68869cd841e0edaf2493bf1886e4d51cb35cad595eb474c4196a5e959997b0a8) `docker pull apache/submarine:agent-0.8.0`
+
+  - SDK:
+    - [PySubmarine](https://pypi.org/project/apache-submarine/0.8.0/) `pip install apache-submarine==0.8.0`
+
+## Verify the integrity of the files
+
+It is essential that you [verify](https://www.apache.org/info/verification.html) the integrity of the downloaded files using the PGP or MD5 signatures. This signature should be matched against the [KEYS](https://www.apache.org/dist/submarine/KEYS) file.
+
+```
+gpg --import KEYS
+gpg --verify submarine-dist-X.Y.Z-src.tar.gz.asc
+```
+
+## Old releases
 
 - Apache Submarine `0.7.0` released on April 25, 2022 ([release notes](https://submarine.apache.org/releases/submarine-release-0.7.0)) ([git tag](https://github.com/apache/submarine/tree/rel/release-0.7.0))
   - Binary package:
@@ -34,23 +63,12 @@ The latest release of Apache Submarine is `0.7.0`.
     - [submarine jupyter-notebook](https://hub.docker.com/layers/submarine/apache/submarine/jupyter-notebook-0.7.0/images/sha256-0cacc189c7d2f220c23a89e6c9f0a542c274985f3a349e71613b5a92a0afea31?context=explore) `docker pull apache/submarine:jupyter-notebook-0.7.0`
     - [submarine quickstart](https://hub.docker.com/layers/submarine/apache/submarine/quickstart-0.7.0/images/sha256-eefbfde93d279a5bb69aecd74111addbdee4a5462eb0adb1805a0116532e75cb?context=explore) `docker pull apache/submarine:quickstart-0.7.0`
     - [submarine serve](https://hub.docker.com/layers/submarine/apache/submarine/serve-0.7.0/images/sha256-0bfed0744174c8c1d87fe8441f9fe006ab060ffcc2b207b4d013eef45267d103?context=explore) `docker pull apache/submarine:serve-0.7.0`
-    - [submarine mlflow](https://hub.docker.com/layers/apache/submarine/mlflow-0.6.0/images/sha256-b395838b6c30e21c48c3304f20315788e2416bb4cf410779ad2d1530688e7fa9?context=explore) `docker pull apache/submarine:mlflow-0.7.0`
+    - [submarine mlflow](https://hub.docker.com/layers/apache/submarine/mlflow-0.7.0/images/sha256-3cc868ef73793119206ed57340f80cf3d321f41b6315f8e02f98596a4180525d?context=explore) `docker pull apache/submarine:mlflow-0.7.0`
     - [submarine operator](https://hub.docker.com/layers/submarine/apache/submarine/operator-0.7.0/images/sha256-cd8b9a3c1e4a367ecf9df45e4ea8e78b9be0d347db5a70b3910cca87e73c4f28?context=explore) `docker pull apache/submarine:operator-0.7.0`
     - [submarine agent](https://hub.docker.com/layers/submarine/apache/submarine/agent-0.7.0/images/sha256-9c14c62478786eb9d7bbe74ca1aed48cd6ae4cb318bd9da149456926cd5c6474?context=explore) `docker pull apache/submarine:agent-0.7.0`
 
   - SDK:
     - [PySubmarine](https://pypi.org/project/apache-submarine/0.7.0/) `pip install apache-submarine==0.7.0`
-
-## Verify the integrity of the files
-
-It is essential that you [verify](https://www.apache.org/info/verification.html) the integrity of the downloaded files using the PGP or MD5 signatures. This signature should be matched against the [KEYS](https://www.apache.org/dist/submarine/KEYS) file.
-
-```
-gpg --import KEYS
-gpg --verify submarine-dist-X.Y.Z-src.tar.gz.asc
-```
-
-## Old releases
 
 - Apache Submarine `0.6.0` released on Oct 21, 2021 ([release notes](https://submarine.apache.org/releases/submarine-release-0.6.0)) ([git tag](https://github.com/apache/submarine/tree/rel/release-0.6.0))
   - Binary package:


### PR DESCRIPTION
### What is this PR for?
Add the missing 0.8.0 download file

### What type of PR is it?
Hot Fix

### Todos
* [x] - 0.8.0 download page

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-1412

### How should this be tested?
NA

### Screenshots (if appropriate)
NA

### Questions:
* Do the license files need updating? No
* Are there breaking changes for older versions? No
* Does this need new documentation? Yes
