### PR TITLE
SUBMARINE-1414. Upgrade java k8s client to 18(k8s-java-client)/6.7(fabric8)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,7 @@
     <!--  Submarine on Kubernetes  -->
     <k8s.client-java.version>18.0.1</k8s.client-java.version>
     <kotlin-stdlib.version>1.6.10</kotlin-stdlib.version>
-    <k8s.fabric8.version>6.9.2</k8s.fabric8.version>
+    <k8s.fabric8.version>6.7.2</k8s.fabric8.version>
     <jersey.test-framework>2.27</jersey.test-framework>
 
     <!-- integration test-->

--- a/pom.xml
+++ b/pom.xml
@@ -135,9 +135,9 @@
     <json.version>20211205</json.version>
 
     <!--  Submarine on Kubernetes  -->
-    <k8s.client-java.version>17.0.2</k8s.client-java.version>
+    <k8s.client-java.version>18.0.1</k8s.client-java.version>
     <kotlin-stdlib.version>1.6.10</kotlin-stdlib.version>
-    <k8s.fabric8.version>6.6.1</k8s.fabric8.version>
+    <k8s.fabric8.version>6.9.2</k8s.fabric8.version>
     <jersey.test-framework>2.27</jersey.test-framework>
 
     <!-- integration test-->

--- a/pom.xml
+++ b/pom.xml
@@ -149,7 +149,7 @@
     <guice-servlet.version>3.0</guice-servlet.version>
     <guice.version>3.0</guice.version>
     <!--  server API  -->
-    <protobuf-java.version>3.21.10</protobuf-java.version>
+    <protobuf-java.version>3.22.0</protobuf-java.version>
     <joda-time.version>2.10.8</joda-time.version>
     <!--  pac4j  -->
     <pac4j.version>5.6.1</pac4j.version>

--- a/submarine-server/server-submitter/submarine-k8s-agent/pom.xml
+++ b/submarine-server/server-submitter/submarine-k8s-agent/pom.xml
@@ -37,7 +37,7 @@
     <dependency>
       <groupId>io.javaoperatorsdk</groupId>
       <artifactId>operator-framework</artifactId>
-      <version>4.3.2</version>
+      <version>4.5.0</version>
       <exclusions>
         <exclusion>
           <groupId>com.fasterxml.jackson.core</groupId>

--- a/submarine-server/server-submitter/submarine-k8s-agent/src/main/java/org/apache/submarine/server/k8s/agent/SubmarineAgentListener.java
+++ b/submarine-server/server-submitter/submarine-k8s-agent/src/main/java/org/apache/submarine/server/k8s/agent/SubmarineAgentListener.java
@@ -19,8 +19,6 @@
 
 package org.apache.submarine.server.k8s.agent;
 
-import io.fabric8.kubernetes.client.KubernetesClient;
-import io.fabric8.kubernetes.client.KubernetesClientBuilder;
 import io.javaoperatorsdk.operator.Operator;
 import io.javaoperatorsdk.operator.api.config.ControllerConfigurationOverrider;
 import io.javaoperatorsdk.operator.api.reconciler.Reconciler;
@@ -49,10 +47,8 @@ public class SubmarineAgentListener {
   public static final DateTimeFormatter DTF = DateTimeFormatter.ISO_DATE_TIME;
 
   public static void main(String[] args) throws IOException {
-    // create kubernetes client
-    KubernetesClient client = new KubernetesClientBuilder().build();
     // create operator
-    Operator operator = new Operator(client);
+    Operator operator = new Operator();
     // scan all Reconciler implemented subclasses
     Reflections reflections = new Reflections("org.apache.submarine.server.k8s.agent");
     Set<Class<? extends Reconciler>> reconcilers = reflections.getSubTypesOf(Reconciler.class);
@@ -69,8 +65,6 @@ public class SubmarineAgentListener {
         }
     );
     LOGGER.info("Starting agent with SUBMARINE_UID={}", OwnerReferenceConfig.getSubmarineUid());
-    // Adds a shutdown hook that automatically calls stop() when the app shuts down.
-    operator.installShutdownHook();
     // start operator
     operator.start();
     // Provide a lightweight service to handle health checks

--- a/submarine-server/server-submitter/submarine-k8s-agent/src/test/java/org/apache/submarine/server/k8s/agent/SubmitSubmarineAgentTest.java
+++ b/submarine-server/server-submitter/submarine-k8s-agent/src/test/java/org/apache/submarine/server/k8s/agent/SubmitSubmarineAgentTest.java
@@ -24,9 +24,7 @@ import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 import io.fabric8.kubernetes.api.model.OwnerReferenceBuilder;
 import io.fabric8.kubernetes.api.model.apiextensions.v1.CustomResourceDefinition;
 import io.fabric8.kubernetes.client.KubernetesClient;
-import io.fabric8.kubernetes.client.dsl.base.CustomResourceDefinitionContext;
 import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
-import io.fabric8.kubernetes.internal.KubernetesDeserializer;
 import io.javaoperatorsdk.operator.Operator;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.submarine.commons.utils.SubmarineConfiguration;
@@ -103,10 +101,10 @@ public class SubmitSubmarineAgentTest {
 
     // set client and operator
     client = server.getClient();
-    operator = new Operator(client);
+    operator = new Operator(client, null);
 
     // create notbook resource
-    KubernetesDeserializer.registerCustomKind("apiextensions.k8s.io/v1","Notebook", NotebookResource.class);
+    client.getKubernetesSerialization().registerKubernetesResource("apiextensions.k8s.io/v1","Notebook", NotebookResource.class);
     CustomResourceDefinition notebookCrd = client
             .apiextensions().v1()
             .customResourceDefinitions()
@@ -116,7 +114,7 @@ public class SubmitSubmarineAgentTest {
     client.apiextensions().v1().customResourceDefinitions().createOrReplace(notebookCrd);
 
     // create tf resource
-    KubernetesDeserializer.registerCustomKind("apiextensions.k8s.io/v1", "TFJob", TFJob.class);
+    client.getKubernetesSerialization().registerKubernetesResource("apiextensions.k8s.io/v1", "TFJob", TFJob.class);
     CustomResourceDefinition tfCrd = client
             .apiextensions().v1()
             .customResourceDefinitions()
@@ -126,7 +124,7 @@ public class SubmitSubmarineAgentTest {
     client.apiextensions().v1().customResourceDefinitions().create(tfCrd);
 
     // create pytorch resource
-    KubernetesDeserializer.registerCustomKind("apiextensions.k8s.io/v1", "PyTorchJob", PyTorchJob.class);
+    client.getKubernetesSerialization().registerKubernetesResource("apiextensions.k8s.io/v1", "PyTorchJob", PyTorchJob.class);
     CustomResourceDefinition ptCrd = client
             .apiextensions().v1()
             .customResourceDefinitions()
@@ -136,7 +134,7 @@ public class SubmitSubmarineAgentTest {
     client.apiextensions().v1().customResourceDefinitions().create(ptCrd);
 
     // create xgboost resource
-    KubernetesDeserializer.registerCustomKind("apiextensions.k8s.io/v1", "XGBoostJob", XGBoostJob.class);
+    client.getKubernetesSerialization().registerKubernetesResource("apiextensions.k8s.io/v1", "XGBoostJob", XGBoostJob.class);
     CustomResourceDefinition xgbCrd = client
             .apiextensions().v1()
             .customResourceDefinitions()


### PR DESCRIPTION
### What is this PR for?
Upgrade java k8s client lib to latest version and fix codes when updating the version

### What type of PR is it?
Improvement

### Todos
* [x] - Update k8s-client to 18
* [x] - Update fabric to 6.7
* [x] - Update java operator sdk to 4.5
* [x] - Fix unit test error   

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-1414

### How should this be tested?
CI test

### Screenshots (if appropriate)

### Questions:
* Do the license files need updating? No
* Are there breaking changes for older versions? No
* Does this need new documentation? No
