### PR TITLE
SUBMARINE-1417. Retrieve SUBMARINE_AUTH_SECRET from environment variable instead of using hard-coded value

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -22,6 +22,7 @@ env:
   VERSION: "0.9.0-SNAPSHOT"
   BUILD_FLAG: "clean install -ntp -DskipTests -am"
   TEST_FLAG: "test -DskipRat -ntp"
+  SUBMARINE_AUTH_SECRET: "SUBMARINE_SECRET_12345678901234567890"
 jobs:
   generate-k8s-versions-array:
     runs-on: ubuntu-latest

--- a/submarine-commons/commons-utils/src/main/java/org/apache/submarine/commons/utils/SubmarineConfVars.java
+++ b/submarine-commons/commons-utils/src/main/java/org/apache/submarine/commons/utils/SubmarineConfVars.java
@@ -23,6 +23,19 @@ import org.slf4j.LoggerFactory;
 
 public class SubmarineConfVars {
   private static final Logger LOG = LoggerFactory.getLogger(SubmarineConfVars.class);
+  /**
+  * Retrieves the secret from the environment variable "SUBMARINE_AUTH_DEFAULT_SECRET".
+  * Throws runtimeException if the environment variable is not set or empty.
+  *
+  * @return The secret as a String
+  */
+  private static String getSecretFromEnv() {
+    String secret = System.getenv("SUBMARINE_AUTH_SECRET");
+    if (secret == null || secret.isEmpty()) {
+      secret = "";
+    }
+    return secret;
+  }
   public enum ConfVars {
     SUBMARINE_CONF_DIR("submarine.conf.dir", "conf"),
     SUBMARINE_LOCALIZATION_MAX_ALLOWED_FILE_SIZE_MB(
@@ -93,7 +106,7 @@ public class SubmarineConfVars {
 
     /* auth */
     SUBMARINE_AUTH_TYPE("submarine.auth.type", "simple"),
-    SUBMARINE_AUTH_DEFAULT_SECRET("submarine.auth.default.secret", "SUBMARINE_SECRET_12345678901234567890"),
+    SUBMARINE_AUTH_DEFAULT_SECRET("submarine.auth.default.secret", getSecretFromEnv()),
     SUBMARINE_AUTH_MAX_AGE_ENV("submarine.auth.maxAge", 60 * 60 * 24);
 
     private String varName;


### PR DESCRIPTION
### What is this PR for?
Retrieve SUBMARINE_AUTH_SECRET from environment variable instead of using hard-coded value

### What type of PR is it?
Bug Fix

### Todos


### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-1417
### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* Do the license files need updating? No
* Are there breaking changes for older versions? No
* Does this need new documentation? No
